### PR TITLE
feat: Add opensearch-skills agent skill

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sean-zheng-amazon @arjunkumargiri @saratvemulapalli
+* @arjunkumargiri @saratvemulapalli @sean-zheng-amazon

--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -1,0 +1,20 @@
+name: Apply 'untriaged' label during issue lifecycle
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add `untriaged` Label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['untriaged']
+            })

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,38 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
+      - name: Backport
+        uses: VachaShah/backport@v2.2.0
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>
+          failure_labels: backport-failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-linux:
+    name: Test on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+  test-macos:
+    name: Test on macOS
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+      - name: Run tests
+        run: uv run pytest tests/ -v
+
+  test-windows:
+    name: Test on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+      - name: Run tests
+        shell: pwsh
+        run: uv run pytest tests/ -v

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -1,0 +1,22 @@
+name: Delete merged branch of the backport PRs
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.repository == 'opensearch-project/opensearch-agent-skills' && (startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/'))
+    steps:
+    - name: Delete merged branch
+      uses: actions/github-script@v8
+      with:
+        script: |
+          github.rest.git.deleteRef({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: `heads/${context.payload.pull_request.head.ref}`,
+          })

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+
+# mypy
+.mypy_cache/
+
+# Ruff
+.ruff_cache/
+
+# IDE
+.vscode/
+.idea/
+
+# IDE-specific local config
+.cursor/*
+!.cursor/skills
+.kiro/*
+!.kiro/skills
+local/
+
+# MCP config (may contain credentials)
+.mcp.json
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+
+This code of conduct applies to all spaces provided by the OpenSource project including in code, documentation, issue trackers, mailing lists, chat channels, wikis, blogs, social media and any other communication channels used by the project.
+
+**Our open source communities endeavor to:**
+
+* Be Inclusive: We are committed to being a community where everyone can join and contribute. This means using inclusive and welcoming language.
+* Be Welcoming: We are committed to maintaining a safe space for everyone to be able to contribute.
+* Be Respectful: We are committed to encouraging differing viewpoints, accepting constructive criticism and work collaboratively towards decisions that help the project grow. Disrespectful and unacceptable behavior will not be tolerated.
+* Be Collaborative: We are committed to supporting what is best for our community and users. When we build anything for the benefit of the project, we should document the work we do and communicate to others on how this affects their work.
+
+**Our Responsibility. As contributors, members, or bystanders we each individually have the responsibility to behave professionally and respectfully at all times. Disrespectful and unacceptable behaviors include, but are not limited to:**
+
+* The use of violent threats, abusive, discriminatory, or derogatory language;
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, race, political or religious affiliation;
+* Posting of sexually explicit or violent content;
+* The use of sexualized language and unwelcome sexual attention or advances;
+* Public or private harassment of any kind;
+* Publishing private information, such as physical or electronic address, without permission;
+* Other conduct which could reasonably be considered inappropriate in a professional setting;
+* Advocating for or encouraging any of the above behaviors.
+* Enforcement and Reporting Code of Conduct Issues:
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported. [Contact us](mailto:opensource-codeofconduct@amazon.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to OpenSearch Agent Skills
+
+We welcome contributions! Please read our [Developer Guide](DEVELOPER_GUIDE.md) for detailed instructions on creating skills, testing, and submitting PRs.
+
+## First Things First
+
+1. **Fork the repo** and clone your fork locally.
+2. **Create a branch** for your changes.
+3. **Follow the conventions** described in the [Developer Guide](DEVELOPER_GUIDE.md).
+4. **Run tests** before submitting: `uv run pytest -q`
+5. **Submit a PR** with a clear description.
+
+## Reporting Issues
+
+If you find a bug or have a feature request, please [open an issue](https://github.com/opensearch-project/opensearch-agent-skills/issues/new).
+
+## Code of Conduct
+
+This project follows the [OpenSearch Code of Conduct](CODE_OF_CONDUCT.md).

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,125 @@
+# Developer Guide
+
+This guide covers how to contribute new skills, local development, testing, and conventions.
+
+---
+
+## Contributing a New Skill
+
+### 1. Create the skill directory
+
+```
+skills/<skill-name>/
+    SKILL.md              # Required — entry point
+    scripts/              # Optional: scripts the agent executes
+    references/           # Optional: detailed docs loaded on demand
+    assets/               # Optional: sample data, templates, configs
+```
+
+### 2. Write SKILL.md
+
+Every skill needs a `SKILL.md` with YAML frontmatter and markdown instructions:
+
+```yaml
+---
+name: your-skill-name
+description: >
+  What the skill does and when to activate it. Include keywords users
+  might say so the agent can match this skill to the task. Max 1024 chars.
+compatibility: Any prerequisites (e.g., Docker, uv, Python 3.11+).
+metadata:
+  author: your-github-handle
+  version: "1.0"
+---
+
+# Skill Title
+
+You are a [role]. You help users [do X].
+
+## Key Rules
+
+- Rule 1
+- Rule 2
+
+## Workflow
+
+### Step 1 — ...
+### Step 2 — ...
+```
+
+**Constraints:**
+- `name`: max 64 chars, lowercase + hyphens only, must match folder name
+- `description`: max 1024 chars — this is the sole trigger for agent discovery
+- `SKILL.md` body: under 500 lines — use separate reference files for detail
+- Use relative paths from the skill root for file references
+
+### 3. Add scripts (optional)
+
+If your skill needs to execute operations, add scripts under `scripts/`:
+
+- Prefer Python scripts run via `uv run python scripts/your_script.py`
+- Include a `--help` flag for discoverability
+- Scripts should be self-contained or clearly document dependencies
+
+### 4. Structure for progressive disclosure
+
+Skills should follow the three-level progressive disclosure pattern:
+
+1. **Metadata** (~100 tokens) — name and description, always loaded
+2. **SKILL.md body** (< 5000 tokens) — loaded when skill activates
+3. **Bundled files** — loaded only when the agent decides it needs them
+
+Keep your main SKILL.md lean and route detail into reference files.
+
+### 5. Add tests
+
+Add tests under `tests/` following the naming convention `test_<skill-name>_*.py`. Tests must not require a running OpenSearch cluster — use mocks/fakes.
+
+```bash
+uv run pytest tests/test_your_skill.py -v
+```
+
+### 6. Submit a PR
+
+- Ensure all tests pass: `uv run pytest -q`
+- Include a brief description of what the skill does
+- Include an example prompt that triggers it
+
+---
+
+## Testing
+
+All tests live in the `tests/` directory and run with [pytest](https://docs.pytest.org/) via `uv`:
+
+```bash
+uv run pytest -q
+```
+
+### Running a subset
+
+```bash
+# Only opensearch-skills tests
+uv run pytest tests/test_opensearch_skills_*.py -v
+
+# Single file
+uv run pytest tests/test_opensearch_skills_search.py -v
+```
+
+### Writing new tests
+
+- Tests must not require a running OpenSearch cluster. Use fake/mock clients.
+- Import from skill scripts by inserting the scripts directory onto `sys.path` (see existing test patterns).
+
+### CI
+
+GitHub Actions runs the full test suite on every push and PR across Linux, macOS, and Windows. See `.github/workflows/ci.yml`.
+
+---
+
+## Conventions
+
+- Skill names: lowercase, hyphens only, max 64 chars
+- Skill folder name must match the `name` field in SKILL.md frontmatter
+- SKILL.md body under 500 lines
+- Reference files should be focused and single-purpose
+- Scripts should handle errors gracefully and include helpful error messages

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,176 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,2 @@
+OpenSearch (https://opensearch.org/)
+Copyright OpenSearch Contributors

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# OpenSearch Agent Skills
+
+A collection of [Agent Skills](https://agentskills.io/specification) for building search applications and analyzing observability data with OpenSearch. Works with Claude Code, Cursor, Kiro, and any agent that supports the Agent Skills standard.
+
+---
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| **[opensearch-skills](skills/opensearch-skills/)** | Build search apps (semantic, hybrid, neural, agentic) and analyze logs/traces with OpenSearch. Includes local execution and optional AWS deployment. |
+
+> More skills coming soon — contributions welcome! See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md).
+
+---
+
+## Install
+
+Install any skill using [`npx skills`](https://agentskills.io):
+
+```bash
+npx skills add opensearch-project/opensearch-agent-skills
+```
+
+This discovers skills under `skills/` and symlinks them into your agent's skill directory (`.claude/skills/`, `.cursor/skills/`, `.kiro/skills/`, etc.).
+
+### Install options
+
+```bash
+# Install to a specific agent
+npx skills add opensearch-project/opensearch-agent-skills -a claude-code
+
+# Install globally (available across all projects)
+npx skills add opensearch-project/opensearch-agent-skills -g
+
+# Install to all detected agents
+npx skills add opensearch-project/opensearch-agent-skills --all
+
+# List available skills before installing
+npx skills add opensearch-project/opensearch-agent-skills --list
+```
+
+After installing, try:
+
+> *"I want to build a semantic search app with OpenSearch"*
+
+Your agent reads the skill instructions and runs the scripts directly — no MCP server required.
+
+---
+
+## Prerequisites
+
+- **Python 3.11+** and [`uv`](https://docs.astral.sh/uv/getting-started/installation/)
+- **Docker** installed and running ([Download Docker](https://docs.docker.com/get-docker/))
+- **For AWS deployment (optional):** AWS credentials configured
+
+---
+
+## Repo Structure
+
+```
+skills/
+  opensearch-skills/         # Main skill
+    SKILL.md                 # Skill instructions (entry point)
+    cli-reference.md         # CLI command reference
+    aws/                     # AWS deployment guides (loaded on demand)
+    launchpad/               # Search architecture guides (loaded on demand)
+    observability/            # Log analytics & trace guides (loaded on demand)
+    scripts/                 # Execution scripts
+```
+
+---
+
+## Contributing
+
+We welcome new skills and improvements! See the [Developer Guide](DEVELOPER_GUIDE.md) for instructions on creating skills, conventions, testing, and the contribution process.
+
+---
+
+## License
+
+This project is licensed under the Apache License, Version 2.0. See [LICENSE.txt](LICENSE.txt) for details.

--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: opensearch-skills
+description: >
+  Build search applications and query log analytics data with OpenSearch.
+  Use this skill when the user mentions OpenSearch, search app, index setup,
+  search architecture, semantic search, vector search, hybrid search, BM25,
+  dense vector, sparse vector, agentic search, RAG, embeddings, KNN, PDF
+  ingestion, document processing, or any related search topic. Also use for
+  log analytics and observability — when the user wants to set up log
+  ingestion, query logs with PPL, analyze error patterns, set up index
+  lifecycle policies, investigate traces, or check stack health. Activate
+  even if the user says log analysis, Fluent Bit, Fluentd, Logstash, syslog,
+  traceId, OpenTelemetry, or log analytics without mentioning OpenSearch.
+compatibility: Requires Docker and uv. AWS deployment requires AWS credentials.
+metadata:
+  author: opensearch-project
+  version: "2.0"
+---
+
+# OpenSearch Launchpad
+
+You are an OpenSearch solution architect. You guide users from initial requirements to a running search setup.
+
+## Prerequisites
+
+- Docker installed and running
+- `uv` installed (for running Python scripts)
+- The `opensearch-skills` skill directory available locally
+
+## Optional MCP Servers
+
+These MCP servers enhance the skill with documentation lookup, AWS knowledge, and direct OpenSearch API access. They can be used during any workflow phase — not just AWS deployment.
+
+```json
+{
+  "mcpServers": {
+    "ddg-search": {
+      "command": "uvx",
+      "args": ["duckduckgo-mcp-server"]
+    },
+    "awslabs.aws-api-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.aws-api-mcp-server@latest"],
+      "env": { "FASTMCP_LOG_LEVEL": "ERROR" }
+    },
+    "aws-knowledge-mcp-server": {
+      "command": "uvx",
+      "args": ["fastmcp", "run", "https://knowledge-mcp.global.api.aws"],
+      "env": { "FASTMCP_LOG_LEVEL": "ERROR" }
+    },
+    "opensearch-mcp-server": {
+      "command": "uvx",
+      "args": ["opensearch-mcp-server-py@latest"],
+      "env": { "FASTMCP_LOG_LEVEL": "ERROR" }
+    }
+  }
+}
+```
+
+- **`ddg-search`** — Search OpenSearch documentation via DuckDuckGo. Use `search(query="site:opensearch.org <your query>")` to find docs, then `fetch_content(url)` to read the full page.
+- **`awslabs.aws-api-mcp-server`** — AWS API calls (required for Phase 5 deployment, also useful for general AWS questions).
+- **`aws-knowledge-mcp-server`** — AWS documentation lookup.
+- **`opensearch-mcp-server`** — Direct OpenSearch API access on local and remote clusters, including Amazon OpenSearch Service (AOS) and Serverless (AOSS). Handles SigV4 auth transparently. See the [User Guide](https://github.com/opensearch-project/opensearch-mcp-server-py/blob/main/USER_GUIDE.md) for full configuration options.
+
+### opensearch-mcp-server Configuration Variants
+
+The JSON block above shows a minimal config. For AOS/AOSS clusters, ask the user for their endpoint, auth method, and region, then use the appropriate env block:
+
+For basic auth (local/self-managed):
+```json
+{
+  "opensearch-mcp-server": {
+    "command": "uvx",
+    "args": ["opensearch-mcp-server-py@latest"],
+    "env": {
+      "OPENSEARCH_URL": "<endpoint_url>",
+      "OPENSEARCH_USERNAME": "<username>",
+      "OPENSEARCH_PASSWORD": "<password>",
+      "OPENSEARCH_SSL_VERIFY": "false",
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}
+```
+
+For Amazon OpenSearch Service (AOS):
+```json
+{
+  "opensearch-mcp-server": {
+    "command": "uvx",
+    "args": ["opensearch-mcp-server-py@latest"],
+    "env": {
+      "OPENSEARCH_URL": "<endpoint_url>",
+      "AWS_REGION": "<region>",
+      "AWS_PROFILE": "<profile>",
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}
+```
+
+For Amazon OpenSearch Serverless (AOSS):
+```json
+{
+  "opensearch-mcp-server": {
+    "command": "uvx",
+    "args": ["opensearch-mcp-server-py@latest"],
+    "env": {
+      "OPENSEARCH_URL": "<endpoint_url>",
+      "AWS_REGION": "<region>",
+      "AWS_PROFILE": "<profile>",
+      "AWS_OPENSEARCH_SERVERLESS": "true",
+      "FASTMCP_LOG_LEVEL": "ERROR"
+    }
+  }
+}
+```
+
+If the cluster type is unclear, ask the user: "Is this a local OpenSearch cluster, Amazon OpenSearch Service, or Amazon OpenSearch Serverless?"
+
+## Auto-Installing Missing MCP Servers
+
+Before using any MCP tool, check if the server is available. If a required MCP server is missing, auto-install it:
+
+1. Locate the MCP config file for the current IDE:
+   - Kiro: `.kiro/settings/mcp.json`
+   - Cursor: `.cursor/mcp.json`
+   - Claude Code: `.mcp.json`
+   - VS Code (Copilot): `.vscode/mcp.json`
+   - Windsurf: `~/.codeium/windsurf/mcp_config.json`
+   - If unsure, check for any of the above files in the workspace root.
+2. Read the existing config (or start with `{"mcpServers": {}}` if the file doesn't exist).
+3. Merge in the missing server entry from the JSON block above. Do not overwrite existing entries.
+4. Save the file.
+5. Inform the user: *"I've added the [server name] MCP server to your config. Please restart your IDE or reconnect MCP servers for the changes to take effect."*
+6. Wait for the user to confirm the restart, then retry the tool call.
+
+## Answering OpenSearch Knowledge Questions
+
+When the user asks about OpenSearch features, APIs, configuration, version history, or any general OpenSearch topic:
+
+1. Run `opensearch_ops.py search-docs --query "<your query>"` to search opensearch.org (default).
+   - Covers `docs.opensearch.org` (APIs, configuration, query DSL, plugins), `opensearch.org/blog` (release announcements, feature deep-dives), and `opensearch.org/platform`.
+2. For AWS-specific questions (e.g. Amazon OpenSearch Service, Serverless, IAM policies, pricing), use `--site docs.aws.amazon.com`:
+   ```bash
+   uv run python scripts/opensearch_ops.py search-docs --query "OpenSearch Serverless pricing" --site docs.aws.amazon.com
+   ```
+3. Review the returned titles, URLs, and snippets.
+4. If more detail is needed, fetch the full page content from the top result URL.
+5. Summarize the answer based on the documentation.
+
+Examples:
+```bash
+uv run python scripts/opensearch_ops.py search-docs --query "OpenSearch 3.5 features"
+uv run python scripts/opensearch_ops.py search-docs --query "neural sparse search" --count 3
+uv run python scripts/opensearch_ops.py search-docs --query "OpenSearch Service domain access policy" --site docs.aws.amazon.com
+```
+
+This applies at any point — not just during the workflow phases.
+
+## Scripts
+
+All operations are executed via two scripts in `scripts/` relative to this file:
+
+- **`start_opensearch.sh`** — Start a local OpenSearch cluster via Docker
+- **`opensearch_ops.py`** — CLI for all OpenSearch operations. See [CLI Reference](cli-reference.md) for exact invocations and examples
+
+```bash
+bash scripts/start_opensearch.sh
+uv run python scripts/opensearch_ops.py <command> [options]
+```
+
+## Key Rules
+
+- Ask **one** preference question per message.
+- **Never skip Phase 1** (sample document collection).
+- Show architecture proposals to the user before execution.
+- Follow the phases **in order** — do not jump ahead.
+- When a step fails, present the error and wait for guidance.
+
+## Workflow Phases
+
+### Phase 1 — Start OpenSearch & Collect Sample
+
+**Before starting OpenSearch**, check if a cluster is already running:
+
+```bash
+uv run python scripts/opensearch_ops.py preflight-check
+```
+
+**Interpreting the preflight result:**
+
+- **`status: "available"`** — A cluster is already running and reachable. Use it directly. The `auth_mode` field shows which authentication was detected (`none`, `default`, or `custom`).
+- **`status: "auth_required"`** — A cluster is running but requires credentials. Ask the user for their username and password, then run:
+  ```bash
+  uv run python scripts/opensearch_ops.py preflight-check --auth-mode custom --username <user> --password <pass>
+  ```
+  If successful, the credentials are persisted for the session and all subsequent commands will use them automatically.
+- **`status: "no_cluster"`** — No cluster detected. Start one:
+  ```bash
+  bash scripts/start_opensearch.sh
+  ```
+
+Once a cluster is available, ask the user for their data source. Use `load-sample` to load data. The output includes inferred text fields — use these to inform the plan.
+
+If the user provides PDF, DOCX, PPTX, XLSX, or other document files (not structured data like CSV/JSON/TSV), use Docling to process them before indexing. Read `launchpad/document_processing_guide.md` for the full workflow. In summary:
+
+1. Install Docling: `uv pip install docling`
+2. Convert the document using Docling's `DocumentConverter` to extract structured text.
+3. Chunk the output using `HybridChunker(max_tokens=512, overlap_tokens=50)`.
+4. Export chunks as JSONL and use `opensearch_ops.py index-bulk` to load them.
+
+Ask the user whether they want to process the entire document or specific page ranges.
+
+### Phase 2 — Gather Preferences
+
+Ask the user **one at a time**: query pattern (keyword, semantic, hybrid, agentic) and deployment preference. Skip questions that don't apply.
+
+### Phase 3 — Plan
+
+Design a search architecture based on sample data and preferences. Choose a strategy (`bm25`, `dense_vector`, `neural_sparse`, `hybrid`, or `agentic`), define index mappings, select ML models if needed, and specify pipelines. Read the relevant knowledge files directly for model and search pattern details:
+
+- `launchpad/dense_vector_models.md`
+- `launchpad/sparse_vector_models.md`
+- `launchpad/opensearch_semantic_search_guide.md`
+- `launchpad/agentic_search_guide.md`
+- `launchpad/document_processing_guide.md` (when working with PDF/DOCX/PPTX sources)
+
+Present the plan and wait for user approval.
+
+### Phase 4 — Execute
+
+Execute the approved plan step by step using `opensearch_ops.py` commands: create index, deploy model, create pipeline, index documents, launch UI. Run `opensearch_ops.py --help` for the full command reference. When launching the UI, always present the URL (default: `http://127.0.0.1:8765`) to the user so they can click to open the Search Builder in their browser.
+
+After the UI is running, present the next steps:
+> "Your search app is live! Here's what you can do next:"
+> 1. **Evaluate search quality** (Phase 4.5) — I'll run test queries, measure relevance metrics (nDCG, precision, MRR), and suggest improvements.
+> 2. **Deploy to Amazon OpenSearch Service** (Phase 5) — Provision an Amazon OpenSearch cluster and deploy your search setup.
+> 3. **Done for now** — Keep experimenting with the Search Builder UI.
+
+### Phase 4.5 — Evaluate (Optional)
+
+If the user chooses to evaluate search quality, read and follow `launchpad/evaluation_guide.md` for the full methodology. If HIGH severity findings exist, offer to restart from Phase 3 with a specific fix.
+
+### Phase 5 — Deploy to Amazon OpenSearch Service (Optional)
+
+Only if the user wants AWS deployment. Read the appropriate reference guide:
+
+| Strategy | Target | Guide |
+|---|---|---|
+| `neural_sparse` | serverless | [Provision](aws/serverless-01-provision.md) then [Deploy](aws/serverless-02-deploy-search.md) |
+| `dense_vector` / `hybrid` | serverless | [Provision](aws/serverless-01-provision.md) then [Deploy](aws/serverless-02-deploy-search.md) |
+| `bm25` | serverless | [Provision](aws/serverless-01-provision.md) then [Deploy](aws/serverless-02-deploy-search.md) |
+| `agentic` | domain | [Provision](aws/domain-01-provision.md) then [Deploy](aws/domain-02-deploy-search.md) then [Agentic](aws/domain-03-agentic-setup.md) |
+
+**Required MCP servers for Phase 5:** `awslabs.aws-api-mcp-server`, `aws-knowledge-mcp-server`, `opensearch-mcp-server` (see Optional MCP Servers section above).
+
+See [AWS Reference](aws/reference.md) for cost, security, and constraints.
+
+## Observability & Log Analytics
+
+When the user wants to analyze logs or investigate observability data in OpenSearch, follow a discovery-first approach: understand what indices exist, learn the schema from mappings and sample documents, then build queries. Read the appropriate reference file based on intent:
+
+| Intent | Reference |
+|---|---|
+| Log analytics (discover indices, understand schema, query logs with PPL) | [observability/log-analytics.md](observability/log-analytics.md) |
+| OTel trace investigation (agent invocations, tool executions, slow spans, errors) | [observability/traces.md](observability/traces.md) |
+| PPL syntax reference (50+ commands, 14 function categories) | [observability/ppl-reference.md](observability/ppl-reference.md) |

--- a/skills/opensearch-skills/aws/domain-01-provision.md
+++ b/skills/opensearch-skills/aws/domain-01-provision.md
@@ -1,0 +1,85 @@
+# Amazon OpenSearch Service Domain — Step 1: Provision Domain
+
+This guide covers creating and configuring an Amazon OpenSearch Service Domain (managed cluster). Follow it after `prepare_aws_deployment()` returns `deployment_target: "domain"`.
+
+## Prerequisites
+
+Before starting:
+1. Read `.opensearch-deploy-state.json` for current deployment state
+2. Confirm AWS credentials are valid: `aws sts get-caller-identity` (via AWS API MCP)
+3. Verify required MCP servers are connected: `awslabs.aws-api-mcp-server`, `opensearch-mcp-server`
+4. Save the AWS account ID and principal ARN to the state file
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `deployment_target`: "domain"
+- `search_strategy`: "agentic" or other
+
+## Step 1: Create Domain
+
+Use the AWS API MCP server:
+
+```
+aws opensearch create-domain
+  --domain-name <domain-name>
+  --engine-version OpenSearch_2.11
+  --cluster-config InstanceType=t3.medium.search,InstanceCount=1
+  --ebs-options EBSEnabled=true,VolumeType=gp3,VolumeSize=100
+  --node-to-node-encryption-options Enabled=true
+  --encryption-at-rest-options Enabled=true
+  --domain-endpoint-options EnforceHTTPS=true
+```
+
+For production, use larger instances (r6g.large.search, 3+ data nodes, 3 dedicated masters).
+
+## Step 2: Enable Fine-Grained Access Control
+
+```
+aws opensearch update-domain-config
+  --domain-name <domain-name>
+  --advanced-security-options Enabled=true,InternalUserDatabaseEnabled=true,MasterUserOptions={MasterUserName=admin,MasterUserPassword=<strong-password>}
+```
+
+Set up:
+- Master user credentials
+- Role-based access control
+
+## Step 3: Configure Network Access
+
+**Public access (development):**
+- Set IP-based access policies
+- Use fine-grained access control
+
+**VPC access (production):**
+- Deploy within VPC, configure security groups
+
+## Step 4: Wait for Domain Active
+
+Poll until domain is active (typically 10-15 minutes):
+
+```
+aws opensearch describe-domain --domain-name <domain-name>
+```
+
+Wait for:
+- `Processing`: false
+- `DomainStatus.Endpoint`: available
+
+## State Output
+
+Update `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "provision-domain",
+  "aws_account_id": "<from sts get-caller-identity>",
+  "aws_region": "<configured region>",
+  "principal_arn": "<from sts get-caller-identity>",
+  "resource_name": "<domain-name>",
+  "resource_endpoint": "<domain-endpoint-url>"
+}
+```
+
+## Next Step
+
+Proceed to [Domain Deploy Search](domain-02-deploy-search.md).

--- a/skills/opensearch-skills/aws/domain-02-deploy-search.md
+++ b/skills/opensearch-skills/aws/domain-02-deploy-search.md
@@ -1,0 +1,151 @@
+# Amazon OpenSearch Service Domain — Step 2: Deploy Search Configuration
+
+This guide covers migrating index configuration, deploying ML models, and creating pipelines on the OpenSearch domain.
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: domain endpoint URL
+- `search_strategy`: determines which components to deploy
+
+From `prepare_aws_deployment()` output:
+- `local_config.text_fields`: fields to configure
+- `plan_summary.solution`: full architecture plan
+
+## Step 1: Migrate Index Configuration
+
+Using opensearch-mcp-server:
+
+1. Create the index on the domain endpoint with mappings from the local setup
+2. Include all field mappings, settings, and analyzers
+3. Configure replicas for high availability (1-2 replicas)
+
+```
+PUT <domain-endpoint>/<index-name>
+{
+  "settings": { ... from local config ... },
+  "mappings": { ... from local config ... }
+}
+```
+
+Update state: `"index_name": "<index-name>"`
+
+## Step 2: Deploy ML Models (if semantic/hybrid search)
+
+For search strategies that use embeddings (dense vector, hybrid, neural sparse):
+
+### Deploy pretrained models from OpenSearch model repository:
+
+```
+POST <domain-endpoint>/_plugins/_ml/models/_register?deploy=true
+{
+  "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
+  "version": "1.0.1",
+  "model_format": "TORCH_SCRIPT"
+}
+```
+
+Or deploy remote Bedrock models (see [Domain Agentic Setup](domain-03-agentic-setup.md) Step 1-2 for IAM role and connector setup pattern).
+
+Test model inference:
+```
+POST <domain-endpoint>/_plugins/_ml/models/<model-id>/_predict
+{
+  "parameters": { "inputText": "hello world" }
+}
+```
+
+Update state: `"model_id": "<model_id>"`
+
+## Step 3: Create Ingest Pipelines
+
+Recreate ingest pipelines from local setup:
+
+```
+PUT <domain-endpoint>/_ingest/pipeline/<pipeline-name>
+{
+  "description": "Embedding pipeline",
+  "processors": [{
+    "text_embedding": {
+      "model_id": "<model_id>",
+      "field_map": { "<text-field>": "<vector-field>" }
+    }
+  }]
+}
+```
+
+Attach pipeline to index:
+```
+PUT <domain-endpoint>/<index-name>/_settings
+{ "index.default_pipeline": "<pipeline-name>" }
+```
+
+Update state: `"ingest_pipeline_name": "<pipeline-name>"`
+
+## Step 4: Create Search Pipelines (if applicable)
+
+For hybrid search, create normalization pipeline:
+
+```
+PUT <domain-endpoint>/_search/pipeline/<search-pipeline-name>
+{
+  "phase_results_processors": [{
+    "normalization-processor": {
+      "normalization": { "technique": "min_max" },
+      "combination": { "technique": "arithmetic_mean", "parameters": { "weights": [0.3, 0.7] } }
+    }
+  }]
+}
+```
+
+Update state: `"search_pipeline_name": "<search-pipeline-name>"`
+
+## Step 5: Index Sample Documents
+
+1. Use the same sample documents from Phase 1
+2. Index test documents to verify the setup
+3. Test search queries appropriate to the strategy
+4. Verify embeddings and pipeline processing
+
+## State Output
+
+Update `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "deploy-search",
+  "index_name": "<index-name>",
+  "model_id": "<if created>",
+  "ingest_pipeline_name": "<if created>",
+  "search_pipeline_name": "<if created>"
+}
+```
+
+## Next Step
+
+- **For agentic search**: Proceed to [Domain Agentic Setup](domain-03-agentic-setup.md)
+- **For all other strategies**: Deployment complete. Connect the Search UI and provide access information.
+
+### Connect Search UI to AWS Endpoint
+
+```
+Call connect_search_ui_to_endpoint(
+  endpoint="<domain-endpoint>",
+  port=443,
+  use_ssl=true,
+  username="<master-user>",
+  password="<master-password>",
+  index_name="<index-name>"
+)
+```
+
+The UI header badge will change from "Local" to "AWS Cloud" with a green connection indicator.
+
+### Access Information (non-agentic)
+
+Give the user:
+- Domain endpoint URL
+- Domain ARN
+- OpenSearch Dashboards URL
+- Master user credentials (securely)
+- Sample search queries
+- Search Builder UI URL (already connected to AWS endpoint)

--- a/skills/opensearch-skills/aws/domain-03-agentic-setup.md
+++ b/skills/opensearch-skills/aws/domain-03-agentic-setup.md
@@ -1,0 +1,211 @@
+# Amazon OpenSearch Service Domain — Step 3: Configure Agentic Search
+
+This guide configures conversational agents with QueryPlanningTool for natural language search. Only follow this for agentic search strategy.
+
+Agentic search requires OpenSearch 2.11+ and uses Bedrock Claude as the reasoning model.
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: domain endpoint URL
+- `index_name`: target index
+- `aws_region`: for Bedrock endpoint
+- `aws_account_id`: for IAM role ARN
+
+## Step 1: Create IAM Role for Bedrock Access
+
+```json
+POST /iam/CreateRole
+{
+  "RoleName": "opensearch-bedrock-agent-role",
+  "AssumeRolePolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": { "Service": "opensearchservice.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }]
+  }
+}
+```
+
+Attach Bedrock invoke permissions:
+
+```json
+POST /iam/PutRolePolicy
+{
+  "RoleName": "opensearch-bedrock-agent-role",
+  "PolicyName": "BedrockClaudeInvokePolicy",
+  "PolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": "arn:aws:bedrock:*::foundation-model/anthropic.claude-3-5-sonnet-*"
+    }]
+  }
+}
+```
+
+Update state: `"iam_role_arn": "<role-arn>"`
+
+## Step 2: Map ML Role (if fine-grained access control enabled)
+
+1. Log in to OpenSearch Dashboards
+2. Navigate to Security > Roles > `ml_full_access`
+3. Mapped users > Manage mapping
+4. Add IAM role ARN under Backend roles: `arn:aws:iam::<aws_account_id>:role/opensearch-bedrock-agent-role`
+5. Click Map
+
+## Step 3: Create Bedrock Claude Connector
+
+```
+POST <domain-endpoint>/_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Claude 3.5 Sonnet",
+  "description": "Connector for Bedrock Claude for agentic search",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": { "roleArn": "<iam_role_arn>" },
+  "parameters": {
+    "region": "<aws_region>",
+    "service_name": "bedrock",
+    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "system_prompt": "You are a helpful assistant that plans and executes search queries.",
+    "temperature": 0.0,
+    "top_p": 0.9,
+    "max_tokens": 2000
+  },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "headers": { "content-type": "application/json" },
+    "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+    "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": ${parameters.messages}, \"inferenceConfig\": {\"temperature\": ${parameters.temperature}, \"topP\": ${parameters.top_p}, \"maxTokens\": ${parameters.max_tokens}} }"
+  }]
+}
+```
+
+Update state: `"connector_id": "<connector_id>"`
+
+## Step 4: Register and Deploy Model
+
+```
+POST <domain-endpoint>/_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Bedrock Claude 3.5 Sonnet for Agentic Search",
+  "function_name": "remote",
+  "description": "Claude model for query planning and reasoning",
+  "connector_id": "<connector_id>"
+}
+```
+
+Test the model:
+```
+POST <domain-endpoint>/_plugins/_ml/models/<model-id>/_predict
+{
+  "parameters": {
+    "messages": [{ "role": "user", "content": [{ "text": "hello" }] }]
+  }
+}
+```
+
+Verify the response contains generated text.
+
+Update state: `"model_id": "<model_id>"`
+
+## Step 5: Create Conversational Agent
+
+```
+POST <domain-endpoint>/_plugins/_ml/agents/_register
+{
+  "name": "Agentic Search Agent",
+  "type": "conversational",
+  "description": "Agent for natural language search with query planning",
+  "llm": {
+    "model_id": "<model_id>",
+    "parameters": { "max_iteration": 15 }
+  },
+  "memory": { "type": "conversation_index" },
+  "parameters": { "_llm_interface": "bedrock/converse" },
+  "tools": [{ "type": "QueryPlanningTool" }],
+  "app_type": "os_chat"
+}
+```
+
+Update state: `"agent_id": "<agent_id>"`
+
+## Step 6: Create Agentic Search Pipeline
+
+```
+PUT <domain-endpoint>/_search/pipeline/agentic-search-pipeline
+{
+  "request_processors": [{
+    "agentic_query_translator": { "agent_id": "<agent_id>" }
+  }]
+}
+```
+
+Update state: `"search_pipeline_name": "agentic-search-pipeline"`
+
+## Step 7: Test Agentic Search
+
+```
+GET <domain-endpoint>/<index-name>/_search?search_pipeline=agentic-search-pipeline
+{
+  "query": {
+    "agentic": {
+      "query_text": "Find all documents about machine learning published in the last year",
+      "query_fields": ["title", "content", "publish_date"]
+    }
+  }
+}
+```
+
+The agent will:
+1. Analyze the natural language question
+2. Examine the index mapping
+3. Generate appropriate OpenSearch DSL query
+4. Execute the query and return results
+
+## State Output
+
+Final `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "agentic-setup",
+  "iam_role_arn": "<role-arn>",
+  "connector_id": "<connector-id>",
+  "model_id": "<model-id>",
+  "agent_id": "<agent-id>",
+  "search_pipeline_name": "agentic-search-pipeline"
+}
+```
+
+## Connect Search UI to AWS Endpoint
+
+After agentic setup is complete, switch the local Search Builder UI to query the AWS domain:
+
+```
+Call connect_search_ui_to_endpoint(
+  endpoint="<domain-endpoint>",
+  port=443,
+  use_ssl=true,
+  username="<master-user>",
+  password="<master-password>",
+  index_name="<index-name>"
+)
+```
+
+The UI header badge will change from "Local" to "AWS Cloud" with a green connection indicator.
+
+## Provide Access Information
+
+Give the user:
+- Domain endpoint URL
+- Domain ARN
+- OpenSearch Dashboards URL
+- Master user credentials (securely)
+- Sample agentic search queries
+- Search Builder UI URL (already connected to AWS endpoint)
+- Agent ID for direct agent invocation

--- a/skills/opensearch-skills/aws/reference.md
+++ b/skills/opensearch-skills/aws/reference.md
@@ -1,0 +1,54 @@
+# Amazon OpenSearch Service Deployment Reference
+
+Reference material for cost, security, and operations. Load only when the user asks about these topics.
+
+## Cost: OpenSearch Serverless
+
+- Charged per OCU (OpenSearch Compute Units) hour
+- Minimum: 2 OCUs for indexing, 2 OCUs for search
+- Scales automatically based on workload
+- Storage charged separately per GB
+- Neural sparse enrichment: charged based on SemanticSearchOCU CloudWatch metric
+
+## Cost: OpenSearch Domain
+
+- Instance hours (varies by instance type)
+- EBS storage (GB-month)
+- Data transfer and snapshot storage
+
+Typical small production cluster:
+- 3x r6g.large.search: ~$400-500/month
+- 300GB EBS storage: ~$30/month
+
+Cost optimization: reserved instances (up to 30% savings), right-sizing, UltraWarm for cold data.
+
+## Security Best Practices
+
+1. **Network**: Deploy in VPC for production, use security groups, enable VPC Flow Logs
+2. **Access**: Enable fine-grained access control, use IAM roles, least-privilege policies
+3. **Encryption**: At-rest encryption, node-to-node encryption, enforce HTTPS
+4. **Monitoring**: Enable CloudWatch logs, set up security alerting
+
+## High Availability (Domain)
+
+1. Enable zone awareness, distribute across 3 AZs
+2. Enable automated snapshots to S3
+3. Configure standby replicas
+4. Test restore procedures
+
+## Monitoring
+
+1. CloudWatch logs: index slow logs, search slow logs, error logs, audit logs
+2. CloudWatch alarms: cluster health, CPU/memory, storage, JVM pressure
+3. SNS notifications for alerts
+
+## Troubleshooting
+
+| Issue | Check |
+|---|---|
+| Domain creation fails | Service quotas, VPC config, IAM permissions |
+| Cluster health yellow/red | Shard allocation, storage space, node health |
+| Access denied | Fine-grained access control, IAM policies, data access policies |
+| Model deployment fails | ML plugin enabled, memory allocation, Bedrock region availability |
+| Slow queries | Slow logs, query optimization, resource utilization |
+| Collection creation fails | Service quotas, region availability, encryption policy |

--- a/skills/opensearch-skills/aws/serverless-01-provision.md
+++ b/skills/opensearch-skills/aws/serverless-01-provision.md
@@ -1,0 +1,104 @@
+# Amazon OpenSearch Serverless — Step 1: Provision Collection
+
+This guide covers creating and configuring an OpenSearch Serverless collection. Follow it after `prepare_aws_deployment()` returns `deployment_target: "serverless"`.
+
+## Prerequisites
+
+Before starting:
+1. Read `.opensearch-deploy-state.json` for current deployment state
+2. Confirm AWS credentials are valid: `aws sts get-caller-identity` (via AWS API MCP)
+3. Verify required MCP servers are connected: `awslabs.aws-api-mcp-server`, `opensearch-mcp-server`
+4. Save the AWS account ID and principal ARN to the state file
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `deployment_target`: "serverless"
+- `search_strategy`: determines collection type
+
+## Step 1: Create Encryption Policy
+
+Create an encryption policy (required before collection creation):
+
+```json
+POST /opensearchserverless/CreateSecurityPolicy
+{
+  "name": "<collection-name>-encryption",
+  "type": "encryption",
+  "policy": "{\"Rules\":[{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"]}],\"AWSOwnedKey\":true}"
+}
+```
+
+## Step 2: Create Network Policy
+
+```json
+POST /opensearchserverless/CreateSecurityPolicy
+{
+  "name": "<collection-name>-network",
+  "type": "network",
+  "policy": "[{\"Rules\":[{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"]},{\"ResourceType\":\"dashboard\",\"Resource\":[\"collection/<collection-name>\"]}],\"AllowFromPublic\":true}]"
+}
+```
+
+For production, replace `AllowFromPublic` with VPC endpoint IDs.
+
+## Step 3: Create Data Access Policy
+
+Create a data access policy with permissions for index, collection, and ML resources:
+
+```json
+POST /opensearchserverless/CreateAccessPolicy
+{
+  "name": "<collection-name>-data",
+  "type": "data",
+  "policy": "[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/<collection-name>/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DescribeIndex\",\"aoss:UpdateIndex\",\"aoss:DeleteIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/<collection-name>\"],\"Permission\":[\"aoss:CreateCollectionItems\",\"aoss:DescribeCollectionItems\"]},{\"ResourceType\":\"model\",\"Resource\":[\"model/<collection-name>/*\"],\"Permission\":[\"aoss:CreateMLResource\"]}],\"Principal\":[\"<principal_arn>\"]}]"
+}
+```
+
+Replace `<principal_arn>` with the value from the state file.
+
+## Step 4: Create Collection
+
+Choose collection type based on search strategy:
+- **VECTORSEARCH**: For dense vector search (semantic search with dense embeddings)
+- **SEARCH**: For all other strategies (BM25, neural sparse, hybrid with neural sparse)
+
+Neural sparse (automatic semantic enrichment) requires SEARCH type, not VECTORSEARCH.
+
+```json
+POST /opensearchserverless/CreateCollection
+{
+  "name": "<collection-name>",
+  "type": "SEARCH or VECTORSEARCH",
+  "description": "Search application deployed from local OpenSearch"
+}
+```
+
+## Step 5: Wait for Collection Active
+
+Poll until status is "ACTIVE" (typically 1-3 minutes):
+
+```json
+POST /opensearchserverless/BatchGetCollection
+{
+  "names": ["<collection-name>"]
+}
+```
+
+## State Output
+
+Update `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "provision-collection",
+  "aws_account_id": "<from sts get-caller-identity>",
+  "aws_region": "<configured region>",
+  "principal_arn": "<from sts get-caller-identity>",
+  "resource_name": "<collection-name>",
+  "resource_endpoint": "<collection-endpoint-url>"
+}
+```
+
+## Next Step
+
+Proceed to [Serverless Deploy Search](serverless-02-deploy-search.md).

--- a/skills/opensearch-skills/aws/serverless-02-deploy-search.md
+++ b/skills/opensearch-skills/aws/serverless-02-deploy-search.md
@@ -1,0 +1,294 @@
+# Amazon OpenSearch Serverless — Step 2: Deploy Search Configuration
+
+This guide covers creating indices, deploying ML models, and configuring pipelines on the serverless collection.
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: collection endpoint URL
+- `search_strategy`: determines which path to follow
+- `principal_arn`: for IAM role creation (dense vector path)
+
+From `prepare_aws_deployment()` output:
+- `local_config.text_fields`: fields to configure for search
+- `plan_summary.solution`: full architecture plan
+
+## Route by Strategy
+
+- **Neural Sparse** — follow "Neural Sparse Path" below
+- **Dense Vector or Hybrid** — follow "Dense Vector Path" below
+- **BM25** — follow "BM25 Path" below
+
+---
+
+## Neural Sparse Path (Automatic Semantic Enrichment)
+
+### Create Index with Semantic Enrichment
+
+Use AWS API MCP to create the index with automatic enrichment:
+
+```json
+POST /opensearchserverless/CreateIndex
+{
+  "id": "<collection-id>",
+  "indexName": "<index-name>",
+  "indexSchema": {
+    "mappings": {
+      "properties": {
+        "<text-field>": {
+          "type": "text",
+          "semantic_enrichment": {
+            "status": "ENABLED",
+            "language_options": "english"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Key points:
+- Set `semantic_enrichment.status` to "ENABLED" on text fields for neural sparse
+- `language_options`: "english" or "multi-lingual"
+- System automatically deploys sparse model, creates ingest/search pipelines
+- Standard "match" queries are automatically rewritten to neural sparse queries
+- No manual model or pipeline management required
+
+Update state: `"index_name": "<index-name>"`, `"step_completed": "deploy-search"`
+
+Skip to "Index Sample Documents" below.
+
+---
+
+## Dense Vector Path
+
+### Step 1: Create IAM Role for Bedrock
+
+```json
+POST /iam/CreateRole
+{
+  "RoleName": "opensearch-bedrock-role",
+  "AssumeRolePolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": { "Service": "ml.opensearchservice.amazonaws.com" },
+      "Action": "sts:AssumeRole"
+    }]
+  }
+}
+```
+
+Attach Bedrock invoke permissions:
+
+```json
+POST /iam/PutRolePolicy
+{
+  "RoleName": "opensearch-bedrock-role",
+  "PolicyName": "BedrockInvokePolicy",
+  "PolicyDocument": {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": "arn:aws:bedrock:*::foundation-model/amazon.titan-embed-text-v2:0"
+    }]
+  }
+}
+```
+
+Update state: `"iam_role_arn": "<role-arn>"`
+
+### Step 2: Create ML Connector
+
+Use opensearch-mcp-server to create a Bedrock Titan connector:
+
+```
+POST <collection-endpoint>/_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Titan Embedding V2",
+  "description": "Connector to Bedrock Titan embedding model",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "<aws-region>",
+    "service_name": "bedrock"
+  },
+  "credential": {
+    "roleArn": "<iam_role_arn>"
+  },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "url": "https://bedrock-runtime.<aws-region>.amazonaws.com/model/amazon.titan-embed-text-v2:0/invoke",
+    "headers": { "content-type": "application/json", "x-amz-content-sha256": "required" },
+    "request_body": "{ \"inputText\": \"${parameters.inputText}\" }",
+    "pre_process_function": "\n    StringBuilder builder = new StringBuilder();\n    builder.append(\"\\\"\");\n    String first = params.text_docs[0];\n    builder.append(first);\n    builder.append(\"\\\"\");\n    def parameters = \"{\" +\"\\\"inputText\\\":\" + builder + \"}\";\n    return  \"{\" +\"\\\"parameters\\\":\" + parameters + \"}\";",
+    "post_process_function": "\n      def name = \"sentence_embedding\";\n      def dataType = \"FLOAT32\";\n      if (params.embedding == null || params.embedding.length == 0) {\n        return params.message;\n      }\n      def shape = [params.embedding.length];\n      def json = \"{\" +\n                 \"\\\"name\\\":\\\"\" + name + \"\\\",\" +\n                 \"\\\"data_type\\\":\\\"\" + dataType + \"\\\",\" +\n                 \"\\\"shape\\\":\" + shape + \",\" +\n                 \"\\\"data\\\":\" + params.embedding +\n                 \"}\";\n      return json;\n    "
+  }]
+}
+```
+
+Update state: `"connector_id": "<connector_id>"`
+
+### Step 3: Register and Deploy Model
+
+```
+POST <collection-endpoint>/_plugins/_ml/model_groups/_register
+{ "name": "bedrock_embedding_models", "description": "Bedrock embedding model group" }
+```
+
+Update state: `"model_group_id": "<model_group_id>"`
+
+```
+POST <collection-endpoint>/_plugins/_ml/models/_register
+{
+  "name": "bedrock-titan-embed-v2",
+  "function_name": "remote",
+  "description": "Bedrock Titan Text Embeddings V2",
+  "model_group_id": "<model_group_id>",
+  "connector_id": "<connector_id>"
+}
+```
+
+```
+POST <collection-endpoint>/_plugins/_ml/models/<model-id>/_deploy
+```
+
+Test: `POST <collection-endpoint>/_plugins/_ml/models/<model-id>/_predict` with `{"parameters": {"inputText": "hello world"}}`. Verify 1024-dimensional embeddings.
+
+Update state: `"model_id": "<model_id>"`
+
+### Step 4: Create Ingest Pipeline
+
+```
+PUT <collection-endpoint>/_ingest/pipeline/bedrock-embedding-pipeline
+{
+  "description": "Bedrock Titan embedding pipeline",
+  "processors": [{
+    "text_embedding": {
+      "model_id": "<model_id>",
+      "field_map": { "<text-field>": "<vector-field>" }
+    }
+  }]
+}
+```
+
+Update state: `"ingest_pipeline_name": "bedrock-embedding-pipeline"`
+
+### Step 5: Create Index
+
+```
+PUT <collection-endpoint>/<index-name>
+{
+  "settings": {
+    "index": { "knn": true, "knn.space_type": "cosinesimil", "default_pipeline": "bedrock-embedding-pipeline" }
+  },
+  "mappings": {
+    "properties": {
+      "<text-field>": { "type": "text" },
+      "<vector-field>": {
+        "type": "knn_vector",
+        "dimension": 1024,
+        "method": { "name": "hnsw", "space_type": "cosinesimil", "engine": "faiss" }
+      }
+    }
+  }
+}
+```
+
+Update state: `"index_name": "<index-name>"`
+
+### Step 6: Create Search Pipeline (hybrid search only)
+
+If search strategy is "hybrid":
+
+```
+PUT <collection-endpoint>/_search/pipeline/hybrid-search-pipeline
+{
+  "description": "Hybrid search with normalization",
+  "phase_results_processors": [{
+    "normalization-processor": {
+      "normalization": { "technique": "min_max" },
+      "combination": { "technique": "arithmetic_mean", "parameters": { "weights": [0.3, 0.7] } }
+    }
+  }]
+}
+```
+
+Update state: `"search_pipeline_name": "hybrid-search-pipeline"`, `"step_completed": "deploy-search"`
+
+---
+
+## BM25 Path
+
+### Create Index
+
+Use opensearch-mcp-server to create the index with text mappings from local config:
+
+```
+PUT <collection-endpoint>/<index-name>
+{
+  "mappings": {
+    "properties": {
+      "<text-field>": { "type": "text" }
+    }
+  }
+}
+```
+
+Include all field mappings from the local setup.
+
+Update state: `"index_name": "<index-name>"`, `"step_completed": "deploy-search"`
+
+---
+
+## Index Sample Documents
+
+After index creation (all paths):
+1. Use the same sample documents from Phase 1
+2. Index a few test documents to verify the setup
+3. Test search queries:
+   - Neural Sparse: use standard `match` queries (automatically rewritten)
+   - Dense Vector: use `neural` query with `model_id`
+   - BM25: use standard `match` queries
+
+## Connect Search UI to AWS Endpoint
+
+After deployment is complete, switch the local Search Builder UI to query the AWS collection:
+
+```
+Call connect_search_ui_to_endpoint(
+  endpoint="<collection-endpoint>",
+  port=443,
+  use_ssl=true,
+  index_name="<index-name>"
+)
+```
+
+The UI header badge will change from "Local" to "AWS Cloud" with a green connection indicator.
+
+## Provide Access Information
+
+Give the user:
+- Collection endpoint URL
+- Collection ARN
+- Dashboard URL (if applicable)
+- Sample search queries to test
+- Search Builder UI URL (already connected to AWS endpoint)
+
+## State Output
+
+Final state update:
+```json
+{
+  "step_completed": "deploy-search",
+  "index_name": "<index-name>",
+  "iam_role_arn": "<if created>",
+  "connector_id": "<if created>",
+  "model_id": "<if created>",
+  "ingest_pipeline_name": "<if created>",
+  "search_pipeline_name": "<if created>"
+}
+```

--- a/skills/opensearch-skills/cli-reference.md
+++ b/skills/opensearch-skills/cli-reference.md
@@ -1,0 +1,150 @@
+# CLI Reference
+
+All commands are run from the skill root directory.
+
+```bash
+uv run python scripts/opensearch_ops.py <command> [options]
+```
+
+## Start OpenSearch
+
+```bash
+bash scripts/start_opensearch.sh
+```
+
+## Check connectivity
+
+```bash
+uv run python scripts/opensearch_ops.py status
+```
+
+## Load sample data
+
+```bash
+# Built-in IMDB dataset
+uv run python scripts/opensearch_ops.py load-sample --type builtin_imdb
+
+# From a local file (JSON, JSONL, CSV, TSV, Parquet)
+uv run python scripts/opensearch_ops.py load-sample --type local_file --value /path/to/data.json
+
+# From a URL
+uv run python scripts/opensearch_ops.py load-sample --type url --value https://example.com/data.json
+
+# From an existing local index
+uv run python scripts/opensearch_ops.py load-sample --type localhost_index --value my-index
+
+# From pasted JSON
+uv run python scripts/opensearch_ops.py load-sample --type paste --value '{"title": "Example", "description": "A sample doc"}'
+```
+
+## Deploy a model
+
+```bash
+# Local pretrained model (e.g. sentence-transformers)
+uv run python scripts/opensearch_ops.py deploy-model --name "huggingface/sentence-transformers/all-mpnet-base-v2"
+
+# Bedrock embedding model
+uv run python scripts/opensearch_ops.py deploy-bedrock --name "amazon.titan-embed-text-v2:0"
+```
+
+## Create an index
+
+```bash
+uv run python scripts/opensearch_ops.py create-index --name my-index --body '{"settings": {"index": {"knn": true}}, "mappings": {"properties": {"title": {"type": "text"}, "embedding": {"type": "knn_vector", "dimension": 768, "method": {"engine": "faiss", "name": "hnsw"}}}}}'
+```
+
+Use `--replace` (default: true) to delete and recreate if the index already exists.
+
+## Create and attach a pipeline
+
+```bash
+# Ingest pipeline
+uv run python scripts/opensearch_ops.py create-pipeline --name my-pipeline --index my-index --type ingest --body '{"description": "Embedding pipeline", "processors": [{"text_embedding": {"model_id": "<MODEL_ID>", "field_map": {"title": "embedding"}}}]}'
+
+# Search pipeline
+uv run python scripts/opensearch_ops.py create-pipeline --name my-search-pipeline --index my-index --type search --body '{"request_processors": [{"neural_query_enricher": {"default_model_id": "<MODEL_ID>"}}]}'
+
+# Hybrid pipeline with custom weights
+uv run python scripts/opensearch_ops.py create-pipeline --name my-hybrid-pipeline --index my-index --type search --hybrid --weights '[0.3, 0.7]' --body '{"phase_results_processors": [{"normalization-processor": {"normalization": {"technique": "min_max"}, "combination": {"technique": "arithmetic_mean", "parameters": {"weights": [0.3, 0.7]}}}}]}'
+```
+
+## Index documents
+
+```bash
+# Single document
+uv run python scripts/opensearch_ops.py index-doc --index my-index --id doc1 --doc '{"title": "Example", "description": "A sample document"}'
+
+# Bulk index from file
+uv run python scripts/opensearch_ops.py index-bulk --index my-index --source-file /path/to/data.tsv --count 50
+```
+
+## Search
+
+```bash
+# Simple match query
+uv run python scripts/opensearch_ops.py search --index my-index --body '{"query": {"match": {"title": "search term"}}}' --size 10
+
+# Neural (semantic) search
+uv run python scripts/opensearch_ops.py search --index my-index --body '{"query": {"neural": {"embedding": {"query_text": "find similar documents", "model_id": "<MODEL_ID>", "k": 5}}}}'
+
+# Hybrid search
+uv run python scripts/opensearch_ops.py search --index my-index --body '{"query": {"hybrid": {"queries": [{"match": {"title": "search term"}}, {"neural": {"embedding": {"query_text": "search term", "model_id": "<MODEL_ID>", "k": 5}}}]}}}'
+```
+
+## Launch Search Builder UI
+
+```bash
+uv run python scripts/opensearch_ops.py launch-ui --index my-index
+```
+
+## Launch Comparison View
+
+After evaluation and restart, compare the baseline and improved indices side by side:
+
+```bash
+uv run python scripts/opensearch_ops.py compare-ui \
+  --baseline my-index-v1 \
+  --improved my-index-v2
+```
+
+## Connect UI to remote endpoint
+
+```bash
+# Amazon OpenSearch Service
+uv run python scripts/opensearch_ops.py connect-ui --endpoint search-my-domain.us-east-1.es.amazonaws.com --aws-region us-east-1 --aws-service es --index my-index
+
+# Amazon OpenSearch Serverless
+uv run python scripts/opensearch_ops.py connect-ui --endpoint abc123.us-east-1.aoss.amazonaws.com --aws-region us-east-1 --aws-service aoss --index my-index
+
+# Basic auth
+uv run python scripts/opensearch_ops.py connect-ui --endpoint my-opensearch.example.com --port 443 --username admin --password admin --index my-index
+```
+
+## Agentic search setup
+
+```bash
+# 1. Deploy Bedrock Claude model for agent reasoning
+uv run python scripts/opensearch_ops.py deploy-agentic-model --region us-east-1
+
+# 2. Create a flow agent
+uv run python scripts/opensearch_ops.py create-flow-agent --name my-agent --model-id <CONNECTOR_MODEL_ID>
+
+# 3. Create and attach agentic search pipeline
+uv run python scripts/opensearch_ops.py create-agentic-pipeline --name my-agentic-pipeline --agent-id <AGENT_ID> --index my-index
+```
+
+## Read knowledge base files
+
+```bash
+uv run python scripts/opensearch_ops.py read-knowledge --file dense_vector_models.md
+uv run python scripts/opensearch_ops.py read-knowledge --file sparse_vector_models.md
+uv run python scripts/opensearch_ops.py read-knowledge --file opensearch_semantic_search_guide.md
+uv run python scripts/opensearch_ops.py read-knowledge --file agentic_search_guide.md
+uv run python scripts/opensearch_ops.py read-knowledge --file evaluation_guide.md
+```
+
+## Cleanup
+
+```bash
+uv run python scripts/opensearch_ops.py cleanup
+```

--- a/skills/opensearch-skills/launchpad/agentic_search_guide.md
+++ b/skills/opensearch-skills/launchpad/agentic_search_guide.md
@@ -1,0 +1,253 @@
+# OpenSearch Agentic Search Guide
+
+---
+
+## 1. Overview
+
+Agentic search is an AI-powered retrieval method introduced in OpenSearch 3.2 that handles multi-step natural language questions and provides answer synthesis. It is a **standalone retrieval approach** designed for complex reasoning scenarios where users expect synthesized answers rather than ranked documents.
+
+**Architecture:**
+```
+User Multi-Step Question
+         ↓
+   Agentic Search Agent (LLM-powered reasoning & orchestration)
+         ↓
+   Query Planning & Decomposition
+         ↓
+   Document Retrieval (agent selects optimal method internally)
+         ↓
+   Answer Synthesis
+         ↓
+   Synthesized Answer (not just ranked hits)
+```
+
+**How it works:**
+1. User asks a multi-step natural language question (e.g., "What are the top-rated products under $100 and why are they popular?")
+2. LLM-powered agent analyzes the question and breaks it down into steps
+3. Agent determines the best retrieval strategy and generates appropriate queries
+4. Agent retrieves relevant documents using its internal retrieval capabilities
+5. Agent synthesizes results into a coherent, reasoned answer
+
+**Key Distinction:** Agentic search is a complete, standalone retrieval method. Unlike BM25, Dense Vector, or Hybrid search which return ranked documents, agentic search returns synthesized answers. Choose agentic search when users need multi-step reasoning and answer synthesis, not when they just need ranked search results.
+
+---
+
+## 2. Agent Types
+
+Agentic search supports two agent types optimized for different use cases.
+
+### 2.1 Conversational Agents
+
+**Overview:** Full-featured agents with multi-tool support and conversation memory.
+
+| Aspect | Details |
+|--------|---------|
+| **Tools** | Multiple (QueryPlanningTool + others) |
+| **Memory** | Conversation history with memory IDs |
+| **Reasoning** | Detailed step-by-step traces |
+| **Latency** | Higher (multiple LLM calls) |
+| **Cost** | Higher (more API calls) |
+| **Use Case** | Complex multi-turn conversations, tool orchestration |
+
+### 2.2 Flow Agents
+
+**Overview:** Streamlined agents focused solely on query planning.
+
+| Aspect | Details |
+|--------|---------|
+| **Tools** | Single (QueryPlanningTool only) |
+| **Memory** | None |
+| **Reasoning** | Simplified |
+| **Latency** | Lower (fewer LLM calls) |
+| **Cost** | Lower |
+| **Use Case** | Simple stateless queries, known indexes |
+
+---
+
+## 3. Accuracy Characteristics
+
+| Aspect | Rating | Notes |
+|--------|--------|-------|
+| **Simple Queries** | 5/5 | Excellent for straightforward keyword/filter queries |
+| **Complex Logic** | 4/5 | Good for multi-condition boolean queries |
+| **Ambiguity Handling** | 4/5 | LLM can interpret ambiguous intent |
+| **Consistency** | 3/5 | May generate different DSL for same question |
+| **Domain Knowledge** | 3/5 | Limited to index schema; no external domain knowledge |
+
+**Strengths:**
+- Handles natural language variations well
+- Can infer user intent from context
+- Generates syntactically correct DSL
+- Adapts to index schema automatically
+
+**Weaknesses:**
+- May misinterpret ambiguous questions
+- No guarantee of optimal query structure
+- Can be inconsistent across similar queries
+- Result quality depends on underlying retrieval method
+
+---
+
+## 4. Latency & Cost Profile
+
+### 4.1 Latency Composition
+
+```
+Total Latency = LLM Inference + DSL Execution
+```
+
+| Component | Typical Range | Notes |
+|-----------|---------------|-------|
+| **LLM Inference** | 200-2000ms | Dominates total latency |
+| **DSL Execution** | 10-500ms | Depends on query type (BM25/neural/hybrid) |
+| **Total** | 210-2500ms | 10-100x slower than direct DSL |
+
+**Latency Factors:**
+- Model size (GPT-4 vs GPT-3.5)
+- Query complexity
+- Agent type (flow faster than conversational)
+- Number of tools invoked
+
+### 4.2 Cost Profile
+
+| Resource | Cost Level | Details |
+|----------|------------|---------|
+| **LLM API Calls** | 4/5 (High) | Per-query inference costs |
+| **Storage** | 2/5 (Low-Medium) | Conversation memory (if enabled) |
+| **Compute** | 2/5 (Low-Medium) | Agent orchestration overhead |
+| **Underlying Search** | Varies | Depends on generated query (BM25/neural/hybrid) |
+
+**Cost Optimization:**
+- Use flow agents when memory not needed
+- Cache common query patterns
+- Use smaller/faster LLM models
+- Limit max_iteration parameter
+- Disable conversation memory if not required
+
+---
+
+## 5. When to Use Agentic Search
+
+**Use Agentic Search (standalone retrieval method) when:**
+- Users ask multi-step questions requiring reasoning and answer synthesis
+  - Example: "What are the top-rated products under $30k and why are they popular?"
+  - Example: "Show me budget laptops with good reviews and explain the trade-offs"
+- Questions need context from multiple queries to form a complete answer
+- Users expect ChatGPT-like synthesized answers, not just ranked documents
+- Complex analytical questions requiring query decomposition and reasoning
+- Conversational search experiences where synthesis is more valuable than document ranking
+
+**Use Other Methods (BM25/Dense/Sparse/Hybrid) when:**
+- Users just need ranked documents (not synthesized answers)
+- Simple keyword searches or semantic similarity lookups
+- Latency-critical applications (agentic adds 200-2000ms overhead)
+- Cost-sensitive deployments (LLM API costs per query)
+- High-frequency queries where query templates work well
+- Query structure is known and predictable
+
+---
+
+## 6. Setup Requirements
+
+### 6.1 Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| **OpenSearch Version** | 3.2+ |
+| **LLM Provider** | Amazon Bedrock (Claude 4 Sonnet recommended), OpenAI, or self-hosted |
+| **Permissions** | IAM role with Bedrock InvokeModel permissions (if using Bedrock) |
+| **Plugins** | ML Commons Plugin, Agent Framework (built-in 3.2+) |
+
+### 6.2 Setup Components
+
+Agentic search requires three main components:
+
+1. **LLM Model Registration**: Register the LLM (e.g., Bedrock Claude) as a remote model in OpenSearch
+2. **Agent Creation**: Create a conversational or flow agent with query planning tools
+3. **Search Pipeline**: Attach an agentic query translator processor to your search pipeline
+
+**Agent Tools Configuration:**
+- `ListIndexTool`: Discovers available indices
+- `IndexMappingTool`: Retrieves index schema
+- `WebSearchTool`: Optional external search (e.g., DuckDuckGo)
+- `QueryPlanningTool`: Core tool that generates OpenSearch DSL
+
+### 6.3 Query Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query_text` | String | Yes | Natural language question |
+| `query_fields` | Array | No | Fields to consider (inferred if omitted) |
+| `memory_id` | String | No | Conversation memory ID (conversational agents only) |
+
+**Note:** Actual setup is handled by implementation tools. The knowledge base focuses on decision criteria.
+
+---
+
+## 7. Advanced Features
+
+### 7.1 Conversation Memory
+
+Conversational agents support multi-turn conversations with context retention:
+
+- First query establishes a conversation session
+- Response includes a `memory_id` 
+- Subsequent queries reference the `memory_id` to maintain context
+- Enables follow-up questions like "What about blue ones?" after asking about red cars
+
+### 7.2 Automatic Retrieval Method Selection
+
+When configured with an embedding model, agents can automatically choose the optimal retrieval method:
+
+| Query Type | Selected Method |
+|------------|-----------------|
+| Keyword queries | BM25 |
+| Conceptual queries | Dense/sparse vector |
+| Mixed queries | Hybrid |
+
+This eliminates the need for manual query routing logic.
+
+---
+
+## 8. Deployment Considerations
+
+### 8.1 Model Options
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Amazon Bedrock** | AWS integration, Claude 4 Sonnet, IAM auth | AWS-only, requires IAM role |
+| **OpenAI API** | Easy setup, SOTA models | External dependency, per-call cost |
+| **Self-hosted** | Full control | Infrastructure overhead |
+
+**Recommended:** Amazon Bedrock with Claude 4 Sonnet for Amazon OpenSearch Service deployments.
+
+### 8.2 Scaling
+
+- **LLM API rate limits:** Plan for concurrent queries
+- **Conversation memory:** Monitor index growth
+- **Cost:** Linear with query volume
+
+### 8.3 Security
+
+- Secure API key storage
+- Be mindful of PII in natural language queries
+- Understand LLM provider data policies
+- Implement conversation memory retention policies
+
+---
+
+## 9. Limitations
+
+1. **Latency:** 200-2000ms overhead per query
+2. **Cost:** LLM API calls per query
+3. **Consistency:** Same question may generate different DSL
+4. **Answer synthesis quality:** Depends on LLM capabilities and retrieved documents
+5. **Complex DSL:** May struggle with advanced DSL features
+6. **Not a replacement for traditional search:** Users expecting simple ranked results may prefer direct retrieval
+
+---
+
+*Document Version: 1.0*
+*Last Updated: January 2025*
+*Applicable OpenSearch Versions: 3.2+*
+*Based on: https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/*

--- a/skills/opensearch-skills/launchpad/dense_vector_models.md
+++ b/skills/opensearch-skills/launchpad/dense_vector_models.md
@@ -1,0 +1,109 @@
+# Dense Vector Models Guide
+
+This document lists model options for Dense Vector Search in OpenSearch, categorized by deployment mode, with practical recommendations.
+
+> Key takeaways:
+> - **OpenSearch node (CPU) pretrained models tend to be older baselines**: convenient for quick starts, but **not SOTA** for retrieval quality.
+> - **Default recommendation for most users: Amazon Titan Embeddings (via Amazon Bedrock)** for strong quality + managed ops.
+
+DO NOT talk about default recommendation with users.
+> - **External Embedding API Services**: OpenSearch can work with **any embedding service** via ML Commons Connectors; the list below is just common examples.
+
+---
+
+## 1. OpenSearch Node Deployment (CPU)
+
+Deploy models directly on OpenSearch nodes using CPU inference.
+
+**When to use**
+- Dev / POC / low QPS workloads
+- Environments where you cannot run GPU endpoints
+- You prioritize simplicity over best retrieval quality
+
+**Caveat**
+- The pretrained models available on OpenSearch nodes are generally **older** and may not match the quality of newer retrieval-optimized models (e.g., E5/BGE or vendor-managed models like Titan).
+
+### 1.1 Supported Pre-trained Models (examples)
+
+OpenSearch provides a repository of pre-trained models that can be registered directly.
+
+| Model Name | Dimensions | Description | Size | Latency (Approx) |
+|------------|------------|-------------|------|------------------|
+| `huggingface/sentence-transformers/all-MiniLM-L6-v2` | 384 | Good speed/quality tradeoff for English. | 22M | Low (5–15ms) |
+| `huggingface/sentence-transformers/all-mpnet-base-v2` | 768 | Often higher quality than MiniLM, slower. | 110M | Medium (20–50ms) |
+| `huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` | 384 | Multilingual baseline for many languages. | 120M | Medium (10–30ms) |
+| `huggingface/sentence-transformers/multi-qa-MiniLM-L6-cos-v1` | 384 | Tuned for QA-style semantic search. | 22M | Low (5–15ms) |
+
+> Note: Actual latency depends heavily on hardware, JVM overhead, batch size, and concurrent load.
+
+### 1.2 Custom Models
+
+**Not Supported.** Custom or fine-tuned sparse encoding models cannot be deployed on OpenSearch Nodes. You must use a SageMaker GPU Endpoint.
+
+---
+
+## 2. SageMaker GPU Endpoint (Recommended for Custom / High-QPS)
+
+Deploy models on AWS SageMaker with GPU acceleration for high throughput and low latency. This is the recommended approach for:
+- High QPS / large batch ingestion
+- Larger or retrieval-optimized models (E5/BGE family, etc.)
+- Custom/fine-tuned models and custom inference logic
+
+### 2.1 Recommended Models (examples)
+
+Any model compatible with Hugging Face Text Embeddings Inference (TEI) or a custom SageMaker inference script can be used.
+
+| Model Name | Dimensions | Description | Recommended Instance |
+|------------|------------|-------------|---------------------|
+| `intfloat/e5-base-v2` | 768 | Strong retrieval performance; widely used. | `ml.g5.xlarge` |
+| `intfloat/multilingual-e5-base` | 768 | Strong multilingual retrieval. | `ml.g5.xlarge` |
+| `BAAI/bge-base-en-v1.5` | 768 | High-quality English retrieval. | `ml.g5.xlarge` |
+| `BAAI/bge-m3` | 1024 | Multilingual + multi-granularity; heavier. | `ml.g5.xlarge` |
+
+### 2.2 Custom Models
+
+If you have a **custom** or **fine-tuned dense embedding model**, deploy it using a SageMaker GPU Endpoint. This mode supports custom model weights and custom inference logic that you control.
+
+---
+
+## 3. External Embedding API Services (Managed Providers)
+
+Use managed API services to generate embeddings. OpenSearch connects via the **ML Commons Connector**.
+
+**Important:** OpenSearch can integrate with **any embedding provider/service** as long as:
+- You can call an HTTP endpoint from OpenSearch (or from the connector runtime),
+- The service returns a numeric embedding vector,
+- You can configure authentication and request/response transformation.
+
+So the providers below are **examples of common choices**, not an exhaustive list.
+
+### 3.1 Common Providers (Examples)
+
+| Provider | Model Names (Examples) | Dimensions (Typical) | Notes |
+|----------|-------------------------|----------------------|------|
+| **Amazon Bedrock** *(Default recommendation)* | `amazon.titan-embed-text-v2`<br>`cohere.embed-english-v3`<br>`cohere.embed-multilingual-v3` | 1024<br>1024<br>1024 | Fully managed, integrated with AWS IAM. Titan v2 supports variable dimensions. |
+| **OpenAI** | `text-embedding-3-small`<br>`text-embedding-3-large`<br>`text-embedding-ada-002` | 1536<br>3072<br>1536 | Widely adopted; requires API key. |
+| **Cohere** | `embed-english-v3.0`<br>`embed-multilingual-v3.0` | 1024 | Strong retrieval-focused embeddings. |
+
+**Why default recommend Amazon Titan**
+- Strong general-purpose embedding quality
+- Fully managed + straightforward operations on AWS
+- IAM-based auth and Bedrock integration reduces operational overhead
+
+---
+
+## Summary of Trade-offs
+
+| Deployment Mode | Latency | Cost | Maintenance | Scalability | Best For |
+|-----------------|---------|------|-------------|-------------|----------|
+| **OpenSearch node (CPU)** | Medium/High | Low (shared) | Medium | Limited by cluster | Dev/POC, low QPS, simple setups |
+| **SageMaker (GPU)** | Low | High (dedicated) | Low/Medium | High | Production ingestion + high QPS + custom models |
+| **External API** | Medium/High (network) | Usage-based | Very Low | High | Fast rollout, managed quality, minimal ops |
+
+---
+
+## Practical Tips (Common Gotchas)
+
+- **Dimensions must match** your index mapping (`dense_vector` dimension).
+- If your model recommends **normalization** (common for cosine similarity), apply it consistently at ingestion and query time.
+- For E5/BGE-style retrieval models, follow their recommended query/document formatting (e.g., prefixes) for best results.

--- a/skills/opensearch-skills/launchpad/document_processing_guide.md
+++ b/skills/opensearch-skills/launchpad/document_processing_guide.md
@@ -1,0 +1,152 @@
+# Document Processing with Docling
+
+This guide covers how to process PDF, DOCX, PPTX, XLSX, HTML, and other document formats for ingestion into OpenSearch using [Docling](https://docling.site/).
+
+## Overview
+
+Docling is an open-source Python library (MIT license) by IBM Research that converts unstructured documents into structured data. It detects page layout, reading order, table structure, code blocks, formulas, and images using AI models, and runs locally on commodity hardware.
+
+## Supported Input Formats
+
+PDF, DOCX, PPTX, XLSX, HTML, Markdown, AsciiDoc, CSV, images (PNG, JPEG, TIFF, BMP, WEBP), audio (MP3, WAV).
+
+## Installation
+
+```bash
+pip install docling
+# or with uv
+uv pip install docling
+```
+
+Docling requires Python 3.9–3.13. First run downloads AI models (~1.5 GB) automatically.
+
+## Basic Usage — Convert a Document
+
+```python
+from docling.document_converter import DocumentConverter
+
+converter = DocumentConverter()
+
+# From local file
+result = converter.convert("/path/to/document.pdf")
+doc = result.document
+
+# From URL
+result = converter.convert("https://example.com/report.pdf")
+doc = result.document
+
+# Export as markdown
+markdown_text = doc.export_to_markdown()
+
+# Export as dict (JSON-serializable)
+doc_dict = doc.export_to_dict()
+```
+
+## CLI Usage
+
+```bash
+# Convert a PDF to markdown
+docling /path/to/document.pdf --output ./output_dir
+
+# Convert with specific format
+docling /path/to/document.pdf --to json --output ./output_dir
+
+# Convert multiple files
+docling ./input_dir --output ./output_dir
+```
+
+## Chunking for Search Ingestion
+
+Docling provides two chunking strategies for breaking documents into search-ready pieces:
+
+### HierarchicalChunker (structure-based)
+
+Splits at every section/heading boundary. Produces many small chunks that respect document structure.
+
+```python
+from docling.chunking import HierarchicalChunker
+
+chunker = HierarchicalChunker()
+chunks = list(chunker.chunk(doc))
+# Each chunk has: chunk.text, chunk.meta (headings, page numbers)
+```
+
+### HybridChunker (recommended for OpenSearch)
+
+Combines structure-aware splitting with token limits. Preserves document hierarchy while ensuring chunks fit within embedding model constraints.
+
+```python
+from docling.chunking import HybridChunker
+
+chunker = HybridChunker(max_tokens=512, overlap_tokens=50)
+chunks = list(chunker.chunk(doc))
+```
+
+## Preparing Chunks for OpenSearch Bulk Indexing
+
+Convert Docling chunks into JSON documents suitable for `opensearch_ops.py index-bulk` or direct OpenSearch indexing:
+
+```python
+import json
+from pathlib import Path
+from docling.document_converter import DocumentConverter
+from docling.chunking import HybridChunker
+
+converter = DocumentConverter()
+result = converter.convert("/path/to/document.pdf")
+doc = result.document
+
+chunker = HybridChunker(max_tokens=512, overlap_tokens=50)
+chunks = list(chunker.chunk(doc))
+
+# Write as JSONL for bulk indexing
+output_path = Path("chunks.jsonl")
+with output_path.open("w") as f:
+    for i, chunk in enumerate(chunks):
+        record = {
+            "text": chunk.text,
+            "chunk_id": i,
+            "source": "/path/to/document.pdf",
+        }
+        # Include heading metadata if available
+        if hasattr(chunk, "meta") and chunk.meta:
+            headings = chunk.meta.headings if hasattr(chunk.meta, "headings") else []
+            if headings:
+                record["section"] = " > ".join(headings)
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+print(f"Wrote {len(chunks)} chunks to {output_path}")
+```
+
+Then index into OpenSearch:
+
+```bash
+uv run python scripts/opensearch_ops.py index-bulk \
+  --index my-docs-index \
+  --source-file chunks.jsonl \
+  --count 500
+```
+
+## Processing Pipeline for Document Search
+
+The recommended end-to-end flow:
+
+1. **Convert** — Use Docling to parse the document into structured form.
+2. **Chunk** — Use `HybridChunker` with token limits matching your embedding model.
+3. **Export** — Write chunks as JSONL with text + metadata fields.
+4. **Index** — Use `opensearch_ops.py index-bulk` to load into OpenSearch.
+5. **Search** — Use the search UI or `opensearch_ops.py search` to query.
+
+## Performance Tips
+
+- Use `PdfPipelineOptions(generate_page_images=False)` to skip page images and save memory.
+- Use `max_num_pages` or `page_range` to limit processing for large documents.
+- Use `enable_parallel_processing=True` for multi-core processing.
+- For scanned PDFs, OCR is enabled by default. Use `do_ocr=False` to skip if not needed.
+
+## Choosing Chunk Size
+
+- For BM25 (keyword search): larger chunks (1000+ tokens) work well since BM25 benefits from more context.
+- For dense vector / semantic search: 256–512 tokens is typical, matching embedding model input limits.
+- For hybrid search: 512 tokens with 50-token overlap is a good default.
+- For agentic search: larger chunks (512–1024 tokens) give the agent more context per retrieval.

--- a/skills/opensearch-skills/launchpad/evaluation_guide.md
+++ b/skills/opensearch-skills/launchpad/evaluation_guide.md
@@ -1,0 +1,265 @@
+# Search Quality Evaluation Guide
+
+Data-driven evaluation that runs real queries against the live index, computes quantitative metrics, and diagnoses issues with actionable recommendations.
+
+## When to Evaluate
+
+Offer evaluation after Phase 4 completes successfully:
+> "Would you like to evaluate the search quality? I can run test queries, measure relevance metrics, and suggest improvements."
+
+If the user declines, skip to Phase 5.
+
+## Evaluation Workflow
+
+### Step 1: Generate Test Queries
+
+**Option A — UI server is running (preferred):**
+
+Call the suggestions endpoint. It returns test queries with capabilities already assigned from the search configuration in Phase 4:
+
+```
+GET http://127.0.0.1:8765/api/suggestions?index=<index>
+```
+
+Response:
+```json
+{
+  "suggestions": [
+    {"text": "The Godfather", "capability": "exact", "query_mode": "TERM", ...},
+    {"text": "director:Frank Darabont", "capability": "structured", "query_mode": "FILTER", ...},
+    ...
+  ],
+  "sample_docs": [...],
+  "has_semantic": true,
+  "index": "my-index"
+}
+```
+
+Use the `suggestions` list directly as test queries.
+
+**Option B — UI server is not running:**
+
+Ask the user to provide test queries. The agent assigns a capability to each query based on its form:
+
+| Capability | How to detect | Example |
+|-----------|---------------|---------|
+| `exact` | Matches a known title/name in the data | `The Matrix` |
+| `structured` | Contains `field:value` syntax | `genres:Drama` |
+| `combined` | Free text + `field:value` | `space adventure genres:Sci-Fi` |
+| `autocomplete` | Short prefix (< 5 chars or partial word) | `The Ma` |
+| `fuzzy` | Contains apparent misspelling | `Teh Matrx` |
+| `semantic` | Natural language describing a concept | `movies about redemption in prison` |
+
+### Step 2: Batch Search
+
+Run **all** queries through the search pipeline in a single call using `evaluate_search_results`. This runs every query through `search_ui_search` (the real pipeline from Phase 4) and returns results for the agent to judge:
+
+```bash
+uv run python -c "
+import sys, json; sys.path.insert(0, 'scripts')
+from opensearchpy import OpenSearch
+from lib.evaluate import evaluate_search_results
+client = OpenSearch(hosts=[{'host': 'localhost', 'port': 9200}], use_ssl=False, verify_certs=False)
+result = evaluate_search_results(client, '<index>', title_field='<title_field>', k=5)
+print(json.dumps(result['queries'], indent=2))
+"
+```
+
+Output — one entry per query with all results:
+```json
+[
+  {"query": "The Godfather", "capability": "exact", "results": [
+    {"title": "The Godfather", "score": 1.28},
+    {"title": "The Matrix", "score": 0.40}, ...
+  ]},
+  {"query": "director:Frank Darabont", "capability": "structured", "results": [
+    {"title": "The Shawshank Redemption", "score": 1.91}
+  ]},
+  ...
+]
+```
+
+This is **one command, one approval** — no per-query back-and-forth.
+
+### Step 3: Judge Relevance
+
+For each query, the agent reviews the returned documents and assigns a relevance grade to each query-document pair. Grade every document in the top-k results — do not skip any.
+
+**Grading scale:**
+
+| Grade | Label | Criteria |
+|-------|-------|----------|
+| 3 | Perfect | The document is exactly what a user searching this query would want. For exact queries, the title matches. For semantic queries, the document directly addresses the concept. |
+| 2 | Relevant | The document is clearly useful and related to the query intent, but is not the ideal result. For example, a sequel when the user searched for the original. |
+| 1 | Marginal | The document shares a topic, genre, or keyword with the query but does not satisfy the search intent. A loose thematic connection. |
+| 0 | Irrelevant | The document has no meaningful connection to the query. This is the default for unlisted documents. |
+
+**Judgment prompt — for each query-document pair, evaluate:**
+
+1. **Intent match**: What is the user trying to find with this query? Does this document satisfy that intent?
+2. **Content relevance**: How well does the document's content relate to the query, regardless of how the query was issued? A document about prison redemption is relevant to "movies about redemption in prison" whether the query came from a keyword search, semantic search, or a structured filter.
+3. **Would a real user click this?** If yes, grade >= 2. If maybe, grade 1. If no, grade 0.
+
+**Example judgment for query `"movies about redemption in prison"`:**
+
+| Document | Grade | Reasoning |
+|----------|-------|-----------|
+| The Shawshank Redemption | 3 | Directly about redemption and prison — perfect match |
+| Pulp Fiction | 1 | Contains themes of redemption but not about prison |
+| Interstellar | 0 | Space exploration — no connection to prison or redemption |
+
+Also judge documents that **should** appear but are missing from results — these feed into Rule 5 (missed relevant docs). Include them in the `relevance` dict even if they weren't returned.
+
+### Step 4: Compute Metrics and Diagnose
+
+Pass the relevance judgments from Step 3 together with the cached search results from Step 2 into `evaluate_index`. This reuses the search results — no queries are re-run:
+
+```bash
+uv run python -c "
+import sys, json; sys.path.insert(0, 'scripts')
+from opensearchpy import OpenSearch
+from lib.evaluate import evaluate_search_results, evaluate_index
+client = OpenSearch(hosts=[{'host': 'localhost', 'port': 9200}], use_ssl=False, verify_certs=False)
+search_results = evaluate_search_results(client, '<index>', title_field='<title_field>', k=5)
+report = evaluate_index(
+    search_results=search_results,
+    relevance_overrides={
+        'The Godfather': {'The Godfather': 3, 'Goodfellas': 1},
+        'director:Frank Darabont': {'The Shawshank Redemption': 3},
+    },
+)
+print(report)
+"
+```
+
+If Step 2 was not run separately, `evaluate_index` can also run searches from scratch:
+
+```python
+report = evaluate_index(
+    client, index_name, title_field="title", k=5,
+    relevance_overrides={...},
+)
+```
+
+### Step 5: Present Results
+
+**Always present the output of `format_report()` (or `evaluate_index()`) directly to the user.** Do not reformat, summarize, or rearrange the report. The report has a fixed schema with these sections in order:
+
+1. **Header** — index name, methods, k, query count
+2. **Per-query detail** — for each query: relevance labels, per-method star rating + nDCG/P@k/MRR, ranked document list with scores, grades, and DCG contributions
+3. **nDCG table** — all queries × methods in a single table with MEAN row
+4. **Summary** — mean metrics per method with visual bar
+5. **Per-type breakdown** — mean nDCG grouped by query capability
+6. **Findings & recommendations** — grouped by tag, sorted by severity, with recommended next action
+7. **Completion check** — pass/fail against target thresholds
+
+This schema is produced by `format_report()` in `evaluate.py`. Present it as a code block so formatting is preserved:
+
+````
+```
+<output of evaluate_index() or format_report()>
+```
+````
+
+After the report, add a brief summary (2-3 sentences) highlighting the key takeaway and suggested next step.
+
+## Metrics
+
+Three metrics are computed per query per method, all at cutoff `k`:
+
+| Metric | Formula | What it measures |
+|--------|---------|------------------|
+| **nDCG@k** | Normalized Discounted Cumulative Gain | Ranking quality -- are the best docs at the top? |
+| **P@k** | Precision at k | What fraction of top-k results are relevant? |
+| **MRR** | Mean Reciprocal Rank | How quickly does the first relevant result appear? |
+
+### Target Thresholds
+
+| Metric | Good (>= ) | Acceptable (>=) | Poor (<) |
+|--------|-----------|-----------------|----------|
+| Mean nDCG@k | 0.70 | 0.50 | 0.30 |
+| Mean P@k | 0.60 | 0.40 | 0.20 |
+| Mean MRR | 0.70 | 0.50 | 0.20 |
+
+## Diagnosis Rules
+
+The engine applies five diagnostic rules, comparing across all provided methods:
+
+### Rule 1: All methods fail (nDCG < 0.3 for every method)
+- **Severity**: HIGH
+- **Meaning**: No retrieval strategy can find relevant documents for this query
+- **Tag**: `[MODEL_SELECTION]` for semantic queries, `[INDEX_MAPPING]` for combined/structured
+- **Fix**: Check field mappings, analyzers, or upgrade embedding model
+
+### Rule 2: Pairwise method gaps (tag-aware)
+- **Severity**: MEDIUM
+- **Triggers when**: A vector-tagged method fails (nDCG < 0.3) while a lexical-tagged method succeeds (nDCG > 0.5), or vice versa
+- **Tag**: `[MODEL_SELECTION]` when vector fails, `[INDEX_MAPPING]` when lexical fails
+- **Fix**: Upgrade embedding model, or add proper text analyzers/boosting
+
+### Rule 3: Hybrid worse than single signals
+- **Severity**: MEDIUM/LOW
+- **Triggers when**: A hybrid-tagged method's nDCG is > 0.15 below the best non-hybrid method
+- **Tag**: `[SEARCH_PIPELINE]`
+- **Fix**: Adjust hybrid weights, or use query-type-aware routing
+
+### Rule 4: Irrelevant docs in top-2
+- **Severity**: MEDIUM
+- **Triggers when**: An irrelevant document (grade 0) appears in positions 1-2 and nDCG < 0.8
+- **Tag**: `[QUERY_TUNING]` or `[MODEL_SELECTION]`
+- **Fix**: Reduce field boosts, restructure query, or upgrade model
+
+### Rule 5: Missed relevant documents
+- **Severity**: LOW
+- **Triggers when**: High-relevance documents (grade >= 2) don't appear in any method's top-k
+- **Tag**: `[MODEL_SELECTION]`
+- **Fix**: Embed more fields, use a higher-capacity model
+
+## Finding Tags
+
+| Tag | What it targets | Example fix |
+|-----|----------------|-------------|
+| `[INDEX_MAPPING]` | Field types, analyzers, `.keyword` sub-fields | Add `.keyword` to filterable fields |
+| `[EMBEDDING_FIELDS]` | Which fields are embedded | Concatenate `title + genres` before embedding |
+| `[MODEL_SELECTION]` | Embedding model quality/type | Switch from sparse to dense, or upgrade model size |
+| `[SEARCH_PIPELINE]` | Hybrid weights, normalization | Shift from 0.8/0.2 to 0.5/0.5 balanced |
+| `[QUERY_TUNING]` | Field boosts, fuzziness, filter placement | Move filters to `bool.filter` to avoid score pollution |
+
+## Completion Criteria
+
+The evaluation passes if **any** of:
+- Mean nDCG@k across all methods > 0.7
+- All findings are LOW severity only
+- No HIGH severity findings and setup matches the use case
+
+## After Evaluation
+
+Present the evaluation results, then offer the user these options:
+
+> "Based on the evaluation, here's what you can do next:"
+> 1. **Restart with improvements** — I'll apply the recommended fixes and rebuild the search setup with a new index.
+> 2. **Deploy to Amazon OpenSearch Service** (Phase 5) — Deploy the current configuration as-is.
+> 3. **Done for now** — Keep experimenting with the Search Builder UI.
+
+If HIGH severity findings exist, recommend option 1 and explain the specific fix. If only LOW findings, note that the setup is acceptable and any option is reasonable.
+
+### Restart Flow
+
+When the user chooses to restart:
+
+1. **Record the current index name** — do not delete it. The user can compare against it later.
+2. Restart from Phase 3 with the recommended fixes. During Phase 4, create the new index with a **different name** (e.g. append `-v2` or `-improved` to the original name).
+3. **After Phase 4 completes**, launch the UI normally:
+
+```bash
+uv run python scripts/opensearch_ops.py launch-ui --index <new-index-name>
+```
+
+4. Let the user know they can compare the old and new indices using the Compare toggle:
+
+> "The improved search setup is live. You can use the **Compare** toggle in the Search Builder to select the old index alongside the new one and compare results side by side. Both indices are available in the index dropdowns."
+
+After the user reviews the results, offer:
+> 1. **Re-evaluate** — Run the evaluation again on the improved index to measure the impact.
+> 2. **Deploy to Amazon OpenSearch Service** (Phase 5) — Deploy the improved configuration.
+> 3. **Done for now** — Keep experimenting with the Search Builder UI.

--- a/skills/opensearch-skills/launchpad/opensearch_semantic_search_guide.md
+++ b/skills/opensearch-skills/launchpad/opensearch_semantic_search_guide.md
@@ -1,0 +1,489 @@
+# OpenSearch Semantic Search Methods Guide
+
+---
+
+## 1. BM25 (Lexical Search)
+
+### 1.1 Overview
+
+BM25 is the default ranking algorithm in OpenSearch. It calculates relevance based on term frequency (TF), inverse document frequency (IDF), and document length normalization.
+
+### 1.2 Accuracy Characteristics
+
+| Aspect | Rating | Notes |
+|--------|--------|-------|
+| Exact Match Precision | 5/5 | Excellent for exact keyword queries |
+| Semantic Understanding | 2/5 | Cannot understand synonyms or paraphrases |
+| Out-of-vocabulary Handling | 1/5 | Fails completely on unseen terms |
+| Domain-specific Terms | 5/5 | Excellent for technical/domain vocabulary |
+
+**Strengths:**
+- Perfect for exact keyword matching
+- Handles rare/domain-specific terminology well
+- No vocabulary mismatch between query and index
+
+**Weaknesses:**
+- Cannot understand semantic meaning
+- Fails on synonyms (e.g., "car" vs "automobile")
+- Language-dependent (requires language-specific analyzers)
+
+### 1.3 Cost Profile
+
+| Resource | Cost Level | Details |
+|----------|------------|---------|
+| Storage | 1/5 (Low) | Only inverted index, typically 10-30% of raw text size |
+| Memory | 1/5 (Low) | Field data cache only when needed |
+| CPU (Indexing) | 1/5 (Low) | Simple tokenization and analysis |
+| CPU (Query) | 1/5 (Low) | Efficient inverted index lookup |
+
+**Storage Estimation:**
+```
+Index Size ≈ Raw Text Size × 0.1 to 0.3
+Example: 1GB text → 100-300MB index
+```
+
+**Scaling Behavior:**
+- Cost&Latency grows sub-linearly with data size
+- Horizontal scaling is straightforward
+- Query complexity significantly affects latency
+
+### 1.5 Unique Features & Query Types
+
+BM25 supports several special query types that vector search cannot:
+
+| Query Type | Description | Use Case |
+|------------|-------------|----------|
+| `prefix` | Matches terms starting with specified prefix | Autocomplete, partial matching |
+| `wildcard` | Pattern matching with * and ? | Flexible string matching |
+| `regexp` | Regular expression matching | Complex pattern matching |
+| `fuzzy` | Tolerates spelling mistakes | Typo tolerance |
+| `ngram` | Matches character n-grams | Partial word matching |
+| `phrase` | Matches exact phrase in order | Exact phrase search |
+| `span` | Positional queries | Near queries, ordered matching |
+| `term` | Exact term matching (no analysis) | Exact value matching |
+
+### 1.6 Language Support
+
+| Feature | Support Level | Notes |
+|---------|---------------|-------|
+| English | 5/5 | Excellent with standard analyzer |
+| Other Languages | 4/5 | Requires language-specific analyzers |
+| Cross-lingual | 0/5 | Not supported natively |
+| CJK Languages | 3/5 | Requires specialized tokenizers (kuromoji, ik, etc.) |
+
+### 1.7 When to Use BM25
+
+**Recommended:**
+- Exact keyword/phrase search requirements
+- Autocomplete and typeahead features
+- Domain-specific terminology search
+- Regex or wildcard pattern matching
+- Maximum cost efficiency required
+- Low-latency requirements at any scale
+
+**Not Recommended:**
+- Semantic similarity search
+- Cross-lingual search
+- Synonym handling without manual configuration
+- User queries differ significantly from document terminology
+
+---
+
+## 2. Dense Vector Search
+
+### 2.1 Overview
+
+Dense vector search uses neural network embeddings to represent text as dense floating-point vectors (typically 384-1536 dimensions). Similarity is computed using cosine similarity, dot product, or L2 distance.
+
+### 2.2 Accuracy Characteristics
+
+| Aspect | Rating | Notes |
+|--------|--------|-------|
+| Semantic Understanding | 5/5 | Captures meaning beyond keywords |
+| Synonym Handling | 5/5 | Automatically handles synonyms |
+| Cross-lingual | 5/5 | With multilingual models |
+| Exact Match | 1/5 | Does not support exact keyword matches |
+| Domain-specific | 3/5 | If your domain distribution differs greatly from general corpus, fine-tuning is required for good results |
+
+**Strengths:**
+- Understands semantic meaning
+- Handles paraphrases and synonyms naturally
+- Supports cross-lingual search with multilingual models
+- Zero-shot transfer to new domains
+
+**Weaknesses:**
+- May miss exact keyword matches
+- Requires embedding model
+- Higher computational cost
+- Quality depends heavily on embedding model choice
+
+### 2.3 Index Algorithms (Core Structure)
+
+These algorithms determine how vectors are organized and searched.
+
+#### 2.3.1 HNSW (Hierarchical Navigable Small World)
+
+**Overview:** Graph-based approximate nearest neighbor (ANN) algorithm. Default and most popular choice.
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | 95-99%+ recall achievable with proper tuning |
+| **Build Time** | Moderate to slow |
+| **Query Latency** | Fast (1-50ms typically) |
+| **Memory Requirement** | High - entire graph in memory (unless using quantization) |
+| **Scalability** | Good, but memory-bound |
+
+**Key Trade-off:**
+Higher accuracy configurations require significantly more memory and result in slower build times.
+
+**Memory Estimation (Raw):**
+```
+Memory = num_vectors × (dimensions × 4 bytes + m × 8 bytes + overhead)
+Example: 10M vectors × 768 dims, m=16
+Memory ≈ 10M × (768 × 4 + 16 × 8) ≈ 32GB
+```
+
+**Cost Profile:**
+| Resource | Cost Level |
+|----------|------------|
+| Storage | 3/5 (Medium-High) |
+| Memory | 5/5 (Very High) |
+| CPU (Build) | 3/5 (Medium) |
+| CPU (Query) | 2/5 (Low-Medium) |
+
+**Best For:**
+- Small to medium datasets that fit in memory
+- Low-latency requirements
+- High accuracy requirements
+
+#### 2.3.2 IVF (Inverted File Index)
+
+**Overview:** Clustering-based approach that partitions vectors into clusters (buckets).
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | 85-95% recall typical |
+| **Build Time** | Slow (requires training) |
+| **Query Latency** | Medium (5-100ms) |
+| **Memory Requirement** | Lower than HNSW (especially with PQ) |
+| **Scalability** | Better for large datasets |
+
+**Parameters:**
+- `nlist`: Number of clusters. Typically sqrt(n) to n/1000
+- `nprobe`: Clusters to search at query time. Higher = better recall, slower
+
+**Memory Estimation:**
+```
+Memory = num_vectors × dimensions × 4 bytes + cluster_centroids
+Much lower than HNSW as no graph structure overhead
+```
+
+**Best For:**
+- Larger datasets where memory is constrained
+- Can tolerate slightly lower accuracy
+- Batch search workloads
+
+#### 2.3.3 Disk-based Vector Search (mode: on_disk)
+
+**Overview:** OpenSearch's solution for billion-scale vector search with limited memory (introduced in 2.17). It uses **Binary Quantization (BQ)** to keep a compressed index in memory while storing full-precision vectors on disk.
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | Good recall (uses re-ranking from disk) |
+| **Build Time** | Fast (BQ training is automatic) |
+| **Query Latency** | Medium (10-100ms), depends on SSD speed |
+| **Memory Requirement** | Very Low (uses 1-bit BQ compressed vectors in RAM) |
+| **Scalability** | Excellent for billion-scale datasets |
+
+**Configuration (`mode: on_disk`):**
+- **Engine:** Uses `faiss` with `hnsw` method.
+- **Quantization:** Automatically uses **Binary Quantization (BQ)** for the in-memory index.
+  - *Note:* You cannot combine this with PQ (`encoder: pq`).
+  - *Note:* BQ training is automatic during indexing (unlike PQ which often needs training data).
+- **Process:**
+  1. Searches in-memory BQ index (very fast, low precision).
+  2. Fetches full vectors from disk for re-ranking to improve precision.
+
+**Memory Estimation:**
+```
+Memory = num_vectors × dimensions / 8 (bits to bytes) + HNSW graph overhead
+Example: 1B vectors × 768 dims (using BQ)
+Memory ≈ 1B × 96 bytes ≈ 96 GB (manageable on a cluster)
+vs. ~3TB for float32 vectors
+```
+
+**Cost Profile:**
+| Resource | Cost Level |
+|----------|------------|
+| Storage | 4/5 (High - raw vectors + index) |
+| Memory | 2/5 (Low) |
+| CPU (Query) | 3/5 (Medium - BQ distance is fast, IO overhead exists) |
+| SSD IOPS | 4/5 (High - fast NVMe required for re-ranking) |
+
+**Best For:**
+- Billion-scale datasets
+- Cost-efficiency (trading RAM for SSD)
+- High-throughput scenarios where RAM is the bottleneck
+
+### 2.4 Compression & Quantization (For In-Memory Algorithms)
+
+These techniques are explicit configurations for in-memory indices (HNSW/IVF).
+
+*Decision Matrix:*
+- If using `mode: on_disk` → You are using **BQ** (Disk-based).
+- If using standard HNSW/IVF → You can optionally add **PQ** (`encoder: pq`) or **BQ** (via specific config) for memory reduction.
+
+#### 2.4.1 Product Quantization (PQ)
+
+**Overview:** Compression technique that breaks vectors into sub-vectors and encodes them. Used with `method: hnsw` or `method: ivf`.
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | 80-90% recall (lossy) |
+| **Training** | Requires a training step (often handled automatically or via API) |
+| **Memory Reduction** | 10-50x compression |
+
+**Memory Estimation:**
+```
+Compressed Memory = num_vectors × m × code_size / 8
+Example: 10M vectors, m=64, code_size=8
+Memory ≈ 10M × 64 × 1 byte = 640MB
+```
+
+#### 2.4.2 Binary Quantization (BQ) - In-Memory
+
+**Overview:** Using BQ with in-memory HNSW (without offloading full vectors to disk) for extreme speed and compression.
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | Lower than PQ generally, but faster |
+| **Memory Reduction** | 32x compression (float32 -> 1 bit) |
+| **Query Latency** | Ultra-fast (Hamming distance) |
+
+### 2.5 Latency Scaling by Configuration
+
+Scales with doc size O(log n)
+
+### 2.6 Language Support
+
+| Feature | Support Level | Notes |
+|---------|---------------|-------|
+| English | 5/5 | Excellent with most models |
+| Multilingual | 5/5 | With multilingual models (mE5, multilingual-e5, etc.) |
+| Cross-lingual | 5/5 | Query in one language, retrieve in another |
+| Low-resource Languages | 3/5 | Depends on model training data |
+
+### 2.7 Model Deployment Options
+
+#### 2.7.1 Supported Modes
+Dense vector search in OpenSearch supports three main deployment modes for embedding models:
+
+1.  **API Services**: (e.g., Amazon Bedrock, OpenAI) - Best for ease of use and access to SOTA models.
+2.  **OpenSearch Node (CPU)**: Best for self-contained deployments and moderate latency/throughput.
+3.  **SageMaker GPU Endpoint**: Best for high-performance, low-latency production workloads with custom or open-source models.
+
+
+
+### 2.8 Total Latency Composition
+
+For Dense Vector Search, the total end-to-end latency is the sum of two distinct phases:
+
+```
+Total Latency = Embedding Inference Time + Vector Search Time (KNN)
+```
+
+1.  **Embedding Inference (CPU/GPU/API):** Time to convert the query text into a vector.
+    *   *External API:* 50-200ms (network + inference)
+    *   *Local CPU:* 10-100ms (depends on model size)
+    *   *SageMaker/GPU:* 5-20ms
+2.  **Vector Search (KNN):** Time to find nearest neighbors in the index.
+    *   *HNSW:* 1-20ms (typically very fast)
+    *   *IVF:* 10-100ms
+    *   *Disk-based:* 20-100ms
+
+**Critical Note:** Often, **inference time dominates** the total latency. Optimizing the index (HNSW vs IVF) yields diminishing returns if your embedding model takes 100ms to run.
+
+### 2.9 When to Use Dense Vector
+
+**Recommended:**
+- Semantic similarity search
+- Cross-lingual search requirements
+- Synonym and paraphrase handling needed
+- Natural language queries from users
+- Question-answering systems
+- RAG (Retrieval Augmented Generation) applications
+
+**Not Recommended:**
+- Exact keyword matching is critical
+- Highly specialized domain vocabulary not covered by model
+- Extremely cost-sensitive deployments
+- Real-time autocomplete/typeahead
+- Sub-millisecond latency requirements
+
+---
+
+## 3. Sparse Vector Search
+
+### 3.1 Overview
+
+Sparse vector search uses learned sparse representations where most dimensions are zero. Unlike dense vectors with 384-1536 dimensions all populated, sparse vectors may have 30,000+ dimensions but only 100-500 non-zero values.
+
+### 3.2 How Neural Sparse Works
+
+**Overview:** Uses neural networks to learn sparse representations with semantic meaning.
+
+**How it works:**
+1. Documents and queries are encoded into sparse vectors
+2. Each dimension corresponds to a vocabulary token
+3. Weights indicate semantic importance (not just term frequency)
+
+**Advantages over BM25:**
+- Learns semantic term expansion (e.g., "dog" activates "puppy", "canine")
+- Trained on relevance signals
+- Better zero-shot domain transfer
+
+### 3.3 Search Modes: Doc-only (Recommended) vs Bi-encoder
+
+OpenSearch Neural Sparse supports two modes. We **strongly recommend Doc-only mode** for most production use cases due to its superior performance-cost ratio.
+
+#### 3.3.1 Doc-only Mode (Recommended)
+In this mode, the heavy lifting is done during ingestion.
+- **Ingestion**: Documents are encoded using a specialized "doc-only" model (e.g., `opensearch-neural-sparse-encoding-doc-v3-gte`).
+- **Search**: The query is processed using a simple **tokenizer** (not a full model inference). 
+
+**Why it is recommended:**
+- **Zero Query Inference**: No heavy model inference is required at query time, only tokenization.
+- **Low Latency**: Query latency is significantly lower (often 10x+ faster) than bi-encoder mode.
+- **Lower Cost**: Reduces CPU/GPU requirements for search nodes.
+
+**Model Combination Example:**
+- Ingestion: `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-gte`
+- Search: `amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1`
+
+#### 3.3.2 Bi-encoder Mode
+In this mode, both documents and queries are processed by the same deep neural network.
+- **Ingestion & Search**: Use the same model (e.g., `opensearch-neural-sparse-encoding-v2-distill`).
+
+**Characteristics:**
+- **Higher Relevance**: Generally achieves slightly better BEIR scores.
+- **Higher Latency**: Requires running model inference for every query.
+
+### 3.4 Index Backends
+
+#### 3.4.1 rank_features Field (Inverted Index Based)
+
+**Overview:** Uses OpenSearch's native inverted index structure optimized for sparse features.
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | Exact (no approximation) |
+| **Query Latency** | Scales with vocabulary overlap |
+| **Memory** | Moderate |
+| **Index Size** | Similar to text fields |
+
+**Best For:**
+- Exact sparse vector search
+- Smaller datasets (< 50M documents)
+- When accuracy is paramount
+
+#### 3.4.2 SEISMIC (ANN-based Sparse Search)
+
+**Overview:** Approximate nearest neighbor algorithm specifically designed for sparse vectors.
+
+| Aspect | Details |
+|--------|---------|
+| **Accuracy** | 90%+ recall achievable |
+| **Query Latency** | Much faster than rank_features for large data |
+| **Memory** | Moderate |
+| **Build Time** | Slower than rank_features |
+
+**When to Use SEISMIC:**
+- Large-scale datasets (> 10M documents), and latency-sensitive applications
+- Can tolerate slight approximation
+
+### 3.5 Accuracy Characteristics
+
+| Aspect | Rating | Notes |
+|--------|--------|-------|
+| Semantic Understanding | 4/5 | Good, but generally slightly below dense |
+| Exact Match | 4/5 | Better than dense vectors |
+| Term Expansion | 5/5 | Learns relevant term expansion |
+| Interpretability | 5/5 | Can see which terms matched |
+
+### 3.6 Language Support
+
+| Feature | Support Level | Notes |
+|---------|---------------|-------|
+| English | 5/5 | Excellent |
+| Other Languages | 3/5 | Model-dependent |
+| Cross-lingual | 1/5 | Limited, not effective |
+
+### 3.7 Model Deployment Options
+
+Sparse vector search (Neural Sparse) supports the following deployment modes:
+
+1.  **OpenSearch Node (CPU)**: Generally only recommended for the **Tokenizer** in Doc-Only mode.
+2.  **SageMaker GPU Endpoint**: Strongly recommended for Ingestion (Encoding) and Search (Bi-encoder mode).
+
+For most use case, OpenSearch Node is only recommended for sparse tokenizer deployment. And sparse encoding model should be deployed on SageMaker GPU endpoint. The only exception is cost. i.e. user don't want to spend money on a SageMaker GPU instance.
+
+### 3.8 When to Use Sparse Vector
+
+**Recommended:**
+- Balance between lexical and semantic search
+- Users want semantic search, but don't want query-time model inference
+- Users want extreme fast semantic search. use doc-only + seismic (for dense, the model inference takes tens of milliseconds)
+- Interpretability is important (can see which terms matched)
+- Lower memory budget than dense vectors (rank features)
+
+**Not Recommended:**
+- Cross-lingual search
+- Maximum semantic understanding needed
+
+---
+
+## 4. Hybrid Search
+
+### 4.1 Overview
+
+Hybrid search combines multiple retrieval methods (BM25, dense vector, sparse vector) to leverage the strengths of each. OpenSearch supports hybrid search through the hybrid query type and score normalization.
+
+### 4.2 Score Normalization
+To combine scores from different methods (e.g., BM25 scores are unbounded, while vector cosine similarity is 0-1), OpenSearch provides several normalization techniques (Min-Max, L2, Harmonic Mean, etc.) to ensure scores are comparable before combination.
+
+### 4.3 Cost
+- **CPU Load**: The CPU load for a hybrid query is approximately the **sum of the loads** of its sub-queries.
+
+### 4.4 Combination Strategy for Relevance
+When maximum relevance is the primary goal, Hybrid Search is the recommended approach.
+
+- **Hybrid Scope Rule**:
+  - Use at most **two retrieval methods** per hybrid query.
+  - Do **not** combine dense + sparse + BM25 in a single hybrid plan.
+
+- **Recommended Combinations**:
+  - **Dense + Sparse**: Have best search relevance. Provides two layers of semantic understanding (dense for context, sparse for learned expansion).
+  - **Dense + BM25**: A robust baseline to combine semantic understanding with exact keyword precision.
+  
+- **Not Recommended**:
+  - **Sparse + BM25**: Generally redundant. Sparse vectors already capture keyword information (lexical match) along with expansion, making the addition of BM25 less impactful for the cost.
+
+### 4.5 When to Use Hybrid Search
+
+**Recommended:**
+- **Maximum Relevance**: When accuracy and recall are the top priorities.
+- Mixed query types (some exact, some semantic).
+- Unknown query distribution.
+- Can afford additional infrastructure cost (higher CPU load).
+
+**Not Recommended:**
+- Strict cost constraints
+- Simple use cases where one method suffices
+- Sub-10ms latency requirements
+- Development/prototype phase (start simple)
+
+---
+
+*Document Version: 1.0*
+*Last Updated: January 2025*
+*Applicable OpenSearch Versions: 2.9+*

--- a/skills/opensearch-skills/launchpad/sparse_vector_models.md
+++ b/skills/opensearch-skills/launchpad/sparse_vector_models.md
@@ -1,0 +1,87 @@
+# Sparse Vector Models Guide
+
+This document lists the available models for Sparse Vector (Neural Sparse) Search in OpenSearch, categorized by deployment mode.
+
+## 1. OpenSearch Node Deployment (CPU)
+
+Deploying sparse models directly on OpenSearch Nodes.
+
+**Note:** Running sparse encoding models on CPU OpenSearch Nodes is generally **not recommended** for high-throughput production due to latency. CPU OpenSearch Nodes are best suited for **tokenizers** in Doc-only mode search, or **low-traffic/dev** sparse encoding inference.
+
+### 1.1 Supported Pre-trained Models
+
+#### Tokenizers (recommended on CPU for Doc-only query time)
+
+| Model Name | Type | Description | Recommended Use |
+|------------|------|-------------|-----------------|
+| `amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1` | Tokenizer | Neural sparse tokenizer with IDF-based token weights (defaults to 1 if IDF not provided). | **Search Phase** (Doc-only mode) |
+| `amazon/neural-sparse/opensearch-neural-sparse-tokenizer-multilingual-v1` | Tokenizer | Multilingual neural sparse tokenizer with IDF-based token weights (defaults to 1 if IDF not provided). | **Search Phase** (Multilingual Doc-only mode) |
+
+#### Sparse encoding models (CPU = dev/low traffic)
+
+| Model Name | Type | Description | Recommended Use |
+|------------|------|-------------|-----------------|
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-v1` | Sparse Encoder | Neural sparse encoding model (bi-encoder style). | Dev / Low traffic |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-v2-distill` | Sparse Encoder | Distilled v2 sparse encoding model. | Dev / Low traffic (or GPU for prod bi-encoder) |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v1` | Doc Encoder | Document-side sparse encoder for doc-only setups. | Dev / Low traffic |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v2-distill` | Doc Encoder | Distilled doc encoder v2. | Dev / Low traffic |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v2-mini` | Doc Encoder | Smaller “mini” doc encoder v2. | Dev / Low traffic / cost-sensitive experiments |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-distill` | Doc Encoder | v3 distilled doc encoder. | Dev / Low traffic (or GPU for prod doc-only) |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-gte` | Doc Encoder | v3 GTE-based doc encoder. | Dev / Low traffic (or GPU for prod doc-only) |
+| `amazon/neural-sparse/opensearch-neural-sparse-encoding-multilingual-v1` | Sparse Encoder | Multilingual neural sparse encoding model. | Dev / Low traffic (or GPU for prod multilingual) |
+
+### 1.2 Custom Models
+
+**Not Supported.** Custom or fine-tuned sparse encoding models cannot be deployed on OpenSearch Nodes. You must use a SageMaker GPU Endpoint.
+
+---
+
+## 2. SageMaker GPU Endpoint (Recommended for Production)
+
+Deploying sparse models on AWS SageMaker with GPU acceleration is the recommended strategy for:
+- **Ingestion-time doc encoding** (Doc-only mode), and/or
+- **Query-time encoding** (Bi-encoder mode).
+
+### 2.1 Recommended Models
+
+The models listed in 1.1.
+For tokenizers, it's recommended to get deployed on OpenSearch nodes.
+For deep learning models, the recommended instance type is ml.g4dn.xlarge or ml.g5.xlarge.
+
+### 2.2 Custom Models
+
+If you have trained a **custom** or **fine-tuned** sparse encoding model, you **must** deploy it using a SageMaker GPU Endpoint. This deployment mode supports custom model logic and weights that are not available in the pre-trained registry.
+
+---
+
+## 3. Configuration Combinations
+
+### 3.1 Doc-Only Mode (Recommended for Speed/Cost)
+
+In this mode, you decouple ingestion and search compute.
+
+- **Ingestion (Heavy):** Run on **SageMaker GPU**
+  - Model (Recommended): `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-gte`
+  - Alternatives: `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-distill`
+  - Newer models have better accuracy.
+- **Search (Light):** Run on **OpenSearch Node (CPU)**
+  - Model: `amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1`
+  - Why: Search only requires tokenization, which is extremely fast on CPU.
+
+### 3.2 Bi-Encoder Mode (Maximum Accuracy)
+
+In this mode, query processing is heavy and requires inference.
+
+- **Ingestion:** Run on **SageMaker GPU**
+  - Model: `amazon/neural-sparse/opensearch-neural-sparse-encoding-v2-distill`
+- **Search:** Run on **SageMaker GPU**
+  - Model: `amazon/neural-sparse/opensearch-neural-sparse-encoding-v2-distill`
+  - Why: Query time inference is too slow on CPU for most interactive applications.
+
+### 3.3 Multilingual Doc-Only Mode
+
+- **Ingestion (Heavy):** Run on **SageMaker GPU**
+  - Model: `amazon/neural-sparse/opensearch-neural-sparse-encoding-multilingual-v1`
+- **Search (Light):** Run on **OpenSearch Node (CPU)**
+  - Model: `amazon/neural-sparse/opensearch-neural-sparse-tokenizer-multilingual-v1`
+  - Why: Search only requires tokenization, which is extremely fast on CPU.

--- a/skills/opensearch-skills/observability/log-analytics.md
+++ b/skills/opensearch-skills/observability/log-analytics.md
@@ -1,0 +1,359 @@
+# OpenSearch Log Analytics Guide
+
+## Overview
+
+This guide instructs you on how to perform log analytics against an existing OpenSearch cluster. The approach is discovery-first: understand what indices exist, learn the schema, sample the data, then build queries. Do not assume any particular index pattern or field names — discover them.
+
+## Connecting to the Cluster
+
+Before proceeding, determine the cluster type. If it's not clear from context, ask the user:
+
+- "Is your OpenSearch cluster running locally, on Amazon OpenSearch Service (managed), or Amazon OpenSearch Serverless?"
+- "What is the endpoint URL?"
+- "How do you authenticate — username/password, AWS IAM role, or AWS profile?"
+
+This is important because the connection method, authentication, and available features differ between local, AOS, and AOSS clusters.
+
+### Preferred: opensearch-mcp-server (handles AOS/AOSS auth automatically)
+
+If the `opensearch-mcp-server` MCP server is available, prefer its tools over curl — they handle SigV4 authentication for Amazon OpenSearch Service (AOS) and Serverless (AOSS) transparently. Key tools:
+
+- `ListIndexTool` — list indices with doc counts and sizes
+- `IndexMappingTool` — get index mappings and settings
+- `SearchIndexTool` — search with Query DSL
+- `GenericOpenSearchApiTool` — call any OpenSearch API (including `/_plugins/_ppl` for PPL queries)
+
+If the MCP server is not available, follow the auto-install instructions in the main SKILL.md — it covers endpoint collection, auth configuration for local/AOS/AOSS, and IDE restart.
+
+### Fallback: curl (local clusters or basic auth)
+
+For local clusters with basic auth, use curl with `-sk -u` flags. All curl examples in this guide use environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `OPENSEARCH_ENDPOINT` | `https://localhost:9200` | OpenSearch base URL |
+| `OPENSEARCH_USER` | `admin` | OpenSearch username |
+| `OPENSEARCH_PASSWORD` | `My_password_123!@#` | OpenSearch password |
+
+> For AOS/AOSS endpoints, curl requires `--aws-sigv4` which needs AWS credentials configured. The MCP server is simpler — use it when available.
+
+## Phase 1 — Discover Available Indices
+
+Before writing any query, find out what log indices exist on the cluster.
+
+### List All Indices
+
+Via MCP server:
+```
+Use ListIndexTool to list all indices
+```
+
+Via curl:
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  "$OPENSEARCH_ENDPOINT/_cat/indices?format=json&h=index,health,docs.count,store.size&s=docs.count:desc"
+```
+
+Look for indices that suggest logs: names containing `log`, `logs`, `events`, `audit`, `access`, `syslog`, `otel`, `cwl` (CloudWatch Logs), or date-based patterns like `logs-2024.01.15`.
+
+### List Index Patterns with Aliases
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  "$OPENSEARCH_ENDPOINT/_cat/aliases?format=json&h=alias,index&s=alias"
+```
+
+### Check Data Streams
+
+Modern log setups may use data streams instead of plain indices:
+
+Via MCP server:
+```
+Use GenericOpenSearchApiTool with path="/_data_stream" and method="GET"
+```
+
+Via curl:
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  "$OPENSEARCH_ENDPOINT/_data_stream?pretty"
+```
+
+After discovering indices, ask the user which index or index pattern they want to analyze if it's not obvious. If there are multiple log indices, ask about the relationship between them (e.g., are they daily rollover indices for the same data? different applications? different log levels?).
+
+## Phase 2 — Understand the Schema
+
+Once you know the target index pattern, inspect its mapping to learn the available fields.
+
+### Get Index Mapping
+
+Via MCP server:
+```
+Use IndexMappingTool with index="<INDEX_PATTERN>"
+```
+
+Via curl:
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  "$OPENSEARCH_ENDPOINT/<INDEX_PATTERN>/_mapping?pretty"
+```
+
+Via PPL:
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "describe <INDEX_NAME>"}'
+```
+
+> Use a concrete index name (e.g., `logs-2024.01.15`) for `describe`, not a wildcard pattern.
+
+### Identify Key Fields
+
+From the mapping, identify:
+
+1. **Timestamp field** — usually `@timestamp`, `timestamp`, `time`, or `event.created`
+2. **Log level field** — `level`, `log.level`, `severity`, `severityText`, `loglevel`
+3. **Message field** — `message`, `msg`, `body`, `log`, `event.original`
+4. **Service/source field** — `service`, `service.name`, `host.name`, `source`, `kubernetes.pod.name`, `resource.attributes.service.name`
+5. **Error fields** — `error.message`, `error.stack_trace`, `exception.type`
+6. **Correlation fields** — `traceId`, `trace_id`, `spanId`, `request_id`, `correlation_id`
+
+If the mapping is large or unclear, ask the user: "I see fields like X, Y, Z — which field contains the log message? Which one is the log level?"
+
+### Sample Documents
+
+Always look at a few real documents to understand the actual data shape — mappings alone can be misleading (e.g., dynamic fields, nested objects, multi-value fields):
+
+Via MCP server:
+```
+Use SearchIndexTool with index="<INDEX_PATTERN>" and query={"size": 5, "sort": [{"<TIMESTAMP_FIELD>": "desc"}]}
+```
+
+Or use GenericOpenSearchApiTool for PPL:
+```
+Use GenericOpenSearchApiTool with path="/_plugins/_ppl", method="POST", body={"query": "source=<INDEX_PATTERN> | head 5"}
+```
+
+Via curl (PPL):
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=<INDEX_PATTERN> | head 5"}'
+```
+
+Review the sample documents to confirm:
+- Which fields are actually populated (vs defined but empty)
+- The format of timestamps, log levels, and messages
+- Whether the message field is structured JSON or free-text
+- Whether there are nested objects that need backtick-quoting in PPL
+
+## Phase 3 — Ask Clarifying Questions (If Needed)
+
+If the schema is not self-explanatory, ask the user:
+
+- "What does this index contain? Application logs, access logs, audit logs?"
+- "I see multiple log indices (X, Y, Z) — are these from different services or different time periods?"
+- "The message field appears to contain JSON — should I parse specific fields from it?"
+- "I see a `trace_id` field — do you want to correlate logs with traces?"
+- "What time range are you interested in?"
+
+Do not skip this step if the data is ambiguous. Getting the schema right upfront saves failed queries later.
+
+## Phase 4 — Perform Analytics
+
+With the schema understood, build PPL queries using the actual field names discovered above. All examples below use placeholder field names — substitute with the real ones.
+
+### Running PPL Queries
+
+Via MCP server (preferred for AOS/AOSS):
+```
+Use GenericOpenSearchApiTool with path="/_plugins/_ppl", method="POST", body={"query": "<PPL_QUERY>"}
+```
+
+Via curl (local clusters):
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "<PPL_QUERY>"}'
+```
+
+### Log Volume Over Time
+
+```
+source=<INDEX_PATTERN> | stats count() as volume by span(<TIMESTAMP_FIELD>, 1h)
+```
+
+### Error Count by Service
+
+```
+source=<INDEX_PATTERN> | where <LEVEL_FIELD> = 'ERROR' | stats count() as errors by <SERVICE_FIELD> | sort - errors
+```
+
+### Error Rate Trend
+
+```
+source=<INDEX_PATTERN> | stats count() as total, sum(case(<LEVEL_FIELD> = 'ERROR', 1 else 0)) as errors by span(<TIMESTAMP_FIELD>, 1h)
+```
+
+### Recent Errors
+
+```
+source=<INDEX_PATTERN> | where <LEVEL_FIELD> = 'ERROR' | fields <TIMESTAMP_FIELD>, <SERVICE_FIELD>, <MESSAGE_FIELD> | sort - <TIMESTAMP_FIELD> | head 20
+```
+
+### Full-Text Search
+
+```
+source=<INDEX_PATTERN> | where match(<MESSAGE_FIELD>, 'connection timeout') | sort - <TIMESTAMP_FIELD> | head 20
+```
+
+### Top Error Messages
+
+```
+source=<INDEX_PATTERN> | where <LEVEL_FIELD> = 'ERROR' | top 10 <MESSAGE_FIELD>
+```
+
+### Rare Error Messages
+
+```
+source=<INDEX_PATTERN> | where <LEVEL_FIELD> = 'ERROR' | rare <MESSAGE_FIELD>
+```
+
+### Log Pattern Discovery
+
+Automatically cluster similar log messages:
+
+```
+source=<INDEX_PATTERN> | where <LEVEL_FIELD> = 'ERROR' | patterns <MESSAGE_FIELD> | fields <MESSAGE_FIELD>, patterns_field | head 30
+```
+
+### Error Breakdown by Level and Service
+
+```
+source=<INDEX_PATTERN> | stats count() by <LEVEL_FIELD>, <SERVICE_FIELD>
+```
+
+### Time-Filtered Queries
+
+```
+source=<INDEX_PATTERN> | where <TIMESTAMP_FIELD> > DATE_SUB(NOW(), INTERVAL 1 HOUR) | stats count() by <LEVEL_FIELD>
+```
+
+### Unique Services/Hosts
+
+```
+source=<INDEX_PATTERN> | stats distinct_count(<SERVICE_FIELD>) as services, distinct_count(<HOST_FIELD>) as hosts
+```
+
+### Latency from Structured Logs
+
+If logs contain a duration/latency field:
+
+```
+source=<INDEX_PATTERN> | stats avg(<DURATION_FIELD>) as avg_ms, percentile(<DURATION_FIELD>, 95) as p95_ms, percentile(<DURATION_FIELD>, 99) as p99_ms by <SERVICE_FIELD>
+```
+
+### Extract Fields from Unstructured Messages
+
+If the message field contains unstructured text, use grok or parse to extract fields:
+
+```
+source=<INDEX_PATTERN> | grok <MESSAGE_FIELD> '%{IP:client_ip} %{WORD:method} %{URIPATHPARAM:path} %{NUMBER:status}' | stats count() by status
+```
+
+> **Caveat:** `grok` processes all matching rows in memory. Add `| head N` before `grok` on large indices to avoid resource errors.
+
+## Phase 5 — Advanced Analysis
+
+### Cross-Index Correlation
+
+If logs span multiple indices (e.g., application logs + access logs), correlate using shared fields like `request_id`, `trace_id`, or timestamp proximity:
+
+Step 1 — Find an event of interest in one index:
+
+```
+source=<APP_LOGS> | where <LEVEL_FIELD> = 'ERROR' | fields <CORRELATION_FIELD>, <TIMESTAMP_FIELD>, <MESSAGE_FIELD> | head 10
+```
+
+Step 2 — Look up the same correlation ID in the other index:
+
+```
+source=<ACCESS_LOGS> | where <CORRELATION_FIELD> = '<VALUE>' | fields <TIMESTAMP_FIELD>, <MESSAGE_FIELD>
+```
+
+### Anomaly Detection
+
+Use PPL's built-in anomaly detection on numeric fields (e.g., log volume, error count):
+
+```
+source=<INDEX_PATTERN> | stats count() as volume by span(<TIMESTAMP_FIELD>, 5m) | ad time_field=<TIMESTAMP_FIELD>
+```
+
+> The `ad` command auto-detects input fields from the pipeline. It works best on time-series data with regular intervals.
+
+### Query DSL for Complex Aggregations
+
+For queries that PPL doesn't support well (nested aggregations, scripted fields), fall back to Query DSL:
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/<INDEX_PATTERN>/_search" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "size": 0,
+    "query": {
+      "bool": {
+        "must": [{"match": {"<LEVEL_FIELD>": "ERROR"}}],
+        "filter": [{"range": {"<TIMESTAMP_FIELD>": {"gte": "now-1h"}}}]
+      }
+    },
+    "aggs": {
+      "by_service": {
+        "terms": {"field": "<SERVICE_FIELD>", "size": 20},
+        "aggs": {
+          "over_time": {
+            "date_histogram": {"field": "<TIMESTAMP_FIELD>", "fixed_interval": "5m"}
+          }
+        }
+      }
+    }
+  }'
+```
+
+## Common Log Schemas Reference
+
+When you encounter these common schemas, use the field mappings below:
+
+### Elastic Common Schema (ECS)
+
+Timestamp: `@timestamp`, Level: `log.level`, Message: `message`, Service: `service.name`, Host: `host.name`, Error: `error.message`
+
+### OTel Logs (logs-otel-v1-*)
+
+Timestamp: `@timestamp`, Level: `severityText`, Message: `body`, Service: `` `resource.attributes.service.name` `` (backtick-quoted), Trace: `traceId`, Span: `spanId`
+
+### Simple JSON Logs
+
+Timestamp: `timestamp` or `@timestamp`, Level: `level`, Message: `message` or `msg`, Service: `service`, Host: `host`
+
+### Syslog
+
+Timestamp: `@timestamp`, Level: `severity`, Message: `message`, Host: `host`, Program: `program`, Facility: `facility`
+
+### Apache/Nginx Access Logs
+
+Client: `clientip`, Request: `request`, Status: `response`, Bytes: `bytes`, Method: `verb`, Agent: `agent`
+
+## Key PPL Tips for Log Analytics
+
+- Always backtick-quote dotted field names: `` `log.level` ``, `` `host.name` ``
+- Use `head N` before memory-intensive commands (`grok`, `streamstats`, `eventstats`)
+- Use `span(<timestamp>, <interval>)` for time bucketing — common intervals: `5m`, `15m`, `1h`, `1d`
+- Use `match()` for full-text search, `like` for wildcard patterns, `match_phrase()` for exact phrases
+- Use `patterns` for automatic log message clustering
+- Use `dedup` to find unique error messages: `dedup <MESSAGE_FIELD> | fields <MESSAGE_FIELD>`
+- See [ppl-reference.md](ppl-reference.md) for the full PPL command and function reference
+- If a PPL query fails with a syntax error, search the docs: `uv run python scripts/opensearch_ops.py search-docs --query "PPL <command> syntax"`

--- a/skills/opensearch-skills/observability/ppl-reference.md
+++ b/skills/opensearch-skills/observability/ppl-reference.md
@@ -1,0 +1,232 @@
+# PPL Language Reference for Observability
+
+## Overview
+
+Comprehensive reference for PPL (Piped Processing Language) used by OpenSearch. Queries follow pipe-delimited syntax: `source=<index> | command1 | command2 ...`
+
+Grammar sourced from [opensearch-project/sql](https://github.com/opensearch-project/sql) `docs/user/ppl/`.
+
+## Field Name Escaping
+
+Dotted field names must be backtick-quoted:
+
+```
+`attributes.gen_ai.operation.name`
+`status.code`
+`@timestamp`
+`resource.attributes.service.name`
+```
+
+## API Endpoints
+
+### Query
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() by serviceName"}'
+```
+
+### Explain (query plan debugging)
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl/_explain" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
+```
+
+## Core Commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `source` | `source=<index>` | Start query from index pattern |
+| `where` | `where <condition>` | Filter rows |
+| `fields` | `fields [+\|-] <list>` | Select/exclude fields |
+| `stats` | `stats <agg>... [by <field>]` | Aggregate data |
+| `sort` | `sort [+\|-] <field>` | Order results (+ asc, - desc) |
+| `head` | `head [N]` | Limit results (default 10) |
+| `eval` | `eval <new> = <expr>` | Compute new fields |
+| `dedup` | `dedup [N] <field>` | Remove duplicates |
+| `rename` | `rename <old> AS <new>` | Rename fields |
+| `top` | `top [N] <field>` | Most frequent values |
+| `rare` | `rare <field>` | Least frequent values |
+
+## Time-Series Commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `timechart` | `timechart span=<interval> <agg> [by <field>]` | Time-bucketed aggregation |
+| `span()` | `span(<field>, <interval>)` | Bucket numeric/date values |
+| `trendline` | `trendline sort <field> sma(<N>, <field>)` | Moving average |
+| `streamstats` | `streamstats <agg> [by <field>]` | Running statistics (⚠️ memory-intensive) |
+| `eventstats` | `eventstats <agg> [by <field>]` | Add agg as field without collapsing (⚠️ memory-intensive) |
+
+### Span Time Units
+
+`ms`, `s`, `m`, `h`, `d`, `w`, `M`, `q`, `y`
+
+### Timechart Rate Functions
+
+`per_second()`, `per_minute()`, `per_hour()`, `per_day()`
+
+## Parse/Extract Commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `parse` | `parse <field> '<regex>'` | Regex extraction (⚠️ may drop fields on some versions) |
+| `grok` | `grok <field> '<pattern>'` | Grok pattern extraction (⚠️ memory-intensive) |
+| `rex` | `rex field=<field> '<regex>'` | Named capture groups |
+| `patterns` | `patterns <field>` | Auto-discover log patterns |
+
+## Join/Lookup Commands
+
+| Command | Syntax | Description |
+|---|---|---|
+| `join` | `join left=a right=b ON a.f = b.f <index>` | Cross-index join |
+| `lookup` | `lookup <index> <field> [OUTPUT <fields>]` | Enrich from another index |
+| `subquery` | `where <f> IN [source=<idx> \| ... \| fields <f>]` | Nested query filter |
+| `append` | `append [source=<idx> \| ...]` | Append results from another query |
+
+> **Caveat:** Cross-index `join` may return 0 rows on OpenSearch 3.x. Use separate queries + correlate by traceId as fallback.
+
+## Transform Commands
+
+| Command | Description |
+|---|---|
+| `fillnull` | Replace nulls (⚠️ backtick fields not supported in field list) |
+| `flatten` | Flatten nested fields to top-level |
+| `expand` | Expand arrays into separate rows |
+| `transpose` | Pivot rows into columns |
+
+## Aggregation Functions
+
+| Function | Description |
+|---|---|
+| `count()` | Count of events |
+| `sum(field)` | Sum |
+| `avg(field)` | Mean |
+| `max(field)` / `min(field)` | Max / Min |
+| `distinct_count(field)` | Count distinct values |
+| `percentile(field, pct)` | Value at percentile |
+| `var_samp(field)` / `stddev_samp(field)` | Sample variance / std dev |
+| `earliest(field)` / `latest(field)` | First / last chronological value |
+| `values(field)` | Distinct values as list |
+
+## Condition Functions
+
+| Function | Description |
+|---|---|
+| `isnull(f)` / `isnotnull(f)` | Null checks |
+| `if(cond, true_val, false_val)` | Conditional |
+| `case(c1, v1, c2, v2, ..., else)` | Multi-branch conditional |
+| `coalesce(v1, v2, ...)` | First non-null value |
+| `like` / `in` / `between` | Pattern / set / range checks |
+
+## Conversion Functions
+
+`cast(f AS type)`, `tostring()`, `toint()`, `tolong()`, `tofloat()`, `todouble()`
+
+Types: STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP
+
+## Datetime Functions
+
+| Function | Description |
+|---|---|
+| `now()` | Current timestamp |
+| `date_format(date, fmt)` | Format date (`%Y-%m-%d %H:%i:%s`) |
+| `date_add(date, INTERVAL n unit)` | Add interval |
+| `date_sub(date, INTERVAL n unit)` | Subtract interval |
+| `datediff(d1, d2)` | Difference in days |
+| `day()`, `month()`, `year()`, `hour()`, `minute()`, `second()` | Extract components |
+
+## String Functions
+
+| Function | Description |
+|---|---|
+| `concat(s1, s2, ...)` | Concatenate |
+| `length(s)` / `lower(s)` / `upper(s)` / `trim(s)` | Basic string ops |
+| `substring(s, start, len)` | Extract substring |
+| `replace(s, from, to)` | Replace occurrences |
+| `regexp_extract(s, pattern, group)` | Regex capture group |
+| `regexp_replace(s, pattern, repl)` | Regex replace |
+
+## Relevance Functions
+
+| Function | Description |
+|---|---|
+| `match(field, query)` | Full-text match |
+| `match_phrase(field, phrase)` | Exact phrase match |
+| `multi_match([f1, f2], query)` | Match across fields |
+| `query_string([f1, f2], query)` | Lucene query syntax |
+| `wildcard_query(field, pattern)` | Wildcard match (`*`, `?`) |
+
+## Math Functions
+
+`abs()`, `ceil()`, `floor()`, `round(val, decimals)`, `sqrt()`, `pow()`, `mod()`, `log()`, `log10()`, `exp()`
+
+## ML Commands
+
+| Command | Description |
+|---|---|
+| `ad` | Anomaly detection (auto-detects input fields from pipeline) |
+| `kmeans` | K-means clustering (operates on all numeric fields) |
+
+> `ml action=rcf` is not valid in OpenSearch 3.x. Use `ad` command directly.
+
+## System Commands
+
+| Command | Description |
+|---|---|
+| `describe <index>` | Inspect index mapping and field types |
+| `show datasources` | List configured data sources |
+
+## Observability Examples
+
+### Error rate by service over time
+
+```
+source=otel-v1-apm-span-* | stats count() as total, sum(case(`status.code` = 2, 1 else 0)) as errors by span(startTime, 1h), serviceName
+```
+
+### Duration in milliseconds with percentiles
+
+```
+source=otel-v1-apm-span-* | eval duration_ms = durationInNanos / 1000000 | stats avg(duration_ms) as avg_ms, percentile(duration_ms, 95) as p95_ms by serviceName
+```
+
+### Log pattern discovery
+
+```
+source=logs-otel-v1-* | where severityText = 'ERROR' | patterns body | fields body, patterns_field | head 20
+```
+
+### Recent spans with time filter
+
+```
+source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR) | stats count() by serviceName
+```
+
+## Looking Up PPL Documentation
+
+This reference covers the most common commands and functions. If a PPL command isn't listed here, a query fails with a syntax error, or you need to check version-specific behavior:
+
+1. Search OpenSearch docs:
+   ```bash
+   uv run python scripts/opensearch_ops.py search-docs --query "PPL <command_name> syntax"
+   ```
+
+2. Search specifically for PPL grammar:
+   ```bash
+   uv run python scripts/opensearch_ops.py search-docs --query "site:opensearch.org PPL <command_name>"
+   ```
+
+3. If a web search tool is available, search directly:
+   ```
+   site:opensearch.org PPL <command_name> command
+   ```
+
+4. The canonical PPL grammar source is the [opensearch-project/sql](https://github.com/opensearch-project/sql) repository under `docs/user/ppl/`. Fetch the relevant page if you need exact syntax for a specific command.
+
+Always verify PPL syntax against the docs when a query returns an error — syntax can vary between OpenSearch versions.

--- a/skills/opensearch-skills/observability/traces.md
+++ b/skills/opensearch-skills/observability/traces.md
@@ -1,0 +1,207 @@
+# Trace Querying with PPL
+
+## Overview
+
+PPL query templates for investigating trace data in OpenSearch. Traces are stored in `otel-v1-apm-span-*`, service maps in `otel-v2-apm-service-map-*`. All queries use the PPL API at `/_plugins/_ppl` with HTTPS and basic auth.
+
+## Base Command
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "<PPL_QUERY>"}'
+```
+
+## Trace Index Key Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `traceId` | keyword | Unique 128-bit trace identifier |
+| `spanId` | keyword | Unique 64-bit span identifier |
+| `parentSpanId` | keyword | Parent span ID (empty for root spans) |
+| `serviceName` | keyword | Service that produced the span |
+| `name` | text | Span operation name |
+| `kind` | keyword | Span kind (SERVER, CLIENT, INTERNAL, PRODUCER, CONSUMER) |
+| `startTime` | date | Span start timestamp |
+| `endTime` | date | Span end timestamp |
+| `durationInNanos` | long | Span duration in nanoseconds |
+| `status.code` | integer | 0=Unset, 1=Ok, 2=Error |
+| `attributes.gen_ai.operation.name` | keyword | GenAI operation type |
+| `attributes.gen_ai.agent.name` | keyword | Agent name |
+| `attributes.gen_ai.agent.id` | keyword | Agent identifier |
+| `attributes.gen_ai.request.model` | keyword | Requested model |
+| `attributes.gen_ai.usage.input_tokens` | long | Input token count |
+| `attributes.gen_ai.usage.output_tokens` | long | Output token count |
+| `attributes.gen_ai.tool.name` | keyword | Tool name |
+| `attributes.gen_ai.tool.call.id` | keyword | Tool call identifier |
+| `attributes.gen_ai.tool.call.arguments` | text | Tool call arguments (JSON) |
+| `attributes.gen_ai.tool.call.result` | text | Tool call result (JSON) |
+| `attributes.gen_ai.conversation.id` | keyword | Conversation identifier |
+| `attributes.error_type` | keyword | Error type category |
+| `events.attributes.exception.type` | keyword | Exception class/type |
+| `events.attributes.exception.message` | text | Exception message |
+| `events.attributes.exception.stacktrace` | text | Exception stacktrace |
+
+## Agent Invocation Spans
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.operation.name` = '\''invoke_agent'\'' | fields traceId, spanId, `attributes.gen_ai.agent.name`, `attributes.gen_ai.request.model`, durationInNanos, startTime | sort - startTime | head 20"}'
+```
+
+## Tool Execution Spans
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.operation.name` = '\''execute_tool'\'' | fields traceId, spanId, `attributes.gen_ai.tool.name`, durationInNanos, startTime | sort - startTime | head 20"}'
+```
+
+## Slow Spans
+
+Default threshold: 5 seconds (5,000,000,000 nanoseconds). Adjust as needed:
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where durationInNanos > 5000000000 | fields traceId, spanId, serviceName, name, durationInNanos, startTime | sort - durationInNanos | head 20"}'
+```
+
+## Error Spans
+
+`status.code` = 2 means ERROR in OTel:
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId, spanId, serviceName, name, `status.code`, startTime | sort - startTime | head 20"}'
+```
+
+## Token Usage by Model
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.usage.input_tokens` > 0 | stats sum(`attributes.gen_ai.usage.input_tokens`) as total_input, sum(`attributes.gen_ai.usage.output_tokens`) as total_output by `attributes.gen_ai.request.model`"}'
+```
+
+## Token Usage by Agent
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.usage.input_tokens` > 0 | stats sum(`attributes.gen_ai.usage.input_tokens`) as total_input, sum(`attributes.gen_ai.usage.output_tokens`) as total_output by `attributes.gen_ai.agent.name`"}'
+```
+
+## Service Operations Listing
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | stats count() by serviceName, `attributes.gen_ai.operation.name`"}'
+```
+
+## Service Map Queries
+
+> **Important:** `sourceNode`, `targetNode`, `sourceOperation`, `targetOperation` in `otel-v2-apm-service-map-*` are nested struct objects, not flat strings. Each node has `keyAttributes.name` for the service name.
+
+### Service Topology
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v2-apm-service-map-* | dedup nodeConnectionHash | fields sourceNode, targetNode, sourceOperation, targetOperation"}'
+```
+
+## Remote Service Identification with coalesce()
+
+Different OTel instrumentation libraries use different attributes. Use `coalesce()` to check multiple fields:
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where serviceName = '\''frontend'\'' | where kind = '\''SPAN_KIND_CLIENT'\'' | eval _remoteService = coalesce(`attributes.net.peer.name`, `attributes.server.address`, `attributes.rpc.service`, `attributes.db.system`, `attributes.gen_ai.system`, '\''unknown'\'') | stats count() as calls by _remoteService | sort - calls"}'
+```
+
+## Trace Tree Reconstruction
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where traceId = '\''<TRACE_ID>'\'' | fields traceId, spanId, parentSpanId, serviceName, name, startTime, endTime, durationInNanos, `status.code` | sort startTime"}'
+```
+
+## Root Span Identification
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where traceId = '\''<TRACE_ID>'\'' AND parentSpanId = '\'''\'' | fields traceId, spanId, serviceName, name, durationInNanos, startTime, endTime"}'
+```
+
+## GenAI Operation Types
+
+| Operation | Description |
+|---|---|
+| `invoke_agent` | Top-level agent invocation |
+| `execute_tool` | Tool execution within agent reasoning |
+| `chat` | LLM chat completion call |
+| `embeddings` | Text embedding generation |
+| `retrieval` | Retrieval operation (e.g., RAG) |
+| `create_agent` | Agent creation/initialization |
+| `text_completion` | Text completion (non-chat) |
+| `generate_content` | Generic content generation |
+
+## Exception and Error Querying
+
+### Spans with Exceptions
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | fields traceId, spanId, serviceName, name, `events.attributes.exception.type`, `events.attributes.exception.message`, `attributes.error_type`, startTime | sort - startTime | head 20"}'
+```
+
+## Conversation Tracking
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.conversation.id` != '\'''\'' | stats count() as turns, sum(`attributes.gen_ai.usage.input_tokens`) as total_input_tokens, sum(`attributes.gen_ai.usage.output_tokens`) as total_output_tokens by `attributes.gen_ai.conversation.id`"}'
+```
+
+## Tool Call Inspection
+
+```bash
+curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
+  -X POST "$OPENSEARCH_ENDPOINT/_plugins/_ppl" \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.operation.name` = '\''execute_tool'\'' | fields traceId, spanId, `attributes.gen_ai.tool.name`, `attributes.gen_ai.tool.call.id`, `attributes.gen_ai.tool.call.arguments`, `attributes.gen_ai.tool.call.result`, durationInNanos, startTime | sort - startTime | head 20"}'
+```
+
+## AWS Managed OpenSearch
+
+Replace local endpoint with SigV4:
+
+```bash
+curl -s --aws-sigv4 "aws:amz:REGION:es" \
+  --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
+  -X POST https://DOMAIN-ID.REGION.es.amazonaws.com/_plugins/_ppl \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "source=otel-v1-apm-span-* | where `attributes.gen_ai.operation.name` = '\''invoke_agent'\'' | head 20"}'
+```

--- a/skills/opensearch-skills/scripts/lib/__init__.py
+++ b/skills/opensearch-skills/scripts/lib/__init__.py
@@ -1,0 +1,2 @@
+# Standalone OpenSearch operations library for Agent Skills.
+# No dependency on opensearch_orchestrator — uses opensearch-py directly.

--- a/skills/opensearch-skills/scripts/lib/client.py
+++ b/skills/opensearch-skills/scripts/lib/client.py
@@ -1,0 +1,425 @@
+"""OpenSearch client creation, connectivity checks, and Docker bootstrap."""
+
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+from opensearchpy import OpenSearch
+
+OPENSEARCH_HOST = os.getenv("OPENSEARCH_HOST", "localhost")
+OPENSEARCH_PORT = int(os.getenv("OPENSEARCH_PORT", "9200"))
+OPENSEARCH_AUTH_MODE_ENV = "OPENSEARCH_AUTH_MODE"
+OPENSEARCH_AUTH_MODE_DEFAULT = "default"
+OPENSEARCH_AUTH_MODE_NONE = "none"
+OPENSEARCH_AUTH_MODE_CUSTOM = "custom"
+OPENSEARCH_USER_ENV = "OPENSEARCH_USER"
+OPENSEARCH_PASSWORD_ENV = "OPENSEARCH_PASSWORD"
+OPENSEARCH_DEFAULT_USER = "admin"
+OPENSEARCH_DEFAULT_PASSWORD = "myStrongPassword123!"
+OPENSEARCH_DOCKER_IMAGE = os.getenv(
+    "OPENSEARCH_DOCKER_IMAGE", "opensearchproject/opensearch:latest"
+)
+OPENSEARCH_DOCKER_CONTAINER = os.getenv("OPENSEARCH_DOCKER_CONTAINER", "opensearch-local")
+OPENSEARCH_DOCKER_START_TIMEOUT = int(os.getenv("OPENSEARCH_DOCKER_START_TIMEOUT", "120"))
+
+_AUTH_FAILURE_TOKENS = (
+    "401", "403", "unauthorized", "forbidden",
+    "authentication", "security_exception",
+    "missing authentication credentials",
+)
+
+
+def normalize_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    return " ".join(text.split())
+
+
+def resolve_http_auth() -> tuple[str, str] | None:
+    mode = os.getenv("OPENSEARCH_AUTH_MODE", "default").strip().lower()
+    if mode == "none":
+        return None
+    if mode == "custom":
+        user = os.getenv("OPENSEARCH_USER", "").strip()
+        password = os.getenv("OPENSEARCH_PASSWORD", "").strip()
+        if not user or not password:
+            raise RuntimeError(
+                "OPENSEARCH_AUTH_MODE=custom requires OPENSEARCH_USER and OPENSEARCH_PASSWORD."
+            )
+        return user, password
+    return OPENSEARCH_DEFAULT_USER, OPENSEARCH_DEFAULT_PASSWORD
+
+
+def build_client(use_ssl: bool, http_auth: tuple[str, str] | None = None) -> OpenSearch:
+    kwargs = {
+        "hosts": [{"host": OPENSEARCH_HOST, "port": OPENSEARCH_PORT}],
+        "use_ssl": use_ssl,
+        "verify_certs": False,
+        "ssl_show_warn": False,
+    }
+    if http_auth is not None:
+        kwargs["http_auth"] = http_auth
+    return OpenSearch(**kwargs)
+
+
+def can_connect(client: OpenSearch) -> tuple[bool, bool]:
+    try:
+        client.info()
+        return True, False
+    except Exception as e:
+        lowered = normalize_text(e).lower()
+        if "404" in lowered or "notfounderror" in lowered:
+            try:
+                client.cat.indices(format="json")
+                return True, False
+            except Exception:
+                pass
+            try:
+                client.search(index="*", body={"size": 0}, params={"timeout": "5s"})
+                return True, False
+            except Exception as se:
+                sl = normalize_text(se).lower()
+                if "403" in sl or "forbidden" in sl:
+                    return True, False
+        auth_failure = any(t in lowered for t in _AUTH_FAILURE_TOKENS)
+        return False, auth_failure
+
+
+def _resolve_docker() -> str:
+    system = platform.system().lower()
+    candidates = {
+        "darwin": [
+            "/usr/local/bin/docker",
+            "/opt/homebrew/bin/docker",
+            "/Applications/Docker.app/Contents/Resources/bin/docker",
+        ],
+        "linux": ["/usr/bin/docker", "/usr/local/bin/docker", "/snap/bin/docker"],
+    }.get(system, [])
+
+    from_env = os.getenv("OPENSEARCH_DOCKER_CLI_PATH", "").strip()
+    if from_env:
+        candidates.insert(0, from_env)
+
+    from_path = shutil.which("docker")
+    if from_path:
+        candidates.insert(0, from_path)
+
+    for path in candidates:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+
+    raise RuntimeError(
+        "Docker CLI not found. Install Docker or set OPENSEARCH_DOCKER_CLI_PATH."
+    )
+
+
+def _run_docker(command: list[str]) -> subprocess.CompletedProcess:
+    docker = _resolve_docker()
+    return subprocess.run(
+        [docker] + command,
+        capture_output=True, text=True, timeout=60,
+    )
+
+
+def _start_local_container() -> None:
+    result = _run_docker(["ps", "--format", "{{.Names}}"])
+    if OPENSEARCH_DOCKER_CONTAINER in (result.stdout or "").split():
+        print(f"Container '{OPENSEARCH_DOCKER_CONTAINER}' already running.", file=sys.stderr)
+        return
+
+    _run_docker(["rm", "-f", OPENSEARCH_DOCKER_CONTAINER])
+
+    password = os.getenv("OPENSEARCH_PASSWORD", OPENSEARCH_DEFAULT_PASSWORD).strip() or OPENSEARCH_DEFAULT_PASSWORD
+    print(f"Starting OpenSearch container '{OPENSEARCH_DOCKER_CONTAINER}'...", file=sys.stderr)
+    result = _run_docker([
+        "run", "-d",
+        "--name", OPENSEARCH_DOCKER_CONTAINER,
+        "-p", f"{OPENSEARCH_PORT}:9200",
+        "-p", "9600:9600",
+        "-e", "discovery.type=single-node",
+        "-e", "DISABLE_SECURITY_PLUGIN=true",
+        "-e", f"OPENSEARCH_INITIAL_ADMIN_PASSWORD={password}",
+        OPENSEARCH_DOCKER_IMAGE,
+    ])
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to start container: {result.stderr}")
+
+
+def _wait_for_cluster() -> OpenSearch:
+    http_auth = resolve_http_auth()
+    secure = build_client(use_ssl=True, http_auth=http_auth)
+    insecure = build_client(use_ssl=False, http_auth=http_auth)
+    deadline = time.time() + OPENSEARCH_DOCKER_START_TIMEOUT
+
+    while time.time() < deadline:
+        ok, _ = can_connect(secure)
+        if ok:
+            return secure
+        ok, _ = can_connect(insecure)
+        if ok:
+            return insecure
+        time.sleep(2)
+
+    raise RuntimeError(
+        f"OpenSearch did not become ready within {OPENSEARCH_DOCKER_START_TIMEOUT}s."
+    )
+
+
+def _is_local_host(host: str) -> bool:
+    """Check if the given host is a local address."""
+    return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+
+
+def preflight_check_cluster(
+    auth_mode: str = "",
+    username: str = "",
+    password: str = "",
+) -> dict:
+    """Probe the configured OpenSearch host:port before execution.
+
+    On the first call (no auth args), probes with no-auth and default creds.
+    If the result is ``auth_required``, the caller should ask the user for
+    credentials and call again with ``auth_mode="custom"``, ``username``,
+    and ``password``.  When custom creds succeed the function sets
+    ``OPENSEARCH_AUTH_MODE``, ``OPENSEARCH_USER``, and ``OPENSEARCH_PASSWORD``
+    as in-process environment variables so every subsequent tool call
+    (``create_index``, ``execute_plan``, etc.) picks them up automatically
+    via ``resolve_http_auth()``.
+
+    Args:
+        auth_mode: ``""`` (auto-detect), ``"none"``, ``"default"``, or ``"custom"``.
+        username: Required when auth_mode is ``"custom"``.
+        password: Required when auth_mode is ``"custom"``.
+
+    Returns:
+        dict with status, host, port, is_local, message, auth_modes_tried,
+        and auth_mode (when status is "available").
+    """
+    host = OPENSEARCH_HOST
+    port = OPENSEARCH_PORT
+    is_local = _is_local_host(host)
+    result: dict = {"host": host, "port": port, "is_local": is_local}
+
+    normalized_mode = str(auth_mode or "").strip().lower()
+
+    # --- Caller-supplied custom credentials ---
+    if normalized_mode == "custom":
+        user = str(username or "").strip()
+        pwd = str(password or "").strip()
+        if not user or not pwd:
+            result["status"] = "error"
+            result["message"] = (
+                "auth_mode='custom' requires both username and password."
+            )
+            result["auth_modes_tried"] = []
+            return result
+
+        custom_auth = (user, pwd)
+        for use_ssl in (True, False):
+            client = build_client(use_ssl=use_ssl, http_auth=custom_auth)
+            ok, _ = can_connect(client)
+            if ok:
+                # Persist creds in-process for all subsequent tool calls.
+                os.environ[OPENSEARCH_AUTH_MODE_ENV] = OPENSEARCH_AUTH_MODE_CUSTOM
+                os.environ[OPENSEARCH_USER_ENV] = user
+                os.environ[OPENSEARCH_PASSWORD_ENV] = pwd
+                ssl_label = "SSL" if use_ssl else "HTTP"
+                result["status"] = "available"
+                result["auth_mode"] = "custom"
+                result["message"] = (
+                    f"Connected to OpenSearch at {host}:{port} ({ssl_label}) "
+                    f"with provided credentials. Credentials set for this session."
+                )
+                result["auth_modes_tried"] = [
+                    f"custom_{'ssl' if use_ssl else 'http'}"
+                ]
+                return result
+
+        result["status"] = "auth_required"
+        result["message"] = (
+            f"OpenSearch cluster at {host}:{port} rejected the provided "
+            f"credentials. Please verify username/password and try again."
+        )
+        result["auth_modes_tried"] = ["custom_ssl", "custom_http"]
+        return result
+
+    # --- Caller-supplied no-auth mode ---
+    if normalized_mode == "none":
+        for use_ssl in (False, True):
+            client = build_client(use_ssl=use_ssl, http_auth=None)
+            ok, _ = can_connect(client)
+            if ok:
+                os.environ[OPENSEARCH_AUTH_MODE_ENV] = OPENSEARCH_AUTH_MODE_NONE
+                os.environ.pop(OPENSEARCH_USER_ENV, None)
+                os.environ.pop(OPENSEARCH_PASSWORD_ENV, None)
+                ssl_label = "SSL" if use_ssl else "HTTP"
+                result["status"] = "available"
+                result["auth_mode"] = "none"
+                result["message"] = (
+                    f"Connected to OpenSearch at {host}:{port} ({ssl_label}) "
+                    f"with no authentication. Auth mode set for this session."
+                )
+                result["auth_modes_tried"] = [
+                    f"none_{'ssl' if use_ssl else 'http'}"
+                ]
+                return result
+
+        result["status"] = "auth_required"
+        result["message"] = (
+            f"Could not connect to OpenSearch at {host}:{port} without "
+            f"authentication. The cluster may require credentials."
+        )
+        result["auth_modes_tried"] = ["none_http", "none_ssl"]
+        return result
+
+    # --- Explicit default mode ---
+    if normalized_mode == "default":
+        default_auth = (OPENSEARCH_DEFAULT_USER, OPENSEARCH_DEFAULT_PASSWORD)
+        for use_ssl in (True, False):
+            client = build_client(use_ssl=use_ssl, http_auth=default_auth)
+            ok, _ = can_connect(client)
+            if ok:
+                os.environ[OPENSEARCH_AUTH_MODE_ENV] = OPENSEARCH_AUTH_MODE_DEFAULT
+                os.environ.pop(OPENSEARCH_USER_ENV, None)
+                os.environ.pop(OPENSEARCH_PASSWORD_ENV, None)
+                ssl_label = "SSL" if use_ssl else "HTTP"
+                result["status"] = "available"
+                result["auth_mode"] = "default"
+                result["message"] = (
+                    f"Connected to OpenSearch at {host}:{port} ({ssl_label}) "
+                    f"using default credentials. Auth mode set for this session."
+                )
+                result["auth_modes_tried"] = [
+                    f"default_{'ssl' if use_ssl else 'http'}"
+                ]
+                return result
+
+        result["status"] = "auth_required"
+        result["message"] = (
+            f"Could not connect to OpenSearch at {host}:{port} with "
+            f"default credentials. The cluster may require custom credentials."
+        )
+        result["auth_modes_tried"] = ["default_ssl", "default_http"]
+        return result
+
+    # --- Auto-detect (no auth args supplied) ---
+    auth_modes_tried: list[str] = []
+    saw_auth_failure = False
+
+    default_auth = (OPENSEARCH_DEFAULT_USER, OPENSEARCH_DEFAULT_PASSWORD)
+    probes: list[tuple[bool, tuple[str, str] | None, str]] = [
+        (False, None, "none_http"),
+        (True, None, "none_ssl"),
+        (True, default_auth, "default_ssl"),
+        (False, default_auth, "default_http"),
+    ]
+
+    for use_ssl, http_auth, label in probes:
+        auth_modes_tried.append(label)
+        client = build_client(use_ssl=use_ssl, http_auth=http_auth)
+        ok, auth_fail = can_connect(client)
+        if ok:
+            mode_name = "none" if http_auth is None else "default"
+            ssl_label = "SSL" if use_ssl else "HTTP"
+            if http_auth is None:
+                detail = f"with security disabled (no auth, {ssl_label})"
+                os.environ[OPENSEARCH_AUTH_MODE_ENV] = OPENSEARCH_AUTH_MODE_NONE
+                os.environ.pop(OPENSEARCH_USER_ENV, None)
+                os.environ.pop(OPENSEARCH_PASSWORD_ENV, None)
+            else:
+                detail = f"({ssl_label}) using default credentials"
+                os.environ[OPENSEARCH_AUTH_MODE_ENV] = OPENSEARCH_AUTH_MODE_DEFAULT
+                os.environ.pop(OPENSEARCH_USER_ENV, None)
+                os.environ.pop(OPENSEARCH_PASSWORD_ENV, None)
+            result["status"] = "available"
+            result["auth_mode"] = mode_name
+            result["message"] = (
+                f"OpenSearch cluster detected at {host}:{port} {detail}."
+            )
+            result["auth_modes_tried"] = auth_modes_tried
+            return result
+        if auth_fail:
+            saw_auth_failure = True
+
+    result["auth_modes_tried"] = auth_modes_tried
+    if saw_auth_failure:
+        result["status"] = "auth_required"
+        result["message"] = (
+            f"OpenSearch cluster detected at {host}:{port} but authentication "
+            f"failed with all attempted credentials. Please provide your "
+            f"credentials or allow bootstrapping a new local cluster."
+        )
+    else:
+        result["status"] = "no_cluster"
+        result["message"] = (
+            f"No OpenSearch cluster detected at {host}:{port}. "
+            f"A local cluster can be bootstrapped via Docker."
+        )
+    return result
+
+
+def clear_cluster_credentials() -> None:
+    """Remove in-process cluster credentials set by ``preflight_check_cluster``.
+
+    Call this at the end of a session (e.g. from ``cleanup()``) so credentials
+    do not linger in the process environment.
+    """
+    os.environ.pop(OPENSEARCH_AUTH_MODE_ENV, None)
+    os.environ.pop(OPENSEARCH_USER_ENV, None)
+    os.environ.pop(OPENSEARCH_PASSWORD_ENV, None)
+
+
+def create_client() -> OpenSearch:
+    http_auth = resolve_http_auth()
+
+    secure = build_client(use_ssl=True, http_auth=http_auth)
+    ok, _ = can_connect(secure)
+    if ok:
+        return secure
+
+    insecure = build_client(use_ssl=False, http_auth=http_auth)
+    ok, auth_fail = can_connect(insecure)
+    if ok:
+        return insecure
+
+    if auth_fail:
+        raise RuntimeError(
+            f"Authentication failed connecting to OpenSearch at {OPENSEARCH_HOST}:{OPENSEARCH_PORT}."
+        )
+
+    _start_local_container()
+    return _wait_for_cluster()
+
+
+def create_remote_client(
+    endpoint: str,
+    port: int = 443,
+    use_ssl: bool = True,
+    username: str = "",
+    password: str = "",
+    aws_region: str = "",
+    aws_service: str = "",
+) -> OpenSearch:
+    kwargs: dict = {
+        "hosts": [{"host": endpoint, "port": port}],
+        "use_ssl": use_ssl,
+        "verify_certs": use_ssl,
+        "ssl_show_warn": False,
+    }
+
+    if aws_region and aws_service:
+        import boto3
+        from opensearchpy import AWSV4SignerAuth, RequestsHttpConnection
+        session = boto3.Session()
+        credentials = session.get_credentials()
+        kwargs["http_auth"] = AWSV4SignerAuth(credentials, aws_region, aws_service)
+        kwargs["connection_class"] = RequestsHttpConnection
+    elif username and password:
+        kwargs["http_auth"] = (username, password)
+
+    return OpenSearch(**kwargs)

--- a/skills/opensearch-skills/scripts/lib/evaluate.py
+++ b/skills/opensearch-skills/scripts/lib/evaluate.py
@@ -1,0 +1,743 @@
+"""Search quality evaluation engine.
+
+General-purpose evaluation that accepts any number of search methods
+and test queries with graded relevance judgments. Computes nDCG, P@k,
+MRR metrics and produces actionable diagnostic findings.
+
+The engine is method-agnostic: callers provide pre-computed search results
+keyed by method name. Optional method tags ("lexical", "vector", "hybrid")
+enable more specific diagnosis when available.
+
+Usage as library:
+    from lib.evaluate import evaluate_results, compute_query_metrics, format_report
+"""
+
+import math
+from collections import defaultdict
+
+# -- Visual helpers ------------------------------------------------------------
+
+GRADE_LABELS = {3: "perfect", 2: "relevant", 1: "marginal", 0: ""}
+
+
+def star_rating(score):
+    if score >= 1.0:  return "★★★★★"
+    if score >= 0.75: return "★★★★☆"
+    if score >= 0.50: return "★★★☆☆"
+    if score >= 0.25: return "★★☆☆☆"
+    if score > 0:     return "★☆☆☆☆"
+    return "✗ 0.00"
+
+
+def bar(score, width=10):
+    filled = round(score * width)
+    return "█" * filled + "░" * (width - filled)
+
+
+# -- Metrics -------------------------------------------------------------------
+
+def dcg(relevances, k):
+    return sum(rel / math.log2(i + 2) for i, rel in enumerate(relevances[:k]))
+
+
+def ndcg(relevances, ideal_relevances, k):
+    ideal = dcg(sorted(ideal_relevances, reverse=True), k)
+    return dcg(relevances, k) / ideal if ideal > 0 else 0.0
+
+
+def precision_at_k(relevances, k):
+    return sum(1 for r in relevances[:k] if r > 0) / k
+
+
+def mrr(relevances):
+    for i, r in enumerate(relevances):
+        if r > 0:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+# -- Query-level processing ----------------------------------------------------
+
+def compute_query_metrics(results, relevance_map, title_field, k):
+    """Compute metrics for a single query's search results.
+
+    Args:
+        results: OpenSearch search response dict.
+        relevance_map: {document_title: relevance_grade}.
+        title_field: Field name to extract document title from _source.
+        k: Cutoff depth.
+
+    Returns:
+        dict with ndcg, p@k, mrr, rels, titles.
+    """
+    hits = results["hits"]["hits"][:k]
+    titles = [h["_source"].get(title_field, h["_id"]) for h in hits]
+    doc_ids = [h.get("_id", "") for h in hits]
+    scores = [h.get("_score") for h in hits]
+    rels = [relevance_map.get(t, 0) for t in titles]
+    ideal_rels = list(relevance_map.values())
+    # Per-position DCG contribution: rel_i / log2(i+2)
+    dcg_contribs = [rel / math.log2(i + 2) for i, rel in enumerate(rels)]
+    return {
+        "ndcg": ndcg(rels, ideal_rels, k),
+        "p@k": precision_at_k(rels, k),
+        "mrr": mrr(rels),
+        "rels": rels,
+        "titles": titles,
+        "doc_ids": doc_ids,
+        "scores": scores,
+        "dcg_contribs": dcg_contribs,
+    }
+
+
+# -- Diagnosis -----------------------------------------------------------------
+
+_LEXICAL_TAGS = {"lexical", "bm25"}
+_VECTOR_TAGS = {"vector", "knn", "sparse"}
+_HYBRID_TAGS = {"hybrid", "combined"}
+
+
+def _classify_methods(method_names, method_tags):
+    """Classify methods into lexical, vector, hybrid, and untagged groups."""
+    tags = method_tags or {}
+    lexical = [m for m in method_names if tags.get(m) in _LEXICAL_TAGS]
+    vector = [m for m in method_names if tags.get(m) in _VECTOR_TAGS]
+    hybrid = [m for m in method_names if tags.get(m) in _HYBRID_TAGS]
+    untagged = [m for m in method_names if m not in lexical + vector + hybrid]
+    return lexical, vector, hybrid, untagged
+
+
+def diagnose_query(test, metrics_by_method, k, method_tags=None, embedded_fields=""):
+    """Diagnose issues for a single query across all methods.
+
+    Args:
+        test: Test case dict with name, type, query, relevance.
+        metrics_by_method: {method_name: metrics_dict} for this query.
+        k: Cutoff used for metrics.
+        method_tags: Optional {method_name: category} for smarter diagnosis.
+            Recognised categories: "lexical", "bm25", "vector", "knn",
+            "sparse", "hybrid", "combined".
+        embedded_fields: Description of embedded fields (for messages).
+
+    Returns:
+        List of (tag, severity, message) tuples.
+    """
+    findings = []
+    method_names = list(metrics_by_method.keys())
+    if not method_names:
+        return findings
+
+    qtype = test.get("type", "")
+    query = test.get("query", "")
+    relevance = test.get("relevance", {})
+    lexical, vector, hybrid, untagged = _classify_methods(method_names, method_tags)
+
+    # Rule 1: All methods fail (nDCG < 0.3)
+    if all(metrics_by_method[m]["ndcg"] < 0.3 for m in method_names):
+        if qtype == "semantic":
+            findings.append(("[MODEL_SELECTION]", "HIGH",
+                f"All methods nDCG<0.30 for '{query}'. "
+                f"The model cannot bridge the semantic gap. "
+                f"Upgrade to a larger model or enrich documents with topic tags."))
+        elif qtype == "combined":
+            findings.append(("[INDEX_MAPPING]", "HIGH",
+                f"All methods nDCG<0.30 for '{query}'. "
+                f"Possible field type or mapping issue. "
+                f"Check that relevant fields have proper analyzers and keyword sub-fields."))
+        else:
+            findings.append(("[INDEX_MAPPING]", "HIGH",
+                f"All methods nDCG<0.30 for '{query}' (type={qtype}). "
+                f"No method can retrieve relevant documents."))
+        return findings  # skip remaining rules when everything fails
+
+    # Rule 2: Pairwise method gaps (tag-aware)
+    # Vector fails but lexical succeeds -> model issue
+    for vm in vector:
+        if metrics_by_method[vm]["ndcg"] >= 0.3:
+            continue
+        for lm in lexical:
+            if metrics_by_method[lm]["ndcg"] > 0.5:
+                findings.append(("[MODEL_SELECTION]", "MEDIUM",
+                    f"{vm} nDCG={metrics_by_method[vm]['ndcg']:.2f} vs "
+                    f"{lm} nDCG={metrics_by_method[lm]['ndcg']:.2f}. "
+                    f"Embedding model cannot capture semantics that keyword matching handles."))
+                break
+    # Lexical fails but vector succeeds -> analyzer / field issue
+    for lm in lexical:
+        if metrics_by_method[lm]["ndcg"] >= 0.3:
+            continue
+        for vm in vector:
+            if metrics_by_method[vm]["ndcg"] > 0.5:
+                findings.append(("[INDEX_MAPPING]", "MEDIUM",
+                    f"{lm} nDCG={metrics_by_method[lm]['ndcg']:.2f} vs "
+                    f"{vm} nDCG={metrics_by_method[vm]['ndcg']:.2f}. "
+                    f"Text fields may lack proper analyzers or boosting."))
+                break
+    # Generic pairwise: large gap between any two untagged methods
+    for i, m1 in enumerate(untagged):
+        for m2 in untagged[i + 1:]:
+            n1 = metrics_by_method[m1]["ndcg"]
+            n2 = metrics_by_method[m2]["ndcg"]
+            if abs(n1 - n2) > 0.3:
+                weak, strong = (m1, m2) if n1 < n2 else (m2, m1)
+                findings.append(("[QUERY_TUNING]", "MEDIUM",
+                    f"{weak} nDCG={metrics_by_method[weak]['ndcg']:.2f} vs "
+                    f"{strong} nDCG={metrics_by_method[strong]['ndcg']:.2f}. "
+                    f"Significant quality gap between methods."))
+
+    # Rule 3: Hybrid/combined worse than best single-signal method
+    single_methods = lexical + vector + untagged
+    if single_methods and hybrid:
+        best_single_ndcg = max(metrics_by_method[m]["ndcg"] for m in single_methods)
+        best_single_name = max(single_methods, key=lambda m: metrics_by_method[m]["ndcg"])
+        for hm in hybrid:
+            gap = best_single_ndcg - metrics_by_method[hm]["ndcg"]
+            if gap > 0.15:
+                best_lex = max((metrics_by_method[m]["ndcg"] for m in lexical), default=0)
+                best_vec = max((metrics_by_method[m]["ndcg"] for m in vector), default=0)
+                if best_lex > best_vec:
+                    findings.append(("[SEARCH_PIPELINE]", "MEDIUM",
+                        f"{hm} nDCG={metrics_by_method[hm]['ndcg']:.2f} < "
+                        f"{best_single_name} nDCG={best_single_ndcg:.2f}. "
+                        f"Vector signal may be hurting results. "
+                        f"Consider adjusting weights or query-type-aware routing."))
+                else:
+                    findings.append(("[SEARCH_PIPELINE]", "LOW",
+                        f"{hm} nDCG={metrics_by_method[hm]['ndcg']:.2f} < "
+                        f"{best_single_name} nDCG={best_single_ndcg:.2f}. "
+                        f"Lexical noise may be pulling irrelevant keyword matches."))
+
+    # Rule 4: Irrelevant doc in top-2 of any method
+    for m in method_names:
+        mm = metrics_by_method[m]
+        if mm["rels"][:2].count(0) == 0 or mm["ndcg"] >= 0.8:
+            continue
+        irrelevant_top2 = [t for t, r in zip(mm["titles"][:2], mm["rels"][:2]) if r == 0]
+        if not irrelevant_top2:
+            continue
+        other_methods = [om for om in method_names if om != m]
+        doc_title = irrelevant_top2[0]
+        if not other_methods:
+            findings.append(("[QUERY_TUNING]", "MEDIUM",
+                f"Irrelevant doc '{doc_title[:45]}' in top-2 of {m}. "
+                f"Reduce field boost or restructure query."))
+        else:
+            in_others = [om for om in other_methods
+                         if doc_title in set(metrics_by_method[om]["titles"][:3])]
+            not_in_others = [om for om in other_methods
+                             if doc_title not in set(metrics_by_method[om]["titles"][:3])]
+            if not_in_others and in_others:
+                findings.append(("[QUERY_TUNING]", "MEDIUM",
+                    f"Irrelevant doc '{doc_title[:45]}' in top-2 of {m}. "
+                    f"Also in {', '.join(in_others)} but not {', '.join(not_in_others)}. "
+                    f"Reduce field boost or restructure query for {m}."))
+            elif not_in_others:
+                findings.append(("[QUERY_TUNING]", "MEDIUM",
+                    f"Irrelevant doc '{doc_title[:45]}' in top-2 of {m} only. "
+                    f"Noise specific to this method's retrieval signal."))
+            elif in_others:
+                findings.append(("[MODEL_SELECTION]", "LOW",
+                    f"Irrelevant doc '{doc_title[:45]}' in top-2 of {m} "
+                    f"(also in {', '.join(in_others)}). "
+                    f"Document is broadly similar; a more capable model may help."))
+
+    # Rule 5: Relevant docs missing from all methods' top-k
+    all_returned = set()
+    for m in method_names:
+        all_returned.update(metrics_by_method[m]["titles"])
+    missed = [t for t, r in relevance.items() if r >= 2 and t not in all_returned]
+    if missed:
+        fields_note = f" Embedded fields: {embedded_fields}." if embedded_fields else ""
+        findings.append(("[MODEL_SELECTION]", "LOW",
+            f"High-relevance docs not in any top-{k}: {', '.join(missed[:3])}.{fields_note} "
+            f"Model capacity limitation."))
+
+    return findings
+
+
+# -- Evaluation engine ---------------------------------------------------------
+
+def evaluate_results(tests, results_by_method, k=5, title_field="title",
+                     method_tags=None, embedded_fields=""):
+    """Evaluate search quality across multiple methods and test queries.
+
+    Args:
+        tests: [{"name", "type", "query", "relevance": {title: grade}}].
+        results_by_method: {method_name: [opensearch_response_per_test]}.
+            Each response is a standard OpenSearch search response dict.
+        k: Cutoff depth for metrics.
+        title_field: Field in _source to match against relevance judgments.
+        method_tags: Optional {method_name: category} for smarter diagnosis.
+            Recognised categories: "lexical"/"bm25", "vector"/"knn"/"sparse",
+            "hybrid"/"combined".
+        embedded_fields: Description of embedded fields (for diagnosis messages).
+
+    Returns:
+        dict with keys: methods, tests, metrics, findings, summary, k.
+    """
+    method_names = list(results_by_method.keys())
+    all_metrics = {m: [] for m in method_names}
+    all_findings = []
+
+    for i, test in enumerate(tests):
+        metrics_by_method = {}
+        for method in method_names:
+            response = results_by_method[method][i]
+            m = compute_query_metrics(response, test["relevance"], title_field, k)
+            metrics_by_method[method] = m
+            all_metrics[method].append(m)
+
+        findings = diagnose_query(test, metrics_by_method, k, method_tags, embedded_fields)
+        if findings:
+            all_findings.append((test["name"], findings))
+
+    summary = {}
+    for method in method_names:
+        metrics = all_metrics[method]
+        n = len(metrics)
+        summary[method] = {
+            "mean_ndcg": sum(m["ndcg"] for m in metrics) / n,
+            "mean_pk": sum(m["p@k"] for m in metrics) / n,
+            "mean_mrr": sum(m["mrr"] for m in metrics) / n,
+        }
+
+    return {
+        "methods": method_names,
+        "tests": tests,
+        "metrics": all_metrics,
+        "findings": all_findings,
+        "summary": summary,
+        "k": k,
+    }
+
+
+# -- Output formatting ---------------------------------------------------------
+
+W = 90
+
+
+def format_header(config, k, num_tests, method_names):
+    lines = [
+        f"\n{'=' * W}",
+        f"  SEARCH QUALITY EVALUATION",
+        f"  Index: {config.get('index', '?')}  |  Methods: {', '.join(method_names)}  |  k={k}  |  {num_tests} queries",
+        f"{'=' * W}",
+    ]
+    return "\n".join(lines)
+
+
+def format_query_results(test, metrics_by_method, k):
+    method_names = list(metrics_by_method.keys())
+    relevance = test.get("relevance", {})
+    lines = [
+        f"\n{'-' * W}",
+        f"  {test['name']}  ({test.get('type', '')})",
+        f"  Query: \"{test['query']}\"",
+        f"  Relevance: " + ", ".join(
+            f"{t} [{GRADE_LABELS.get(g, '')}={g}]"
+            for t, g in sorted(relevance.items(), key=lambda x: -x[1])
+        ) if relevance else "  Relevance: (none)",
+        f"{'-' * W}",
+    ]
+
+    for method in method_names:
+        m = metrics_by_method[method]
+        stars = star_rating(m["ndcg"])
+        ideal_dcg_val = dcg(sorted(test["relevance"].values(), reverse=True), k)
+        actual_dcg_val = sum(m.get("dcg_contribs", []))
+        lines.append(f"\n  {method}  {stars}  nDCG={m['ndcg']:.2f}  P@{k}={m['p@k']:.2f}  MRR={m['mrr']:.2f}")
+        lines.append(f"  nDCG = DCG / iDCG = {actual_dcg_val:.3f} / {ideal_dcg_val:.3f}" if ideal_dcg_val > 0
+                      else f"  nDCG = 0 (no relevant docs defined)")
+        lines.append(f"  {'':4s}{'#':>2s}  {'Doc ID':<16s} {'Document':<36s} {'_score':>7s} {'Rel':>3s} {'DCG_i':>7s}  Label")
+        lines.append(f"  {'':4s}{'-' * 82}")
+        doc_ids = m.get("doc_ids", [""] * len(m["titles"]))
+        os_scores = m.get("scores", [None] * len(m["titles"]))
+        dcg_contribs = m.get("dcg_contribs", [0.0] * len(m["titles"]))
+        for i, (doc_id, title, rel, os_score, dcg_c) in enumerate(
+            zip(doc_ids, m["titles"], m["rels"], os_scores, dcg_contribs), 1
+        ):
+            icon = "+" if rel > 0 else "x"
+            label = GRADE_LABELS.get(rel, "")
+            score_str = f"{os_score:.2f}" if os_score is not None else "n/a"
+            title_trunc = title[:35] + "..." if len(title) > 35 else title
+            lines.append(
+                f"  {i:>2}. {icon} {doc_id:<16s} {title_trunc:<36s} {score_str:>7s} {rel:>3d} {dcg_c:>7.3f}  {label}"
+            )
+
+    # Missed docs
+    relevance = test["relevance"]
+    all_returned = set()
+    for m in metrics_by_method.values():
+        all_returned.update(m["titles"])
+    missed = [(t, r) for t, r in relevance.items() if r >= 2 and t not in all_returned]
+    if missed:
+        lines.append(f"\n  Missed (grade>=2, not in any top-{k}):")
+        for title, grade in missed:
+            lines.append(f"    - {title}  [grade={grade}]")
+
+    return "\n".join(lines)
+
+
+def format_ndcg_table(tests, all_metrics, k):
+    method_names = list(all_metrics.keys())
+    name_w = 44
+
+    lines = [
+        f"\n{'=' * W}",
+        f"  PER-QUERY nDCG@{k}",
+        f"{'=' * W}",
+    ]
+
+    header = f"  {'Query':<{name_w}s} {'Type':<10s}"
+    for m in method_names:
+        header += f" {m:>7s}"
+    lines.append(header)
+    lines.append(f"  {'-' * (name_w + 10 + 8 * len(method_names))}")
+
+    for i, test in enumerate(tests):
+        name = test["name"]
+        if len(name) > name_w:
+            name = name[:name_w - 1] + "..."
+        row = f"  {name:<{name_w}s} {test.get('type', ''):<10s}"
+        for m in method_names:
+            row += f" {all_metrics[m][i]['ndcg']:>7.2f}"
+        lines.append(row)
+
+    lines.append(f"  {'-' * (name_w + 10 + 8 * len(method_names))}")
+    mean_row = f"  {'MEAN':<{name_w}s} {'':10s}"
+    for m in method_names:
+        mean_val = sum(met["ndcg"] for met in all_metrics[m]) / len(all_metrics[m])
+        mean_row += f" {mean_val:>7.3f}"
+    lines.append(mean_row)
+
+    return "\n".join(lines)
+
+
+def format_summary(tests, all_metrics, k):
+    method_names = list(all_metrics.keys())
+    name_w = max(12, max((len(m) for m in method_names), default=12))
+    row_w = name_w + 12 + 7 + 7 + 7 + 6  # bar + spaces + 3 metric columns
+    lines = [
+        f"\n{'=' * W}",
+        f"  SUMMARY -- Mean Metrics Across {len(tests)} Queries",
+        f"{'=' * W}",
+        f"  {'Method':<{name_w}s} {'':12s} {'nDCG@'+str(k):>7s} {'P@'+str(k):>7s} {'MRR':>7s}",
+        f"  {'-' * row_w}",
+    ]
+
+    for method in method_names:
+        metrics = all_metrics[method]
+        avg_ndcg = sum(m["ndcg"] for m in metrics) / len(metrics)
+        avg_pk = sum(m["p@k"] for m in metrics) / len(metrics)
+        avg_mrr = sum(m["mrr"] for m in metrics) / len(metrics)
+        lines.append(f"  {method:<{name_w}s} {bar(avg_ndcg)}  {avg_ndcg:>7.3f} {avg_pk:>7.2f} {avg_mrr:>7.2f}")
+
+    return "\n".join(lines)
+
+
+def format_type_breakdown(tests, all_metrics, k):
+    method_names = list(all_metrics.keys())
+    types = defaultdict(lambda: defaultdict(list))
+    for i, test in enumerate(tests):
+        for method in method_names:
+            types[test.get("type", "unknown")][method].append(all_metrics[method][i]["ndcg"])
+
+    col_w = 12 + 8 + 10 * len(method_names)
+    lines = [
+        f"\n  Per-Type Breakdown (mean nDCG@{k})",
+        f"  {'-' * col_w}",
+    ]
+
+    header = f"  {'Type':<12s} {'Queries':>7s}"
+    for m in method_names:
+        header += f" {m:>9s}"
+    lines.append(header)
+    lines.append(f"  {'-' * col_w}")
+
+    for qtype in sorted(types.keys()):
+        n = len(types[qtype][method_names[0]])
+        row = f"  {qtype:<12s} {n:>7d}"
+        for m in method_names:
+            val = sum(types[qtype][m]) / n
+            row += f" {val:>9.3f}"
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
+def format_findings(all_findings):
+    flat = [(qname, tag, sev, msg)
+            for qname, findings in all_findings for tag, sev, msg in findings]
+    if not flat:
+        return (
+            f"\n{'=' * W}\n"
+            f"  FINDINGS: None -- all queries performing well\n"
+            f"{'=' * W}"
+        )
+
+    lines = [
+        f"\n{'=' * W}",
+        f"  FINDINGS & RECOMMENDATIONS ({len(flat)} total)",
+        f"{'=' * W}",
+    ]
+
+    by_tag = defaultdict(list)
+    for qname, tag, sev, msg in flat:
+        by_tag[tag].append((qname, sev, msg))
+
+    severity_order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+    tag_order = [
+        "[INDEX_MAPPING]", "[EMBEDDING_FIELDS]", "[MODEL_SELECTION]",
+        "[SEARCH_PIPELINE]", "[QUERY_TUNING]",
+    ]
+    all_tags = tag_order + [t for t in by_tag if t not in tag_order]
+
+    max_count = max(len(v) for v in by_tag.values())
+    for tag in all_tags:
+        items = by_tag.get(tag, [])
+        if not items:
+            continue
+        tag_bar = "##" * len(items)
+        label = " -- highest impact" if len(items) == max_count else ""
+        lines.append(f"  {tag:22s} ({len(items)}) {tag_bar}{label}")
+    lines.append("")
+
+    for tag in all_tags:
+        items = by_tag.get(tag, [])
+        if not items:
+            continue
+        items.sort(key=lambda x: severity_order.get(x[1], 9))
+        lines.append(f"  {tag} ({len(items)} finding{'s' if len(items) > 1 else ''})")
+        lines.append(f"  {'-' * (W - 4)}")
+        for qname, sev, msg in items:
+            lines.append(f"  [{sev:6s}] {qname}")
+            lines.append(f"          {msg}")
+            lines.append("")
+
+    high = [(q, t, s, m) for q, t, s, m in flat if s == "HIGH"]
+    if high:
+        _, tag, _, msg = high[0]
+        lines.append(f"  RECOMMENDED NEXT ACTION: {tag}")
+        lines.append(f"  {msg}")
+    elif flat:
+        tag_counts = {t: len(v) for t, v in by_tag.items()}
+        top_tag = max(tag_counts, key=tag_counts.get)
+        lines.append(f"  RECOMMENDED NEXT ACTION: {top_tag} ({tag_counts[top_tag]} findings)")
+
+    return "\n".join(lines)
+
+
+def format_completion(report):
+    all_metrics = report["metrics"]
+    all_findings = report["findings"]
+    k = report["k"]
+
+    flat = [(tag, sev) for _, findings in all_findings for tag, sev, _ in findings]
+    all_ndcgs = [m["ndcg"] for metrics in all_metrics.values() for m in metrics]
+    mean_all = sum(all_ndcgs) / len(all_ndcgs)
+    high_count = sum(1 for _, s in flat if s == "HIGH")
+    low_only = all(s == "LOW" for _, s in flat) if flat else True
+
+    lines = [
+        f"\n{'=' * W}",
+        f"  COMPLETION CHECK",
+        f"{'=' * W}",
+        f"  Mean nDCG@{k} across all methods: {mean_all:.3f} (target > 0.7)",
+        f"  HIGH severity findings: {high_count}",
+        f"  All findings LOW only: {low_only}",
+    ]
+
+    if mean_all > 0.7:
+        lines.append(f"  + Target met. Setup is well-optimized.")
+    elif low_only and not high_count:
+        lines.append(f"  + All findings are LOW severity. Setup is acceptable.")
+    else:
+        lines.append(f"  x Further optimization recommended. Apply the highest-impact fix and re-evaluate.")
+
+    return "\n".join(lines)
+
+
+def evaluate_search_results(client, index_name, title_field="title", k=5,
+                            max_suggestions=8, extra_queries=None):
+    """Phase 1 of evaluation: generate suggestions, run ALL queries in batch
+    through the real search pipeline, and return results for the agent to judge.
+
+    Args:
+        client: OpenSearch client instance.
+        index_name: Target index.
+        title_field: Field used to identify documents in results output.
+        k: Cutoff depth (number of results per query).
+        max_suggestions: Max programmatic test queries to generate.
+        extra_queries: Optional list of additional queries, each a dict
+            with keys: text, capability.
+
+    Returns:
+        dict with:
+            - queries: list of {query, capability, results: [{title, score}]}
+              for the agent to review and assign relevance grades.
+            - _raw: internal state to pass to evaluate_index() so searches
+              are not re-run.
+    """
+    from .search import generate_suggestions, search_ui_search
+
+    gen = generate_suggestions(client, index_name, max_count=max_suggestions)
+    suggestions = gen.get("suggestions", []) if isinstance(gen, dict) else gen
+
+    all_queries = []
+    for s in suggestions:
+        all_queries.append({"text": s["text"], "capability": s["capability"]})
+
+    if extra_queries:
+        for eq in extra_queries:
+            if eq.get("text"):
+                all_queries.append({
+                    "text": eq["text"],
+                    "capability": eq.get("capability", "semantic"),
+                })
+
+    # Batch search: run all queries through the real pipeline
+    queries_out = []
+    tests = []
+    results = []
+    for i, q in enumerate(all_queries):
+        ui_result = search_ui_search(client, index_name, query_text=q["text"], size=k)
+        os_response = _ui_result_to_os_response(ui_result)
+
+        # Extract titles and scores for agent review
+        hits_summary = []
+        for h in ui_result.get("hits", []):
+            title = h.get("source", {}).get(title_field, h.get("id", "?"))
+            hits_summary.append({"title": title, "score": round(h.get("score", 0), 4)})
+
+        queries_out.append({
+            "query": q["text"],
+            "capability": q["capability"],
+            "results": hits_summary,
+        })
+
+        tests.append({
+            "name": f"Q{i+1}: {q['capability']} query",
+            "type": q["capability"],
+            "query": q["text"],
+            "relevance": {},  # filled in by evaluate_index
+        })
+        results.append(os_response)
+
+    return {
+        "queries": queries_out,
+        "_raw": {"tests": tests, "results": results,
+                 "index_name": index_name, "title_field": title_field, "k": k},
+    }
+
+
+def evaluate_index(client=None, index_name="", title_field="title", k=5,
+                   max_suggestions=8, relevance_overrides=None,
+                   extra_queries=None, search_results=None):
+    """Compute metrics and produce the evaluation report.
+
+    Can be called in two ways:
+    1. With search_results from evaluate_search_results() — skips re-running
+       searches (preferred, avoids duplicate work).
+    2. Without search_results — runs suggestions + searches from scratch.
+
+    Args:
+        client: OpenSearch client (required if search_results is None).
+        index_name: Target index (required if search_results is None).
+        title_field: Field used to identify documents in relevance judgments.
+        k: Cutoff depth for metrics.
+        max_suggestions: Max programmatic test queries to generate.
+        relevance_overrides: Dict mapping query text to {doc_title: grade}.
+        extra_queries: Optional additional queries (only used when
+            search_results is None).
+        search_results: Output from evaluate_search_results(). When provided,
+            client/index_name/k/max_suggestions/extra_queries are ignored.
+
+    Returns:
+        Formatted report string.
+    """
+    overrides = relevance_overrides or {}
+
+    if search_results and "_raw" in search_results:
+        raw = search_results["_raw"]
+        tests = raw["tests"]
+        results = raw["results"]
+        index_name = raw["index_name"]
+        title_field = raw.get("title_field", title_field)
+        k = raw.get("k", k)
+    else:
+        from .search import generate_suggestions, search_ui_search
+
+        gen = generate_suggestions(client, index_name, max_count=max_suggestions)
+        suggestions = gen.get("suggestions", []) if isinstance(gen, dict) else gen
+
+        all_queries = []
+        for s in suggestions:
+            all_queries.append({"text": s["text"], "capability": s["capability"]})
+        if extra_queries:
+            for eq in extra_queries:
+                if eq.get("text"):
+                    all_queries.append({
+                        "text": eq["text"],
+                        "capability": eq.get("capability", "semantic"),
+                    })
+
+        tests = []
+        results = []
+        for i, q in enumerate(all_queries):
+            ui_result = search_ui_search(client, index_name, query_text=q["text"], size=k)
+            os_response = _ui_result_to_os_response(ui_result)
+            tests.append({
+                "name": f"Q{i+1}: {q['capability']} query",
+                "type": q["capability"],
+                "query": q["text"],
+                "relevance": {},
+            })
+            results.append(os_response)
+
+    # Apply relevance overrides
+    for test in tests:
+        test["relevance"] = overrides.get(test["query"], {})
+
+    report = evaluate_results(
+        tests=tests,
+        results_by_method={"Search": results},
+        k=k,
+        title_field=title_field,
+    )
+    return format_report(report, config={"index": index_name})
+
+
+def _ui_result_to_os_response(ui_result):
+    """Convert a search_ui_search response to OpenSearch-style response."""
+    return {
+        "hits": {
+            "total": {"value": ui_result.get("total", 0)},
+            "hits": [
+                {"_id": h["id"], "_source": h["source"], "_score": h["score"]}
+                for h in ui_result.get("hits", [])
+            ],
+        }
+    }
+
+
+def format_report(report, config=None):
+    """Format a complete evaluation report as a string."""
+    tests = report["tests"]
+    all_metrics = report["metrics"]
+    k = report["k"]
+    method_names = report["methods"]
+
+    parts = []
+    parts.append(format_header(config or {}, k, len(tests), method_names))
+
+    for i, test in enumerate(tests):
+        metrics_by_method = {m: all_metrics[m][i] for m in method_names}
+        parts.append(format_query_results(test, metrics_by_method, k))
+
+    parts.append(format_ndcg_table(tests, all_metrics, k))
+    parts.append(format_summary(tests, all_metrics, k))
+    parts.append(format_type_breakdown(tests, all_metrics, k))
+    parts.append(format_findings(report["findings"]))
+    parts.append(format_completion(report))
+
+    return "\n".join(parts)

--- a/skills/opensearch-skills/scripts/lib/operations.py
+++ b/skills/opensearch-skills/scripts/lib/operations.py
@@ -1,0 +1,449 @@
+"""Core OpenSearch operations: index, model, pipeline, search, docs."""
+
+import json
+import os
+import sys
+import time
+
+from opensearchpy import OpenSearch
+
+from .client import create_client, normalize_text
+
+
+# ---------------------------------------------------------------------------
+# Pretrained model registry
+# ---------------------------------------------------------------------------
+PRETRAINED_MODELS = {
+    "huggingface/cross-encoders/ms-marco-MiniLM-L-12-v2": "1.0.2",
+    "huggingface/cross-encoders/ms-marco-MiniLM-L-6-v2": "1.0.2",
+    "huggingface/sentence-transformers/all-MiniLM-L12-v2": "1.0.2",
+    "huggingface/sentence-transformers/all-MiniLM-L6-v2": "1.0.2",
+    "huggingface/sentence-transformers/all-distilroberta-v1": "1.0.2",
+    "huggingface/sentence-transformers/all-mpnet-base-v2": "1.0.2",
+    "huggingface/sentence-transformers/distiluse-base-multilingual-cased-v1": "1.0.2",
+    "huggingface/sentence-transformers/msmarco-distilbert-base-tas-b": "1.0.3",
+    "huggingface/sentence-transformers/multi-qa-MiniLM-L6-cos-v1": "1.0.2",
+    "huggingface/sentence-transformers/multi-qa-mpnet-base-dot-v1": "1.0.2",
+    "huggingface/sentence-transformers/paraphrase-MiniLM-L3-v2": "1.0.2",
+    "huggingface/sentence-transformers/paraphrase-mpnet-base-v2": "1.0.1",
+    "huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2": "1.0.2",
+    "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v1": "1.0.1",
+    "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v2-distill": "1.0.0",
+    "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v2-mini": "1.0.0",
+    "amazon/neural-sparse/opensearch-neural-sparse-encoding-v2-distill": "1.0.0",
+    "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-distill": "1.0.0",
+    "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-gte": "1.0.0",
+    "amazon/neural-sparse/opensearch-neural-sparse-tokenizer-v1": "1.0.1",
+    "amazon/neural-sparse/opensearch-neural-sparse-tokenizer-multilingual-v1": "1.0.0",
+    "amazon/sentence-highlighting/opensearch-semantic-highlighter-v1": "1.0.0",
+    "amazon/metrics_correlation": "1.0.0b2",
+}
+
+
+# ---------------------------------------------------------------------------
+# ML helpers
+# ---------------------------------------------------------------------------
+def _wait_for_ml_task(
+    client: OpenSearch, task_id: str, *, max_polls: int = 100, interval: int = 3
+) -> tuple[str, dict]:
+    if not task_id:
+        return "FAILED", {"error": "Missing task_id"}
+    for _ in range(max_polls):
+        res = client.transport.perform_request("GET", f"/_plugins/_ml/tasks/{task_id}")
+        state = normalize_text(res.get("state", "")).upper()
+        if state in {"COMPLETED", "FAILED"}:
+            return state, res
+        time.sleep(interval)
+    return "TIMEOUT", {}
+
+
+def set_ml_settings(client: OpenSearch) -> None:
+    body = {
+        "persistent": {
+            "plugins.ml_commons.native_memory_threshold": 95,
+            "plugins.ml_commons.only_run_on_ml_node": False,
+            "plugins.ml_commons.allow_registering_model_via_url": True,
+            "plugins.ml_commons.model_access_control_enabled": True,
+            "plugins.ml_commons.trusted_connector_endpoints_regex": [
+                "^https://runtime\\.sagemaker\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+                "^https://bedrock-runtime\\..*[a-z0-9-]\\.amazonaws\\.com/.*$",
+            ],
+        }
+    }
+    client.transport.perform_request("PUT", "/_cluster/settings", body=body)
+
+
+# ---------------------------------------------------------------------------
+# Index operations
+# ---------------------------------------------------------------------------
+def create_index(
+    index_name: str, body: dict | None = None, replace_if_exists: bool = True
+) -> str:
+    if body is None:
+        body = {}
+    try:
+        client = create_client()
+    except Exception as e:
+        return f"Failed to create index '{index_name}': {e}"
+
+    try:
+        exists = client.indices.exists(index=index_name)
+    except Exception:
+        exists = False
+
+    if exists and replace_if_exists:
+        try:
+            client.indices.delete(index=index_name, ignore=[404])
+        except Exception as e:
+            return f"Failed to delete existing index '{index_name}': {e}"
+    elif exists:
+        return f"Index '{index_name}' already exists."
+
+    try:
+        client.indices.create(index=index_name, body=body)
+        action = "recreated" if exists else "created"
+        return f"Index '{index_name}' {action} successfully."
+    except Exception as e:
+        return f"Failed to create index '{index_name}': {e}"
+
+
+def index_doc(index_name: str, doc: dict, doc_id: str) -> str:
+    client = create_client()
+    try:
+        client.index(index=index_name, body=doc, id=doc_id)
+    except Exception as e:
+        return f"Failed to index document: {e}"
+
+    client.indices.refresh(index=index_name)
+
+    try:
+        result = client.get(index=index_name, id=doc_id)
+        return json.dumps(result, default=str, ensure_ascii=False)
+    except Exception as e:
+        return f"Indexed but failed to retrieve: {e}"
+
+
+def index_bulk(index_name: str, docs: list[dict], id_prefix: str = "doc") -> str:
+    client = create_client()
+    indexed = []
+    errors = []
+    bulk_body: list[dict] = []
+    doc_id_list: list[str] = []
+
+    for i, doc in enumerate(docs, 1):
+        doc_id = f"{id_prefix}-{i}"
+        bulk_body.append({"index": {"_index": index_name, "_id": doc_id}})
+        bulk_body.append(doc)
+        doc_id_list.append(doc_id)
+
+    if bulk_body:
+        try:
+            resp = client.bulk(body=bulk_body)
+            for item, doc_id in zip(resp.get("items", []), doc_id_list):
+                action_result = item.get("index", {})
+                if action_result.get("error"):
+                    errors.append(f"{doc_id}: {action_result['error']}")
+                else:
+                    indexed.append(doc_id)
+        except Exception as e:
+            errors.append(f"bulk request failed: {e}")
+
+    if indexed:
+        client.indices.refresh(index=index_name)
+
+    return json.dumps({
+        "index_name": index_name,
+        "indexed_count": len(indexed),
+        "doc_ids": indexed,
+        "errors": errors,
+    }, ensure_ascii=False)
+
+
+def search(client: OpenSearch, index_name: str, body: dict | None = None, size: int = 10) -> dict:
+    if body is None:
+        body = {"query": {"match_all": {}}}
+    return client.search(index=index_name, body=body, size=size)
+
+
+# ---------------------------------------------------------------------------
+# ML model deployment
+# ---------------------------------------------------------------------------
+def deploy_local_model(model_name: str) -> str:
+    if model_name not in PRETRAINED_MODELS:
+        return f"Error: Model '{model_name}' not supported. Supported: {list(PRETRAINED_MODELS.keys())}"
+
+    try:
+        client = create_client()
+        set_ml_settings(client)
+
+        version = PRETRAINED_MODELS[model_name]
+        register_body = {
+            "name": model_name,
+            "version": version,
+            "model_format": "TORCH_SCRIPT",
+        }
+        print(f"Registering model '{model_name}'...", file=sys.stderr)
+        resp = client.transport.perform_request(
+            "POST", "/_plugins/_ml/models/_register", body=register_body
+        )
+        task_id = resp.get("task_id")
+
+        state, task_res = _wait_for_ml_task(client, task_id, max_polls=100, interval=5)
+        if state == "FAILED":
+            return f"Model registration failed: {task_res.get('error')}"
+        if state == "TIMEOUT":
+            return "Model registration timed out."
+
+        model_id = task_res.get("model_id")
+        if not model_id:
+            return "Model registration completed but no model_id returned."
+        print(f"Model registered: {model_id}", file=sys.stderr)
+
+        # Deploy
+        resp = client.transport.perform_request(
+            "POST", f"/_plugins/_ml/models/{model_id}/_deploy"
+        )
+        deploy_task_id = resp.get("task_id")
+        print(f"Deploying model {model_id}...", file=sys.stderr)
+
+        state, task_res = _wait_for_ml_task(client, deploy_task_id, max_polls=100, interval=3)
+        if state == "COMPLETED":
+            return f"Model '{model_name}' (ID: {model_id}) created and deployed successfully."
+        if state == "FAILED":
+            return f"Model deployment failed: {task_res.get('error')}"
+        return f"Model deployment timed out. Model ID: {model_id}"
+
+    except Exception as e:
+        return f"Error creating local pretrained model: {e}"
+
+
+def deploy_bedrock_model(model_name: str) -> str:
+    if model_name != "amazon.titan-embed-text-v2:0":
+        return "Error: Only amazon.titan-embed-text-v2:0 is supported."
+
+    region = os.getenv("AWS_REGION", "us-east-1")
+    access_key = os.getenv("AWS_ACCESS_KEY_ID")
+    secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    session_token = os.getenv("AWS_SESSION_TOKEN")
+
+    if not access_key or not secret_key:
+        return "Error: AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) required."
+
+    credentials = {"access_key": access_key, "secret_key": secret_key}
+    if session_token:
+        credentials["session_token"] = session_token
+
+    connector_body = {
+        "name": f"Bedrock Connector for {model_name}",
+        "description": f"Connector for Bedrock model {model_name}",
+        "version": 1,
+        "protocol": "aws_sigv4",
+        "parameters": {"region": region, "service_name": "bedrock"},
+        "credential": credentials,
+        "actions": [{
+            "action_type": "predict",
+            "method": "POST",
+            "url": f"https://bedrock-runtime.{region}.amazonaws.com/model/{model_name}/invoke",
+            "headers": {"content-type": "application/json"},
+            "request_body": '{"inputText": "${parameters.inputText}"}',
+        }],
+    }
+
+    try:
+        client = create_client()
+        set_ml_settings(client)
+
+        resp = client.transport.perform_request(
+            "POST", "/_plugins/_ml/connectors/_create", body=connector_body
+        )
+        connector_id = resp.get("connector_id")
+        if not connector_id:
+            return f"Failed to create connector: {resp}"
+
+        register_body = {
+            "name": f"Bedrock {model_name}",
+            "function_name": "remote",
+            "connector_id": connector_id,
+        }
+        resp = client.transport.perform_request(
+            "POST", "/_plugins/_ml/models/_register?deploy=true", body=register_body
+        )
+        task_id = resp.get("task_id")
+
+        state, task_res = _wait_for_ml_task(client, task_id, max_polls=100, interval=5)
+        if state == "COMPLETED":
+            mid = task_res.get("model_id")
+            return f"Bedrock model '{model_name}' (ID: {mid}) deployed successfully."
+        if state == "FAILED":
+            return f"Bedrock model deployment failed: {task_res.get('error')}"
+        return "Bedrock model deployment timed out."
+
+    except Exception as e:
+        return f"Error deploying Bedrock model: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline operations
+# ---------------------------------------------------------------------------
+def create_pipeline(
+    pipeline_name: str,
+    pipeline_body: dict,
+    index_name: str,
+    pipeline_type: str = "ingest",
+    is_hybrid: bool = False,
+    hybrid_weights: list[float] | None = None,
+) -> str:
+    if not index_name:
+        return "Error: index_name is required."
+
+    if pipeline_type == "search" and is_hybrid and not pipeline_body:
+        weights = hybrid_weights or [0.5, 0.5]
+        pipeline_body = {
+            "phase_results_processors": [{
+                "normalization-processor": {
+                    "normalization": {"technique": "min_max"},
+                    "combination": {
+                        "technique": "arithmetic_mean",
+                        "parameters": {"weights": weights},
+                    },
+                }
+            }]
+        }
+
+    if pipeline_type == "ingest" and not pipeline_body:
+        return "Error: pipeline_body required for ingest pipelines."
+
+    try:
+        client = create_client()
+        client.transport.perform_request(
+            "PUT", f"/_{'search' if pipeline_type == 'search' else 'ingest'}/pipeline/{pipeline_name}",
+            body=pipeline_body,
+        )
+
+        if index_name:
+            setting_key = (
+                "index.search.default_pipeline"
+                if pipeline_type == "search"
+                else "index.default_pipeline"
+            )
+            client.indices.put_settings(
+                index=index_name,
+                body={"index": {setting_key.split(".", 1)[-1]: pipeline_name}},
+            )
+
+        return f"Pipeline '{pipeline_name}' ({pipeline_type}) created and attached to '{index_name}'."
+    except Exception as e:
+        return f"Failed to create pipeline: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Agentic search
+# ---------------------------------------------------------------------------
+def deploy_agentic_model(
+    access_key: str,
+    secret_key: str,
+    region: str = "us-east-1",
+    session_token: str = "",
+    model_name: str = "us.anthropic.claude-sonnet-4-20250514-v1:0",
+) -> str:
+    if not access_key or not secret_key:
+        return "Error: AWS credentials required."
+
+    creds = {"access_key": access_key.strip(), "secret_key": secret_key.strip()}
+    if session_token and session_token.strip():
+        creds["session_token"] = session_token.strip()
+
+    register_body = {
+        "name": f"agentic-search-model-{int(time.time())}",
+        "function_name": "remote",
+        "connector": {
+            "name": f"Bedrock Claude Connector {int(time.time())}",
+            "description": "Bedrock connector for agentic search",
+            "version": 1,
+            "protocol": "aws_sigv4",
+            "parameters": {
+                "region": region.strip(),
+                "service_name": "bedrock",
+                "model": model_name,
+            },
+            "credential": creds,
+            "actions": [{
+                "action_type": "predict",
+                "method": "POST",
+                "url": f"https://bedrock-runtime.{region.strip()}.amazonaws.com/model/{model_name}/converse",
+                "headers": {"content-type": "application/json"},
+                "request_body": '{ "system": [{"text": "${parameters.system_prompt}"}], "messages": [${parameters._chat_history:-}{"role":"user","content":[{"text":"${parameters.user_prompt}"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }',
+            }],
+        },
+    }
+
+    try:
+        client = create_client()
+        set_ml_settings(client)
+        resp = client.transport.perform_request(
+            "POST", "/_plugins/_ml/models/_register?deploy=true", body=register_body
+        )
+        model_id = resp.get("model_id") or resp.get("modelId")
+        if not model_id:
+            return f"Registration failed: {resp}"
+        return model_id
+    except Exception as e:
+        return f"Error creating agentic model: {e}"
+
+
+def create_flow_agent(agent_name: str, model_id: str) -> str:
+    if not model_id:
+        return "Error: model_id required."
+    try:
+        client = create_client()
+        body = {
+            "name": agent_name,
+            "type": "flow",
+            "description": "Flow agent for agentic search",
+            "tools": [
+                {"type": "IndexMappingTool", "name": "IndexMappingTool"},
+                {
+                    "type": "QueryPlanningTool",
+                    "parameters": {
+                        "model_id": model_id,
+                        "response_filter": "$.output.message.content[0].text",
+                    },
+                },
+            ],
+        }
+        resp = client.transport.perform_request(
+            "POST", "/_plugins/_ml/agents/_register", body=body
+        )
+        agent_id = resp.get("agent_id")
+        if not agent_id:
+            return f"Failed to create agent: {resp}"
+        return f"Flow agent '{agent_name}' (ID: {agent_id}) created successfully."
+    except Exception as e:
+        return f"Error creating flow agent: {e}"
+
+
+def create_agentic_pipeline(
+    pipeline_name: str, agent_id: str, index_name: str
+) -> str:
+    if not agent_id or not index_name:
+        return "Error: agent_id and index_name required."
+
+    pipeline_body = {
+        "request_processors": [
+            {"agentic_query_translator": {"agent_id": agent_id}}
+        ],
+        "response_processors": [{"agentic_context": {}}],
+    }
+
+    try:
+        client = create_client()
+        client.transport.perform_request(
+            "PUT", f"/_search/pipeline/{pipeline_name}", body=pipeline_body
+        )
+        client.indices.put_settings(
+            index=index_name,
+            body={"index": {"search.default_pipeline": pipeline_name}},
+        )
+        return f"Agentic pipeline '{pipeline_name}' attached to '{index_name}'."
+    except Exception as e:
+        return f"Failed to create agentic pipeline: {e}"

--- a/skills/opensearch-skills/scripts/lib/samples.py
+++ b/skills/opensearch-skills/scripts/lib/samples.py
@@ -1,0 +1,181 @@
+"""Sample data loading for OpenSearch search builder."""
+
+import csv
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+from .client import create_client
+
+
+def _load_records_from_file(file_path: Path, limit: int = 10) -> tuple[list[dict], str | None]:
+    suffix = file_path.suffix.lower()
+
+    if suffix == ".parquet":
+        try:
+            import pyarrow.parquet as pq
+            table = pq.read_table(str(file_path))
+            records = table.to_pylist()[:limit]
+            return records, None
+        except ImportError:
+            return [], "pyarrow required for Parquet files. Install with: pip install pyarrow"
+        except Exception as e:
+            return [], str(e)
+
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+            if suffix in (".json", ".jsonl", ".ndjson"):
+                content = f.read().strip()
+                if content.startswith("["):
+                    records = json.loads(content)
+                    return records[:limit], None
+                # JSONL
+                records = []
+                for line in content.splitlines():
+                    line = line.strip()
+                    if line:
+                        records.append(json.loads(line))
+                        if len(records) >= limit:
+                            break
+                return records, None
+
+            if suffix in (".csv", ".tsv"):
+                delimiter = "\t" if suffix == ".tsv" else ","
+                reader = csv.DictReader(f, delimiter=delimiter)
+                records = []
+                for row in reader:
+                    records.append(dict(row))
+                    if len(records) >= limit:
+                        break
+                return records, None
+
+            return [], f"Unsupported file format: {suffix}"
+    except Exception as e:
+        return [], str(e)
+
+
+def _infer_text_fields(doc: dict) -> list[str]:
+    text_fields = []
+    for key, value in doc.items():
+        if isinstance(value, str) and len(value.split()) > 3:
+            text_fields.append(key)
+    return text_fields
+
+
+def load_sample_builtin_imdb() -> str:
+    script_dir = Path(__file__).resolve().parent.parent
+    # Look for bundled sample data alongside this script
+    candidates = [
+        script_dir / "sample_data" / "imdb.title.basics.tsv",
+    ]
+    for path in candidates:
+        if path.exists():
+            return load_sample_from_file(str(path.resolve()))
+
+    return json.dumps({"error": "IMDB sample data not found."})
+
+
+def load_sample_from_file(file_path: str) -> str:
+    path = Path(file_path).expanduser().resolve()
+    if not path.exists():
+        return json.dumps({"error": f"File not found: {file_path}"})
+
+    records, error = _load_records_from_file(path, limit=10)
+    if error:
+        return json.dumps({"error": error})
+    if not records:
+        return json.dumps({"error": "No records found in file."})
+
+    sample = records[0]
+    text_fields = _infer_text_fields(sample)
+    return json.dumps({
+        "status": "loaded",
+        "source": str(path),
+        "record_count": len(records),
+        "sample_doc": sample,
+        "text_fields": text_fields,
+        "text_search_required": len(text_fields) > 0,
+    }, ensure_ascii=False, default=str)
+
+
+def load_sample_from_url(url: str) -> str:
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "opensearch-skills/1.0"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            content = resp.read().decode("utf-8", errors="replace")
+
+        # Try JSON
+        try:
+            data = json.loads(content)
+            if isinstance(data, list):
+                records = data[:10]
+            elif isinstance(data, dict):
+                records = [data]
+            else:
+                return json.dumps({"error": "URL returned unexpected JSON format."})
+        except json.JSONDecodeError:
+            # Try CSV
+            lines = content.splitlines()
+            reader = csv.DictReader(lines)
+            records = [dict(row) for row in list(reader)[:10]]
+
+        if not records:
+            return json.dumps({"error": "No records loaded from URL."})
+
+        sample = records[0]
+        text_fields = _infer_text_fields(sample)
+        return json.dumps({
+            "status": "loaded",
+            "source": url,
+            "record_count": len(records),
+            "sample_doc": sample,
+            "text_fields": text_fields,
+            "text_search_required": len(text_fields) > 0,
+        }, ensure_ascii=False, default=str)
+
+    except Exception as e:
+        return json.dumps({"error": f"Failed to load from URL: {e}"})
+
+
+def load_sample_from_index(index_name: str) -> str:
+    try:
+        client = create_client()
+        resp = client.search(index=index_name, body={"query": {"match_all": {}}, "size": 10})
+        hits = resp.get("hits", {}).get("hits", [])
+        if not hits:
+            return json.dumps({"error": f"No documents in index '{index_name}'."})
+
+        records = [hit["_source"] for hit in hits if "_source" in hit]
+        sample = records[0] if records else {}
+        text_fields = _infer_text_fields(sample)
+        return json.dumps({
+            "status": "loaded",
+            "source": f"localhost:{index_name}",
+            "record_count": len(records),
+            "sample_doc": sample,
+            "text_fields": text_fields,
+            "text_search_required": len(text_fields) > 0,
+        }, ensure_ascii=False, default=str)
+
+    except Exception as e:
+        return json.dumps({"error": f"Failed to load from index: {e}"})
+
+
+def load_sample_from_paste(doc_json: str) -> str:
+    try:
+        doc = json.loads(doc_json)
+        if not isinstance(doc, dict):
+            return json.dumps({"error": "Pasted data must be a JSON object."})
+        text_fields = _infer_text_fields(doc)
+        return json.dumps({
+            "status": "loaded",
+            "source": "paste",
+            "record_count": 1,
+            "sample_doc": doc,
+            "text_fields": text_fields,
+            "text_search_required": len(text_fields) > 0,
+        }, ensure_ascii=False, default=str)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid JSON: {e}"})

--- a/skills/opensearch-skills/scripts/lib/search.py
+++ b/skills/opensearch-skills/scripts/lib/search.py
@@ -1,0 +1,979 @@
+"""Search logic for the Agent Skills UI, ported from the MCP path.
+
+Provides smart field detection, semantic/hybrid search, agentic search,
+suggestions, autocomplete, and preview text generation.
+"""
+
+import re
+from opensearchpy import OpenSearch
+
+from .client import normalize_text
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+_NUMERIC_FIELD_TYPES = {
+    "byte", "short", "integer", "long", "float",
+    "half_float", "double", "scaled_float",
+}
+_KEYWORD_FIELD_TYPES = {"keyword", "constant_keyword"}
+_EXACT_TERM_FIELD_TYPES = _KEYWORD_FIELD_TYPES | _NUMERIC_FIELD_TYPES | {
+    "boolean", "date", "date_nanos", "ip", "version", "unsigned_long",
+}
+
+
+# ---------------------------------------------------------------------------
+# Value analysis helpers
+# ---------------------------------------------------------------------------
+def _value_shape(text: str) -> dict[str, object]:
+    compact = normalize_text(text)
+    tokens = re.findall(r"[A-Za-z0-9_]+", compact)
+    alpha_count = sum(1 for ch in compact if ch.isalpha())
+    digit_count = sum(1 for ch in compact if ch.isdigit())
+    length = len(compact)
+    alpha_ratio = (alpha_count / length) if length else 0.0
+    digit_ratio = (digit_count / length) if length else 0.0
+    return {
+        "text": compact,
+        "length": length,
+        "tokens": tokens,
+        "token_count": len(tokens),
+        "alpha_ratio": alpha_ratio,
+        "digit_ratio": digit_ratio,
+        "looks_numeric": bool(re.fullmatch(r"[+-]?\d+(\.\d+)?", compact)),
+        "looks_date": bool(re.fullmatch(r"\d{4}([-/]\d{1,2}([-/]\d{1,2})?)?", compact)),
+    }
+
+
+def _text_richness_score(value: str) -> float:
+    shape = _value_shape(value)
+    length = int(shape["length"])
+    if length < 2:
+        return 0.0
+    alpha_ratio = float(shape["alpha_ratio"])
+    token_count = int(shape["token_count"])
+    return (
+        alpha_ratio * 20.0
+        + token_count * 10.0
+        + min(length, 100) / 100.0 * 5.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Index introspection
+# ---------------------------------------------------------------------------
+def extract_index_field_specs(client: OpenSearch, index_name: str) -> dict[str, dict[str, str]]:
+    field_specs: dict[str, dict[str, str]] = {}
+    try:
+        mapping_response = client.indices.get_mapping(index=index_name)
+    except Exception:
+        return field_specs
+
+    index_mapping = {}
+    if isinstance(mapping_response, dict):
+        index_mapping = next(iter(mapping_response.values()), {})
+    mappings = index_mapping.get("mappings", {})
+
+    def _walk(properties: dict, prefix: str = "") -> None:
+        if not isinstance(properties, dict):
+            return
+        for field_name, config in properties.items():
+            if not isinstance(config, dict):
+                continue
+            full_name = f"{prefix}.{field_name}" if prefix else field_name
+            field_type = config.get("type")
+            if isinstance(field_type, str):
+                field_specs[full_name] = {
+                    "type": field_type,
+                    "normalizer": str(config.get("normalizer", "")).strip(),
+                }
+            sub_fields = config.get("fields")
+            if isinstance(sub_fields, dict):
+                for sub_name, sub_config in sub_fields.items():
+                    if not isinstance(sub_config, dict):
+                        continue
+                    sub_type = sub_config.get("type")
+                    if not isinstance(sub_type, str):
+                        continue
+                    field_specs[f"{full_name}.{sub_name}"] = {
+                        "type": sub_type,
+                        "normalizer": str(sub_config.get("normalizer", "")).strip(),
+                    }
+            nested_props = config.get("properties")
+            if isinstance(nested_props, dict):
+                _walk(nested_props, full_name)
+
+    _walk(mappings.get("properties", {}))
+    return field_specs
+
+
+def _resolve_text_query_fields(field_specs: dict[str, dict[str, str]], limit: int = 6) -> list[str]:
+    text_fields = [
+        field for field, spec in field_specs.items()
+        if spec.get("type") == "text" and not field.endswith(".keyword")
+    ]
+    keyword_fields = [
+        field for field, spec in field_specs.items()
+        if spec.get("type") in _KEYWORD_FIELD_TYPES and not field.endswith(".keyword")
+    ]
+
+    def _score(field_name: str) -> tuple[int, int]:
+        return field_name.count("."), len(field_name)
+
+    ranked = sorted(text_fields, key=_score)
+    if not ranked:
+        ranked = sorted(keyword_fields, key=_score)
+    selected = ranked[:max(1, limit)]
+    return selected if selected else ["*"]
+
+
+def _resolve_field_spec_for_doc_key(
+    field_name: str, field_specs: dict[str, dict[str, str]]
+) -> tuple[str, dict[str, str]]:
+    if field_name in field_specs:
+        return field_name, field_specs[field_name]
+    lowered = field_name.lower()
+    for candidate_name, candidate_spec in field_specs.items():
+        if candidate_name.lower() == lowered:
+            return candidate_name, candidate_spec
+    for candidate_name, candidate_spec in field_specs.items():
+        if candidate_name.split(".")[-1].lower() == lowered:
+            return candidate_name, candidate_spec
+    return "", {}
+
+
+# ---------------------------------------------------------------------------
+# Semantic / agentic runtime detection
+# ---------------------------------------------------------------------------
+def _resolve_semantic_runtime_hints(
+    client: OpenSearch, index_name: str, field_specs: dict[str, dict[str, str]]
+) -> dict[str, str]:
+    vector_fields = [
+        (field, spec.get("type"))
+        for field, spec in field_specs.items()
+        if spec.get("type") in ("knn_vector", "rank_features")
+    ]
+    vector_field = ""
+    has_sparse = False
+    if vector_fields:
+        preferred = sorted(
+            vector_fields,
+            key=lambda item: (
+                # Prefer dense over sparse when both exist
+                0 if item[1] == "knn_vector" else 1,
+                0 if ("embedding" in item[0].lower() or "vector" in item[0].lower()) else 1,
+                len(item[0]), item[0],
+            ),
+        )
+        vector_field = preferred[0][0]
+        has_sparse = preferred[0][1] == "rank_features"
+
+    default_pipeline = ""
+    search_pipeline = ""
+    model_id = ""
+    has_agentic_pipeline = False
+
+    try:
+        settings_response = client.indices.get_settings(index=index_name)
+        index_settings = next(iter(settings_response.values()), {})
+        default_pipeline = normalize_text(
+            index_settings.get("settings", {}).get("index", {}).get("default_pipeline", "")
+        )
+        search_pipeline = normalize_text(
+            index_settings.get("settings", {}).get("index", {}).get("search", {}).get("default_pipeline", "")
+        )
+    except Exception:
+        pass
+
+    has_neural_search_pipeline = False
+
+    if search_pipeline:
+        try:
+            pipeline_response = client.transport.perform_request("GET", f"/_search/pipeline/{search_pipeline}")
+            pipeline = pipeline_response.get(search_pipeline, {})
+            for processor in pipeline.get("request_processors", []):
+                if isinstance(processor, dict):
+                    if "agentic_query_translator" in processor:
+                        has_agentic_pipeline = True
+                    if "neural_query_enricher" in processor:
+                        has_neural_search_pipeline = True
+            # normalization-processor in phase_results_processors also indicates neural search
+            for processor in pipeline.get("phase_results_processors", []):
+                if isinstance(processor, dict) and "normalization-processor" in processor:
+                    has_neural_search_pipeline = True
+        except Exception:
+            pass
+
+    if default_pipeline:
+        try:
+            pipeline_response = client.ingest.get_pipeline(id=default_pipeline)
+            pipeline = pipeline_response.get(default_pipeline, {})
+            for processor in pipeline.get("processors", []):
+                if not isinstance(processor, dict):
+                    continue
+                # Support both text_embedding (dense) and sparse_encoding (sparse)
+                embedding = processor.get("text_embedding") or processor.get("sparse_encoding")
+                if processor.get("sparse_encoding") and not vector_fields:
+                    has_sparse = True
+                if not isinstance(embedding, dict):
+                    continue
+                candidate_model = normalize_text(embedding.get("model_id", ""))
+                field_map = embedding.get("field_map", {})
+                if not candidate_model:
+                    continue
+                if isinstance(field_map, dict) and field_map:
+                    if vector_field:
+                        for source, target in field_map.items():
+                            if normalize_text(target) == vector_field:
+                                model_id = candidate_model
+                                break
+                        if model_id:
+                            break
+                    if not model_id:
+                        first_source, first_target = next(iter(field_map.items()))
+                        model_id = candidate_model
+                        if not vector_field:
+                            vector_field = normalize_text(first_target)
+                else:
+                    model_id = candidate_model
+                    break
+        except Exception:
+            pass
+
+    return {
+        "vector_field": vector_field,
+        "model_id": model_id,
+        "default_pipeline": default_pipeline,
+        "search_pipeline": search_pipeline,
+        "has_agentic_pipeline": str(has_agentic_pipeline).lower(),
+        "has_neural_search_pipeline": str(has_neural_search_pipeline).lower(),
+        "has_sparse": str(has_sparse).lower(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query builders
+# ---------------------------------------------------------------------------
+def _build_default_lexical_query(query: str, fields: list[str]) -> dict:
+    body: dict[str, object] = {"query": query, "fields": fields or ["*"]}
+    if any(field != "*" for field in fields):
+        body["fuzziness"] = "AUTO"
+    return {"multi_match": body}
+
+
+def _build_default_lexical_body(query: str, size: int, fields: list[str]) -> dict:
+    return {"size": size, "query": _build_default_lexical_query(query=query, fields=fields)}
+
+
+def _build_neural_clause(query: str, vector_field: str, model_id: str, size: int) -> dict:
+    return {
+        "neural": {
+            vector_field: {
+                "query_text": query,
+                "model_id": model_id,
+                "k": max(size, 10),
+            }
+        }
+    }
+
+
+def _build_neural_sparse_clause(query: str, vector_field: str, model_id: str = "") -> dict:
+    clause: dict = {"query_text": query}
+    if model_id:
+        clause["model_id"] = model_id
+    return {"neural_sparse": {vector_field: clause}}
+
+
+# ---------------------------------------------------------------------------
+# Preview & suggestions
+# ---------------------------------------------------------------------------
+def _suggestion_candidates_from_doc(source: dict) -> list[str]:
+    if not isinstance(source, dict):
+        return []
+    scored: list[tuple[float, str]] = []
+    for value in source.values():
+        if value is None or isinstance(value, (dict, list)):
+            continue
+        shape = _value_shape(str(value))
+        compact = str(shape["text"])
+        length = int(shape["length"])
+        if length < 4 or length > 80:
+            continue
+        if shape["looks_numeric"] or shape["looks_date"]:
+            continue
+        score = _text_richness_score(str(value))
+        scored.append((score, compact))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [text for _, text in scored]
+
+
+def _is_vector_value(v: object) -> bool:
+    """Return True if *v* looks like a dense or sparse embedding vector."""
+    if isinstance(v, list) and len(v) >= 16:
+        # Dense vector: list of 16+ numbers
+        sample = v[:8]
+        if all(isinstance(x, (int, float)) for x in sample):
+            return True
+    if isinstance(v, dict) and len(v) >= 4:
+        # Sparse vector: dict with string keys and numeric values
+        # Covers both numeric-key sparse vectors and neural sparse
+        # token-weight vectors (e.g. {"movie": 0.33, "comedy": 0.12})
+        # Use a low threshold (4) to catch pruned sparse vectors with
+        # fewer tokens.
+        items = list(v.items())
+        sample = items[:16] if len(items) > 16 else items
+        if all(
+            isinstance(k, str) and isinstance(val, (int, float))
+            for k, val in sample
+        ):
+            return True
+    return False
+
+
+def _strip_vector_fields(source: dict) -> dict:
+    """Return a shallow copy of *source* with embedding/vector fields removed."""
+    return {k: v for k, v in source.items() if not _is_vector_value(v)}
+
+
+def preview_text(source: dict) -> str:
+    candidates = _suggestion_candidates_from_doc(source)
+    if candidates:
+        return candidates[0]
+    if source:
+        for value in source.values():
+            if value is None or isinstance(value, (dict, list)):
+                continue
+            text = " ".join(str(value).split())
+            if text:
+                return text[:180]
+    return "(No preview text)"
+
+
+def generate_suggestions(
+    client: OpenSearch, index_name: str, max_count: int = 8,
+) -> dict:
+    """Generate diverse suggestions with capability/query_mode metadata.
+
+    Returns a dict with:
+        - suggestions: list of test queries covering exact, structured,
+          autocomplete, fuzzy, combined, and semantic (when available).
+        - sample_docs: list of sample documents (vector fields stripped).
+        - has_semantic: whether the index supports semantic/hybrid search.
+    """
+    empty = {"suggestions": [], "sample_docs": [], "has_semantic": False}
+    if not index_name:
+        return empty
+
+    field_specs = extract_index_field_specs(client, index_name)
+    runtime_hints = _resolve_semantic_runtime_hints(client, index_name, field_specs)
+    has_semantic = bool(
+        (runtime_hints.get("vector_field") and runtime_hints.get("model_id"))
+        or runtime_hints.get("has_neural_search_pipeline", "false") == "true"
+    )
+
+    # Categorise fields
+    text_fields, keyword_fields, numeric_fields = [], [], []
+    # Track text fields that have .keyword sub-fields (filterable)
+    filterable_fields = []
+    for name, spec in field_specs.items():
+        ftype = spec.get("type", "")
+        if ftype == "text" and not name.endswith(".keyword"):
+            text_fields.append(name)
+            # Check if this text field has a .keyword sub-field
+            if f"{name}.keyword" in field_specs:
+                filterable_fields.append(name)
+        elif ftype in _KEYWORD_FIELD_TYPES and not name.endswith(".keyword"):
+            keyword_fields.append(name)
+            filterable_fields.append(name)
+        elif ftype in _NUMERIC_FIELD_TYPES:
+            numeric_fields.append(name)
+
+    # Sample a few documents
+    try:
+        response = client.search(
+            index=index_name,
+            body={"size": 20, "query": {"match_all": {}}},
+        )
+        docs = [h.get("_source", {}) for h in response.get("hits", {}).get("hits", [])]
+    except Exception:
+        docs = []
+
+    if not docs:
+        return empty
+
+    # Strip vector fields from sample docs for agent readability
+    sample_docs = [_strip_vector_fields(doc) for doc in docs]
+
+    meta: list[dict] = []
+    seen: set[str] = set()
+
+    def _add(text: str, capability: str, query_mode: str, field: str = ""):
+        key = text.lower().strip()
+        if key in seen or not key:
+            return
+        seen.add(key)
+        meta.append({
+            "text": text.strip(),
+            "capability": capability,
+            "query_mode": query_mode,
+            "field": field,
+            "value": "",
+            "case_insensitive": False,
+        })
+
+    # Resolve title fields early (used by exact, structured, and other sections)
+    title_fields = [f for f in text_fields if any(h in f.lower() for h in ("title", "name", "label"))]
+    title_set = set(f.lower() for f in (title_fields or []))
+
+    # 1. Exact match — title/name value
+    if title_fields:
+        for doc in docs[1:6]:
+            val = str(doc.get(title_fields[0], "")).strip()
+            if 3 < len(val) < 100:
+                _add(val, "exact", "TERM")
+                break
+
+    # 2. Structured — filterable field:value
+    filter_candidates = [f for f in filterable_fields if f.lower() not in title_set]
+    if not filter_candidates and numeric_fields:
+        filter_candidates = numeric_fields[:2]
+    if filter_candidates:
+        for doc in docs[:10]:
+            for kf in filter_candidates:
+                val = doc.get(kf)
+                if val is None:
+                    continue
+                val_str = str(val).strip()
+                if val_str and len(val_str) < 60:
+                    _add(f"{kf}:{val_str}", "structured", "FILTER", field=kf)
+                    break
+            if sum(1 for m in meta if m["capability"] == "structured") >= 1:
+                break
+
+    # 3. Combined — text + filter (semantic + structured)
+    if has_semantic and filter_candidates and title_fields:
+        for doc in docs[3:10]:
+            title_val = str(doc.get(title_fields[0], "")).strip()
+            for kf in filter_candidates:
+                kf_val = doc.get(kf)
+                if kf_val is None:
+                    continue
+                kf_val_str = str(kf_val).strip()
+                if title_val and kf_val_str and len(kf_val_str) < 40:
+                    words = title_val.split()[:3]
+                    _add(f"{' '.join(words)} {kf}:{kf_val_str}", "combined", "HYBRID+FILTER")
+                    break
+            if sum(1 for m in meta if m["capability"] == "combined") >= 1:
+                break
+
+    # 4. Autocomplete — prefix of a title/name
+    if title_fields:
+        for doc in docs[2:8]:
+            val = str(doc.get(title_fields[0], "")).strip()
+            if len(val) > 5:
+                prefix = val[:max(4, len(val) // 3)]
+                _add(prefix, "autocomplete", "PREFIX", field=title_fields[0])
+                break
+
+    # 5. Fuzzy — intentional slight misspelling of a title
+    if title_fields:
+        for doc in docs[4:10]:
+            val = str(doc.get(title_fields[0], "")).strip()
+            words = val.split()
+            if words and len(words[0]) > 4:
+                # Swap two middle characters to create a typo
+                w = words[0]
+                mid = len(w) // 2
+                fuzzy_word = w[:mid-1] + w[mid] + w[mid-1] + w[mid+1:]
+                rest = " ".join(words[1:])
+                fuzzy_text = f"{fuzzy_word} {rest}".strip() if rest else fuzzy_word
+                _add(fuzzy_text, "fuzzy", "FUZZY")
+                break
+
+    # 6. Semantic — natural language query from descriptive text fields
+    if has_semantic:
+        # Find long text fields likely to contain descriptions
+        desc_fields = [f for f in text_fields if any(
+            h in f.lower() for h in ("overview", "description", "plot", "summary", "content", "body", "text", "abstract")
+        )]
+        if not desc_fields:
+            # Fall back to any text field that isn't a title
+            desc_fields = [f for f in text_fields if f.lower() not in title_set]
+        if desc_fields:
+            for doc in docs[:10]:
+                val = str(doc.get(desc_fields[0], "")).strip()
+                if len(val) < 20:
+                    continue
+                # Use the first sentence or clause as a natural query
+                for sep in ",;.—":
+                    pos = val.find(sep)
+                    if 15 < pos < 80:
+                        phrase = val[:pos].strip()
+                        break
+                else:
+                    # No sentence boundary — take first ~8 words
+                    words = val.split()
+                    phrase = " ".join(words[:min(8, len(words))]).rstrip(".,;:")
+                if 10 < len(phrase) < 120:
+                    _add(phrase, "semantic", "SEMANTIC")
+                    break
+
+    # 7. Another exact if we have room
+    if title_fields and len(meta) < max_count:
+        for doc in docs[5:12]:
+            val = str(doc.get(title_fields[0], "")).strip()
+            if 3 < len(val) < 100:
+                _add(val, "exact", "TERM")
+                if sum(1 for m in meta if m["capability"] == "exact") >= 2:
+                    break
+
+    return {
+        "suggestions": meta[:max_count],
+        "sample_docs": sample_docs,
+        "has_semantic": has_semantic,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Autocomplete
+# ---------------------------------------------------------------------------
+def _resolve_autocomplete_fields(
+    field_specs: dict[str, dict[str, str]],
+    preferred_field: str = "",
+    limit: int = 4,
+) -> list[str]:
+    selected: list[str] = []
+    seen: set[str] = set()
+
+    def _append(field_name: str) -> None:
+        normalized = normalize_text(field_name)
+        if not normalized or normalized in seen:
+            return
+        seen.add(normalized)
+        selected.append(normalized)
+
+    preferred = normalize_text(preferred_field)
+    if preferred:
+        resolved_field, resolved_spec = _resolve_field_spec_for_doc_key(preferred, field_specs)
+        candidate = resolved_field or preferred
+        candidate_type = str(resolved_spec.get("type", "")).strip().lower()
+        if candidate_type in {"keyword", "constant_keyword", "text"}:
+            _append(candidate)
+
+    keyword_fields = [
+        name for name, spec in field_specs.items()
+        if str(spec.get("type", "")).strip().lower() in {"keyword", "constant_keyword"}
+    ]
+    text_fields = [
+        name for name, spec in field_specs.items()
+        if str(spec.get("type", "")).strip().lower() == "text"
+    ]
+
+    def _rank(field_name: str) -> tuple[int, int, str]:
+        return (field_name.count("."), len(field_name), field_name)
+
+    for field_name in sorted(text_fields, key=_rank):
+        _append(field_name)
+        if len(selected) >= max(1, limit):
+            return selected
+    for field_name in sorted(keyword_fields, key=_rank):
+        _append(field_name)
+        if len(selected) >= max(1, limit):
+            return selected
+    return selected
+
+
+def _source_field_variants(field_name: str) -> list[str]:
+    normalized = normalize_text(field_name)
+    if not normalized:
+        return []
+    variants = [normalized]
+    if normalized.endswith(".keyword"):
+        base_field = normalized[:-8]
+        if base_field:
+            variants.insert(0, base_field)
+    return variants
+
+
+def _extract_values_from_source_by_path(source: object, field_path: str) -> list[object]:
+    path = normalize_text(field_path)
+    if not path:
+        return []
+    segments = [segment for segment in path.split(".") if segment]
+    if not segments:
+        return []
+    values: list[object] = []
+
+    def _walk(node: object, idx: int) -> None:
+        if idx >= len(segments):
+            if isinstance(node, list):
+                for item in node:
+                    _walk(item, idx)
+                return
+            if isinstance(node, dict) or node is None:
+                return
+            values.append(node)
+            return
+        if isinstance(node, list):
+            for item in node:
+                _walk(item, idx)
+            return
+        if isinstance(node, dict):
+            child = node.get(segments[idx])
+            if child is not None:
+                _walk(child, idx + 1)
+
+    _walk(source, 0)
+    return values
+
+
+def autocomplete(
+    client: OpenSearch, index_name: str, prefix_text: str,
+    size: int = 8, preferred_field: str = "",
+) -> dict[str, object]:
+    target_index = normalize_text(index_name)
+    prefix = normalize_text(prefix_text)
+    effective_size = max(1, min(size, 20))
+    if not target_index or not prefix:
+        return {"index": target_index, "prefix": prefix, "field": "", "options": [], "error": ""}
+
+    try:
+        field_specs = extract_index_field_specs(client, target_index)
+        fields = _resolve_autocomplete_fields(field_specs, preferred_field, limit=4)
+        if not fields:
+            return {"index": target_index, "prefix": prefix, "field": "", "options": [],
+                    "error": "No suitable autocomplete fields found."}
+
+        should_clauses = [{"prefix": {f: {"value": prefix.lower(), "case_insensitive": True}}} for f in fields]
+        body = {
+            "size": max(effective_size * 8, 24),
+            "query": {"bool": {"should": should_clauses, "minimum_should_match": 1}},
+        }
+        response = client.search(index=target_index, body=body)
+
+        options: list[str] = []
+        seen: set[str] = set()
+        prefix_lower = prefix.lower()
+
+        for hit in response.get("hits", {}).get("hits", []):
+            source = hit.get("_source", {})
+            if not isinstance(source, dict):
+                continue
+            for field_name in fields:
+                for variant in _source_field_variants(field_name):
+                    raw_values = _extract_values_from_source_by_path(source, variant)
+                    for raw_value in raw_values:
+                        candidate = normalize_text(raw_value)
+                        if not candidate or len(candidate) > 100 or not candidate.lower().startswith(prefix_lower):
+                            continue
+                        key = candidate.lower()
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        options.append(candidate[:120])
+                        if len(options) >= effective_size:
+                            return {"index": target_index, "prefix": prefix,
+                                    "field": fields[0], "options": options, "error": ""}
+
+        return {"index": target_index, "prefix": prefix, "field": fields[0] if fields else "",
+                "options": options, "error": ""}
+    except Exception as e:
+        return {"index": target_index, "prefix": prefix, "field": "", "options": [], "error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Search config: one query configuration per index from the execution plan
+# ---------------------------------------------------------------------------
+_search_configs: dict[str, dict] = {}
+
+
+def set_search_config(index_name: str, config: dict) -> None:
+    """Store the execution plan's query configuration for an index.
+
+    Config keys:
+        strategy: "bm25" | "neural_sparse" | "dense_vector" | "hybrid" | "agentic"
+        lexical_fields: list of field names (with optional ^boost)
+        vector_field: name of the vector/rank_features field (if semantic)
+        vector_type: "sparse" | "dense" (if semantic)
+        model_id: ML model ID for query-time encoding (if semantic)
+    """
+    _search_configs[index_name] = config
+
+
+def get_search_config(index_name: str) -> dict | None:
+    """Retrieve the stored search config for an index, or None."""
+    return _search_configs.get(index_name)
+
+
+def _introspect_search_config(client: OpenSearch, index_name: str) -> dict:
+    """Derive a search config by introspecting the index (fallback when no
+    execution plan config is available)."""
+    field_specs = extract_index_field_specs(client, index_name)
+    lexical_fields = _resolve_text_query_fields(field_specs)
+    hints = _resolve_semantic_runtime_hints(client, index_name, field_specs)
+
+    vector_field = hints.get("vector_field", "")
+    model_id = hints.get("model_id", "")
+    has_sparse = hints.get("has_sparse", "false") == "true"
+    has_neural = hints.get("has_neural_search_pipeline", "false") == "true"
+    has_agentic = hints.get("has_agentic_pipeline", "false") == "true"
+    semantic_ready = bool(vector_field and (model_id or (has_sparse and has_neural)))
+
+    has_search_pipeline = bool(hints.get("search_pipeline", ""))
+    if has_agentic:
+        strategy = "agentic"
+    elif semantic_ready and has_search_pipeline:
+        strategy = "hybrid"
+    elif semantic_ready:
+        strategy = "neural_sparse" if has_sparse else "dense_vector"
+    else:
+        strategy = "bm25"
+
+    return {
+        "strategy": strategy,
+        "lexical_fields": lexical_fields,
+        "vector_field": vector_field,
+        "vector_type": "sparse" if has_sparse else "dense",
+        "model_id": model_id,
+    }
+
+
+def _build_search_query(config: dict, query_text: str, size: int) -> dict:
+    """Build the search query clause from a search config and query text.
+
+    The same query structure is used for ALL query types (exact, fuzzy,
+    semantic, autocomplete) because the index's pipeline configuration
+    handles scoring and normalization.
+    """
+    strategy = config.get("strategy", "bm25")
+    lexical_fields = config.get("lexical_fields", ["*"])
+    vector_field = config.get("vector_field", "")
+    vector_type = config.get("vector_type", "sparse")
+    model_id = config.get("model_id", "")
+
+    lexical = _build_default_lexical_query(query_text, lexical_fields)
+
+    if strategy == "hybrid":
+        if vector_type == "sparse":
+            semantic = _build_neural_sparse_clause(query_text, vector_field, model_id)
+        else:
+            semantic = _build_neural_clause(query_text, vector_field, model_id, size)
+        return {"hybrid": {"queries": [lexical, semantic]}}
+    elif strategy == "neural_sparse":
+        return _build_neural_sparse_clause(query_text, vector_field, model_id)
+    elif strategy == "dense_vector":
+        return _build_neural_clause(query_text, vector_field, model_id, size)
+    elif strategy == "agentic":
+        return {"agentic": {"query_text": query_text}}
+    else:
+        return lexical
+
+
+# ---------------------------------------------------------------------------
+# Main search
+# ---------------------------------------------------------------------------
+def search_ui_search(
+    client: OpenSearch,
+    index_name: str,
+    query_text: str,
+    size: int = 20,
+    debug: bool = False,
+    search_intent: str = "",
+    field_hint: str = "",
+) -> dict:
+    empty_response = {
+        "error": "", "hits": [], "total": 0, "took_ms": 0,
+        "query_mode": "", "capability": "",
+        "used_semantic": False, "fallback_reason": "",
+    }
+
+    if not index_name:
+        empty_response["error"] = "Missing index name."
+        return empty_response
+
+    # Load execution plan config, or introspect once and cache
+    config = get_search_config(index_name)
+    if not config:
+        config = _introspect_search_config(client, index_name)
+        set_search_config(index_name, config)
+
+    strategy = config.get("strategy", "bm25")
+    query = query_text.strip()
+    fallback_reason = ""
+    used_semantic = strategy in ("hybrid", "neural_sparse", "dense_vector", "agentic")
+
+    if not query:
+        executed_body: dict = {"size": size, "query": {"match_all": {}}}
+        query_mode = "match_all"
+    else:
+        # Build query from the execution plan config — same for all queries
+        executed_body = {
+            "size": size,
+            "query": _build_search_query(config, query, size),
+        }
+        query_mode = strategy
+
+    try:
+        response = client.search(index=index_name, body=executed_body)
+    except Exception as query_error:
+        if query:
+            fallback_reason = f"primary query failed: {query_error}"
+            lexical_fields = config.get("lexical_fields", ["*"])
+            executed_body = _build_default_lexical_body(
+                query=query, size=size, fields=lexical_fields,
+            )
+            try:
+                response = client.search(index=index_name, body=executed_body)
+            except Exception:
+                executed_body = {
+                    "size": size,
+                    "query": {"multi_match": {"query": query, "fields": ["*"]}},
+                }
+                response = client.search(index=index_name, body=executed_body)
+            used_semantic = False
+            query_mode = f"{query_mode}_fallback_bm25"
+        else:
+            raise
+
+    capability = strategy
+
+    return _format_search_response(
+        response, query_mode, capability, used_semantic,
+        fallback_reason, executed_body if debug else None,
+    )
+
+
+def detect_index_profile(client: OpenSearch, index_name: str) -> dict:
+    """Analyze index to detect field categories, capabilities, and suggest a UI template."""
+    field_specs = extract_index_field_specs(client, index_name)
+    runtime_hints = _resolve_semantic_runtime_hints(client, index_name, field_specs)
+
+    text_fields = []
+    keyword_fields = []
+    numeric_fields = []
+    date_fields = []
+    vector_fields = []
+
+    for name, spec in field_specs.items():
+        ftype = spec.get("type", "")
+        if ftype == "text" and not name.endswith(".keyword"):
+            text_fields.append(name)
+        elif ftype in _KEYWORD_FIELD_TYPES and not name.endswith(".keyword"):
+            keyword_fields.append(name)
+        elif ftype in _NUMERIC_FIELD_TYPES:
+            numeric_fields.append(name)
+        elif ftype in ("date", "date_nanos"):
+            date_fields.append(name)
+        elif ftype in ("knn_vector", "rank_features"):
+            vector_fields.append(name)
+
+    has_agentic = runtime_hints.get("has_agentic_pipeline", "false") == "true"
+    has_sparse = runtime_hints.get("has_sparse", "false") == "true"
+    has_neural_search_pipeline = runtime_hints.get("has_neural_search_pipeline", "false") == "true"
+    has_semantic = bool(
+        (runtime_hints.get("vector_field") and (
+            runtime_hints.get("model_id") or (has_sparse and has_neural_search_pipeline)
+        ))
+        or has_neural_search_pipeline
+    )
+
+    capabilities = ["lexical"]
+    if has_semantic:
+        capabilities.insert(0, "semantic")
+    if has_agentic:
+        capabilities.insert(0, "agentic")
+    if keyword_fields or numeric_fields:
+        capabilities.append("structured")
+
+    # Detect image-like fields
+    _image_hints = {"image", "img", "poster", "photo", "thumbnail", "picture", "cover", "avatar", "logo", "icon"}
+    has_image_field = any(
+        any(hint in name.lower() for hint in _image_hints)
+        for name in field_specs
+    )
+
+    # Detect price/cost fields (strong ecommerce signal)
+    _price_hints = {"price", "cost", "msrp", "amount", "discount", "sale_price", "list_price"}
+    has_price_field = any(
+        any(hint in name.lower() for hint in _price_hints)
+        for name in numeric_fields
+    )
+
+    # Detect category/brand fields (ecommerce signal)
+    _ecommerce_hints = {"category", "brand", "sku", "product", "vendor", "manufacturer", "color", "size", "stock", "inventory"}
+    has_ecommerce_field = any(
+        any(hint in name.lower() for hint in _ecommerce_hints)
+        for name in keyword_fields
+    )
+
+    structured_count = len(keyword_fields) + len(numeric_fields) + len(date_fields)
+    # NOTE: agentic-chat and media templates are disabled in the UI for now.
+    # if has_agentic:
+    #     template = "agentic-chat"
+    # elif has_image_field and structured_count >= 2:
+    #     template = "media"
+    if has_price_field or (has_image_field and has_ecommerce_field):
+        template = "ecommerce"
+    elif text_fields or vector_fields:
+        template = "document"
+    else:
+        template = "document"
+
+    # Hide vector/embedding fields from UI-facing field lists
+    _embedding_hints = {"embedding", "vector", "knn", "dense_vector", "rank_features"}
+    _hidden = set(vector_fields)
+    for name in field_specs:
+        if any(h in name.lower() for h in _embedding_hints):
+            _hidden.add(name)
+
+    ui_fields = {n: s["type"] for n, s in field_specs.items() if n not in _hidden}
+    ui_field_specs = {n: s for n, s in field_specs.items() if n not in _hidden}
+
+    return {
+        "fields": ui_fields,
+        "field_specs": ui_field_specs,
+        "field_categories": {
+            "text": [f for f in text_fields if f not in _hidden],
+            "keyword": [f for f in keyword_fields if f not in _hidden],
+            "numeric": [f for f in numeric_fields if f not in _hidden],
+            "date": [f for f in date_fields if f not in _hidden],
+            "vector": vector_fields,
+        },
+        "capabilities": capabilities,
+        "suggested_template": template,
+        "has_semantic": has_semantic,
+        "has_agentic": has_agentic,
+    }
+
+
+def _format_search_response(
+    response: dict,
+    query_mode: str,
+    capability: str,
+    used_semantic: bool,
+    fallback_reason: str,
+    query_body: dict | None = None,
+) -> dict:
+    hits_out: list[dict] = []
+    for hit in response.get("hits", {}).get("hits", []):
+        source = hit.get("_source", {})
+        clean_source = _strip_vector_fields(source)
+        hits_out.append({
+            "id": hit.get("_id"),
+            "score": hit.get("_score"),
+            "preview": preview_text(source),
+            "source": clean_source,
+        })
+    result = {
+        "error": "",
+        "hits": hits_out,
+        "total": response.get("hits", {}).get("total", {}).get("value", len(hits_out)),
+        "took_ms": response.get("took", 0),
+        "query_mode": query_mode,
+        "capability": capability,
+        "used_semantic": used_semantic,
+        "fallback_reason": fallback_reason,
+    }
+    if query_body is not None:
+        result["query_body"] = query_body
+    return result

--- a/skills/opensearch-skills/scripts/lib/ui.py
+++ b/skills/opensearch-skills/scripts/lib/ui.py
@@ -1,0 +1,481 @@
+"""Search Builder UI server for Agent Skills standalone path.
+
+Serves the static React frontend and proxies search requests to OpenSearch.
+Matches the MCP path's full-featured search UI with smart field detection,
+semantic/hybrid search, agentic search, suggestions, and autocomplete.
+"""
+
+import json
+import os
+import re
+import signal
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from .client import create_client, can_connect
+from .search import (
+    autocomplete,
+    extract_index_field_specs,
+    generate_suggestions,
+    detect_index_profile,
+    search_ui_search,
+)
+
+SEARCH_UI_HOST = os.getenv("SEARCH_UI_HOST", "127.0.0.1")
+SEARCH_UI_PORT = int(os.getenv("SEARCH_UI_PORT", "8765"))
+
+# Find UI static assets - bundled alongside this script
+_SCRIPT_DIR = Path(__file__).resolve().parent.parent
+SEARCH_UI_STATIC_DIR = _SCRIPT_DIR / "ui"
+
+_CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".jsx": "application/javascript; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+}
+
+# Mutable state
+_default_index = ""
+_endpoint_override = {}  # {host, port, use_ssl, auth, aws_region, aws_service}
+_comparison_config = {
+    "comparison_enabled": False,
+    "baseline_index": "",
+    "improved_index": "",
+}
+
+
+def set_comparison_mode(baseline_index: str, improved_index: str) -> str:
+    """Configure the UI server for comparison mode.
+
+    Args:
+        baseline_index: The first index name.
+        improved_index: The second index name.
+
+    Returns:
+        Success message or error string.
+    """
+    global _comparison_config
+    if not baseline_index or not improved_index:
+        return "Both baseline and improved index names are required."
+    _comparison_config = {
+        "comparison_enabled": True,
+        "baseline_index": baseline_index,
+        "improved_index": improved_index,
+    }
+    return f"Comparison mode enabled: '{baseline_index}' vs '{improved_index}'."
+
+
+def clear_comparison_mode() -> str:
+    """Disable comparison mode and clear stored index names.
+
+    Returns:
+        Confirmation message.
+    """
+    global _comparison_config
+    _comparison_config = {
+        "comparison_enabled": False,
+        "baseline_index": "",
+        "improved_index": "",
+    }
+    return "Comparison mode disabled."
+
+
+def _get_client():
+    override = _endpoint_override
+    if override.get("host"):
+        from .client import create_remote_client
+        return create_remote_client(
+            endpoint=override["host"],
+            port=override.get("port", 443),
+            use_ssl=override.get("use_ssl", True),
+            username=override.get("username", ""),
+            password=override.get("password", ""),
+            aws_region=override.get("aws_region", ""),
+            aws_service=override.get("aws_service", ""),
+        )
+    return create_client()
+
+
+def _resolve_asset(path: str) -> Path | None:
+    if not SEARCH_UI_STATIC_DIR.exists():
+        return None
+    clean = path.lstrip("/") or "index.html"
+    target = (SEARCH_UI_STATIC_DIR / clean).resolve()
+    if target.is_file() and str(target).startswith(str(SEARCH_UI_STATIC_DIR)):
+        return target
+    return None
+
+
+class _UIHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass  # Suppress request logging
+
+    def _send_json(self, data: dict, status: int = 200):
+        body = json.dumps(data, default=str, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        # Health check
+        if parsed.path in ("/_health", "/api/health"):
+            backend = _get_backend_info()
+            self._send_json({
+                "ok": True,
+                "status": "running",
+                "default_index": _default_index,
+                "pid": os.getpid(),
+                "backend_type": backend["backend_type"],
+                "endpoint": backend["endpoint"],
+                "connected": backend["connected"],
+            })
+            return
+
+        # Config
+        if parsed.path == "/api/config":
+            backend = _get_backend_info()
+            self._send_json({
+                "default_index": _default_index,
+                "backend_type": backend["backend_type"],
+                "endpoint": backend["endpoint"],
+                "connected": backend["connected"],
+            })
+            return
+
+        # Comparison config
+        if parsed.path == "/api/comparison-config":
+            self._send_json(_comparison_config)
+            return
+
+        # List available indices
+        if parsed.path == "/api/indices":
+            try:
+                client = _get_client()
+                indices = sorted([
+                    idx for idx in client.cat.indices(format="json")
+                    if not str(idx.get("index", "")).startswith(".")
+                ], key=lambda x: x.get("index", ""))
+                self._send_json({
+                    "indices": [
+                        {"name": idx["index"], "docs": idx.get("docs.count", "0"), "health": idx.get("health", "")}
+                        for idx in indices
+                    ]
+                })
+            except Exception as e:
+                self._send_json({"indices": [], "error": str(e)})
+            return
+
+        # Suggestions
+        if parsed.path == "/api/suggestions":
+            index_name = (params.get("index") or [""])[0] or _default_index
+            try:
+                client = _get_client()
+                gen = generate_suggestions(client, index_name, max_count=8)
+                result = {
+                    "suggestions": gen.get("suggestions", []),
+                    "sample_docs": gen.get("sample_docs", []),
+                    "has_semantic": gen.get("has_semantic", False),
+                    "index": index_name,
+                }
+                self._send_json(result)
+            except Exception as e:
+                self._send_json({"suggestions": [], "sample_docs": [], "has_semantic": False, "index": index_name, "error": str(e)})
+            return
+
+        # Autocomplete
+        if parsed.path == "/api/autocomplete":
+            index_name = (params.get("index") or [""])[0] or _default_index
+            prefix_text = (params.get("q") or [""])[0]
+            field_name = (params.get("field") or [""])[0]
+            try:
+                ac_size = int((params.get("size") or ["8"])[0])
+            except ValueError:
+                ac_size = 8
+            ac_size = max(1, min(ac_size, 20))
+            try:
+                client = _get_client()
+                result = autocomplete(
+                    client, index_name, prefix_text,
+                    size=ac_size, preferred_field=field_name,
+                )
+                self._send_json(result)
+            except Exception as e:
+                self._send_json({
+                    "index": index_name, "prefix": prefix_text,
+                    "field": "", "options": [], "error": str(e),
+                })
+            return
+
+        # Schema / template detection
+        if parsed.path == "/api/schema":
+            index_name = (params.get("index") or [""])[0] or _default_index
+            if not index_name:
+                self._send_json({"error": "No index specified."}, 400)
+                return
+            try:
+                client = _get_client()
+                schema = detect_index_profile(client, index_name)
+                schema["index"] = index_name
+                self._send_json(schema)
+            except Exception as e:
+                self._send_json({"error": str(e)}, 500)
+            return
+
+        # Search API
+        if parsed.path == "/api/search":
+            self._handle_search(params)
+            return
+
+        # Static file
+        asset = _resolve_asset(parsed.path)
+        if asset is None:
+            asset = _resolve_asset("/index.html")
+        if asset is None:
+            self.send_error(404)
+            return
+
+        content_type = _CONTENT_TYPES.get(asset.suffix, "application/octet-stream")
+        body = asset.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/search":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length else {}
+            self._handle_search_post(body)
+            return
+        self.send_error(404)
+
+    def _handle_search(self, params: dict):
+        query = (params.get("q") or params.get("query") or [""])[0]
+        index = (params.get("index") or [_default_index])[0] or _default_index
+        search_intent = (params.get("intent") or [""])[0]
+        field_hint = (params.get("field") or [""])[0]
+        debug_param = (params.get("debug") or ["0"])[0].strip().lower()
+        debug_mode = debug_param in {"1", "true", "yes", "on"}
+        try:
+            size = int((params.get("size") or ["20"])[0])
+        except ValueError:
+            size = 20
+        size = max(1, min(size, 50))
+
+        if not index:
+            self._send_json({"error": "No index specified."}, 400)
+            return
+
+        try:
+            client = _get_client()
+            result = search_ui_search(
+                client=client,
+                index_name=index,
+                query_text=query,
+                size=size,
+                debug=debug_mode,
+                search_intent=search_intent,
+                field_hint=field_hint,
+            )
+            self._send_json(result)
+        except Exception as e:
+            self._send_json({
+                "error": str(e),
+                "hits": [], "took_ms": 0,
+                "query_mode": "", "capability": "",
+                "used_semantic": False, "fallback_reason": "",
+            }, status=500)
+
+    def _handle_search_post(self, body: dict):
+        index = body.pop("index", _default_index) or _default_index
+        size = body.pop("size", 20)
+        if not index:
+            self._send_json({"error": "No index specified."}, 400)
+            return
+        try:
+            client = _get_client()
+            # If the POST body has a "query" key, treat as raw DSL pass-through
+            if "query" in body:
+                result = client.search(index=index, body=body, size=size)
+                self._send_json(result)
+            else:
+                # Otherwise treat as a structured search request
+                query_text = body.get("q", body.get("query_text", ""))
+                debug = body.get("debug", False)
+                result = search_ui_search(
+                    client=client,
+                    index_name=index,
+                    query_text=query_text,
+                    size=size,
+                    debug=debug,
+                )
+                self._send_json(result)
+        except Exception as e:
+            self._send_json({"error": str(e)}, 500)
+
+
+def _get_backend_info() -> dict:
+    override = _endpoint_override
+    if override.get("host"):
+        endpoint = override["host"]
+        backend_type = "aws" if override.get("aws_region") else "remote"
+        try:
+            client = _get_client()
+            ok, _ = can_connect(client)
+            connected = ok
+        except Exception:
+            connected = False
+        return {"backend_type": backend_type, "endpoint": endpoint, "connected": connected}
+    from .client import OPENSEARCH_HOST, OPENSEARCH_PORT
+    endpoint = f"{OPENSEARCH_HOST}:{OPENSEARCH_PORT}"
+    try:
+        client = _get_client()
+        ok, _ = can_connect(client)
+        connected = ok
+    except Exception:
+        connected = False
+    return {"backend_type": "local", "endpoint": endpoint, "connected": connected}
+
+
+def _kill_existing_ui() -> None:
+    """Kill any existing process listening on the UI port."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f"tcp:{SEARCH_UI_PORT}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        pids = result.stdout.strip().split()
+        for pid in pids:
+            if pid.isdigit() and int(pid) != os.getpid():
+                os.kill(int(pid), signal.SIGTERM)
+        if pids:
+            time.sleep(0.5)
+    except Exception:
+        pass
+
+
+def launch_ui(index_name: str = "") -> str:
+    global _default_index
+    if index_name:
+        _default_index = index_name
+
+    if not SEARCH_UI_STATIC_DIR.exists():
+        return (
+            f"Error: Search UI static directory not found at {SEARCH_UI_STATIC_DIR}. "
+            "Make sure you have the full opensearch-skills skill directory."
+        )
+
+    # Kill any existing UI server on the same port
+    _kill_existing_ui()
+
+    try:
+        server = ThreadingHTTPServer((SEARCH_UI_HOST, SEARCH_UI_PORT), _UIHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        url = f"http://{SEARCH_UI_HOST}:{SEARCH_UI_PORT}"
+
+        # Wait for ready
+        import urllib.request
+        for _ in range(20):
+            try:
+                urllib.request.urlopen(f"{url}/_health", timeout=1)
+                break
+            except Exception:
+                time.sleep(0.25)
+
+        msg = f"Search Builder UI started at: {url}"
+        if _default_index:
+            msg += f"\nDefault index: {_default_index}"
+        return msg
+
+    except OSError as e:
+        if "Address already in use" in str(e):
+            url = f"http://{SEARCH_UI_HOST}:{SEARCH_UI_PORT}"
+            return f"Search Builder UI already running at: {url}"
+        return f"Failed to start Search UI: {e}"
+
+
+def connect_ui(
+    endpoint: str,
+    port: int = 443,
+    use_ssl: bool = True,
+    username: str = "",
+    password: str = "",
+    aws_region: str = "",
+    aws_service: str = "",
+    index_name: str = "",
+) -> str:
+    global _default_index, _endpoint_override
+
+    if not endpoint:
+        return "Error: endpoint is required."
+
+    # Auto-detect AWS service from endpoint
+    if not aws_service and aws_region:
+        if ".aoss." in endpoint:
+            aws_service = "aoss"
+        elif ".es." in endpoint or ".aos." in endpoint:
+            aws_service = "es"
+    if not aws_region and (".aoss." in endpoint or ".es." in endpoint):
+        m = re.search(r"\.([a-z]{2}-[a-z]+-\d+)\.", endpoint)
+        if m:
+            aws_region = m.group(1)
+            if not aws_service:
+                aws_service = "aoss" if ".aoss." in endpoint else "es"
+
+    _endpoint_override = {
+        "host": endpoint, "port": port, "use_ssl": use_ssl,
+        "username": username, "password": password,
+        "aws_region": aws_region, "aws_service": aws_service,
+    }
+
+    # Verify connectivity
+    try:
+        from .client import create_remote_client
+        client = create_remote_client(
+            endpoint, port, use_ssl, username, password, aws_region, aws_service
+        )
+        ok, _ = can_connect(client)
+        if not ok:
+            _endpoint_override = {}
+            return f"Error: Could not connect to {endpoint}:{port}."
+    except Exception as e:
+        _endpoint_override = {}
+        return f"Error connecting: {e}"
+
+    if index_name:
+        _default_index = index_name
+
+    auth_mode = f"SigV4 ({aws_service}/{aws_region})" if aws_region else "basic" if username else "none"
+    return f"Search UI connected to {endpoint} (auth: {auth_mode})"
+
+
+def cleanup_ui() -> str:
+    """Clean up the UI server and clear any stored cluster credentials."""
+    from .client import clear_cluster_credentials
+    clear_cluster_credentials()
+    return "Search UI cleanup: the UI server runs as a daemon thread and stops when the script exits. Cluster credentials cleared."

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["opensearch-py>=2.4"]
+# ///
+"""Standalone CLI for OpenSearch operations.
+
+No dependency on the opensearch-mcp-server or opensearch_orchestrator.
+Uses opensearch-py directly via the lib/ modules in this directory.
+
+Usage:
+    uv run python scripts/opensearch_ops.py <command> [options]
+
+Commands:
+    status                 Check OpenSearch connectivity
+    preflight-check        Check if OpenSearch cluster is already running
+    create-index           Create an index with mappings
+    deploy-model           Deploy a local pretrained ML model
+    deploy-bedrock         Register a Bedrock embedding model
+    create-pipeline        Create and attach an ingest/search pipeline
+    index-doc              Index a single document
+    index-bulk             Bulk index documents from sample data
+    launch-ui              Launch the Search Builder UI
+    connect-ui             Connect Search UI to a remote endpoint
+    search                 Run a search query
+    load-sample            Load sample data (file, URL, builtin IMDB)
+    cleanup                Stop UI and clean up
+    read-knowledge         Read a knowledge base reference file
+    deploy-agentic-model   Deploy a Bedrock Claude model for agentic search
+    create-flow-agent      Create a flow agent for agentic search
+    create-agentic-pipeline Create and attach an agentic search pipeline
+    search-docs            Search documentation via DuckDuckGo (default: opensearch.org)
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# Ensure the scripts directory is on sys.path for lib/ imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+def cmd_status(args):
+    from lib.client import create_client, can_connect, build_client, resolve_http_auth
+    try:
+        http_auth = resolve_http_auth()
+        for use_ssl in (True, False):
+            client = build_client(use_ssl=use_ssl, http_auth=http_auth)
+            ok, _ = can_connect(client)
+            if ok:
+                proto = "https" if use_ssl else "http"
+                print(json.dumps({"reachable": True, "endpoint": f"{proto}://localhost:9200"}))
+                return
+        print(json.dumps({"reachable": False}))
+    except Exception as e:
+        print(json.dumps({"reachable": False, "error": str(e)}))
+
+
+def cmd_preflight_check(args):
+    from lib.client import preflight_check_cluster
+    result = preflight_check_cluster(
+        auth_mode=args.auth_mode or "",
+        username=args.username or "",
+        password=args.password or "",
+    )
+    print(json.dumps(result, indent=2))
+
+
+def cmd_create_index(args):
+    from lib.operations import create_index
+    body = json.loads(args.body) if args.body else {}
+    print(create_index(args.name, body, args.replace))
+
+
+def cmd_deploy_model(args):
+    from lib.operations import deploy_local_model
+    print(deploy_local_model(args.name))
+
+
+def cmd_deploy_bedrock(args):
+    from lib.operations import deploy_bedrock_model
+    print(deploy_bedrock_model(args.name))
+
+
+def cmd_create_pipeline(args):
+    from lib.operations import create_pipeline
+    body = json.loads(args.body) if args.body else {}
+    print(create_pipeline(
+        pipeline_name=args.name,
+        pipeline_body=body,
+        index_name=args.index,
+        pipeline_type=args.type,
+        is_hybrid=args.hybrid,
+        hybrid_weights=json.loads(args.weights) if args.weights else None,
+    ))
+
+
+def cmd_index_doc(args):
+    from lib.operations import index_doc
+    doc = json.loads(args.doc)
+    print(index_doc(args.index, doc, args.id))
+
+
+def cmd_index_bulk(args):
+    from lib.samples import _load_records_from_file
+    from lib.operations import index_bulk
+    from pathlib import Path
+
+    if args.source_file:
+        records, err = _load_records_from_file(Path(args.source_file), limit=args.count)
+        if err:
+            print(json.dumps({"error": err}))
+            return
+    else:
+        print(json.dumps({"error": "Provide --source-file for bulk indexing."}))
+        return
+
+    print(index_bulk(args.index, records[:args.count], id_prefix="verification"))
+
+
+def cmd_launch_ui(args):
+    from lib.ui import launch_ui
+    result = launch_ui(args.index or "")
+    print(result)
+    if "started" in result.lower() or "running" in result.lower():
+        # Keep process alive while UI is running
+        try:
+            print("Press Ctrl+C to stop the UI server.", file=sys.stderr)
+            import time
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("\nStopping UI server.", file=sys.stderr)
+
+
+def cmd_connect_ui(args):
+    from lib.ui import connect_ui
+    print(connect_ui(
+        endpoint=args.endpoint,
+        port=args.port,
+        use_ssl=not args.no_ssl,
+        username=args.username or "",
+        password=args.password or "",
+        aws_region=args.aws_region or "",
+        aws_service=args.aws_service or "",
+        index_name=args.index or "",
+    ))
+
+
+def cmd_search(args):
+    from lib.client import create_client
+    from lib.operations import search
+    client = create_client()
+    body = json.loads(args.body) if args.body else None
+    result = search(client, args.index, body, args.size)
+    print(json.dumps(result, default=str, ensure_ascii=False, indent=2))
+
+
+def cmd_load_sample(args):
+    from lib.samples import (
+        load_sample_builtin_imdb,
+        load_sample_from_file,
+        load_sample_from_url,
+        load_sample_from_index,
+        load_sample_from_paste,
+    )
+    dispatch = {
+        "builtin_imdb": lambda: load_sample_builtin_imdb(),
+        "local_file": lambda: load_sample_from_file(args.value),
+        "url": lambda: load_sample_from_url(args.value),
+        "localhost_index": lambda: load_sample_from_index(args.value),
+        "paste": lambda: load_sample_from_paste(args.value),
+    }
+    fn = dispatch.get(args.type)
+    if fn:
+        print(fn())
+    else:
+        print(json.dumps({"error": f"Unknown source type: {args.type}"}))
+
+
+def cmd_cleanup(args):
+    from lib.ui import cleanup_ui
+    print(cleanup_ui())
+
+
+def cmd_read_knowledge(args):
+    knowledge_dir = os.path.join(
+        os.path.dirname(__file__), "..", "references", "knowledge"
+    )
+    target = os.path.join(knowledge_dir, args.file)
+    if not os.path.isfile(target):
+        available = os.listdir(knowledge_dir) if os.path.isdir(knowledge_dir) else []
+        print(f"File not found: {args.file}. Available: {available}", file=sys.stderr)
+        sys.exit(1)
+    with open(target) as f:
+        print(f.read())
+
+
+def cmd_deploy_agentic_model(args):
+    from lib.operations import deploy_agentic_model
+    result = deploy_agentic_model(
+        access_key=args.access_key or os.getenv("AWS_ACCESS_KEY_ID", ""),
+        secret_key=args.secret_key or os.getenv("AWS_SECRET_ACCESS_KEY", ""),
+        region=args.region,
+        session_token=args.session_token or os.getenv("AWS_SESSION_TOKEN", ""),
+        model_name=args.model_name,
+    )
+    print(result)
+
+
+def cmd_search_docs(args):
+    """Search documentation via DuckDuckGo with site restriction."""
+    import re as _re
+    from html import unescape
+    from urllib.parse import parse_qs, quote_plus, urlparse
+    from urllib.request import Request, urlopen
+
+    def _strip_html(text):
+        return _re.sub(r"<[^>]+>", "", text)
+
+    def _normalize_text(text):
+        return _re.sub(r"\s+", " ", text).strip()
+
+    def _decode_redirect(url):
+        parsed = urlparse(url)
+        if parsed.netloc.endswith("duckduckgo.com") and parsed.path.startswith("/l/"):
+            target = parse_qs(parsed.query).get("uddg", [None])[0]
+            if target:
+                return target
+        return url
+
+    try:
+        query = args.query
+        site = args.site
+        limit = max(1, min(args.count, 10))
+        site_prefix = f"site:{site} " if site else ""
+        search_query = quote_plus(f"{site_prefix}{query}")
+        url = f"https://duckduckgo.com/html/?q={search_query}"
+        req = Request(url, headers={"User-Agent": "Mozilla/5.0 (compatible; OpenSearchSkill/1.0)"})
+
+        with urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="ignore")
+
+        titles = _re.findall(
+            r'<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>',
+            html, flags=_re.IGNORECASE | _re.DOTALL,
+        )
+        snippets_raw = _re.findall(
+            r'<a[^>]*class="result__snippet"[^>]*>(.*?)</a>|'
+            r'<div[^>]*class="result__snippet"[^>]*>(.*?)</div>',
+            html, flags=_re.IGNORECASE | _re.DOTALL,
+        )
+        snippets = [left or right for left, right in snippets_raw]
+
+        filter_domain = site.lower() if site else None
+        results = []
+        for idx, (raw_href, raw_title) in enumerate(titles):
+            href = _decode_redirect(unescape(raw_href))
+            if filter_domain and filter_domain not in urlparse(href).netloc.lower():
+                continue
+            title = _normalize_text(unescape(_strip_html(raw_title)))
+            snippet = ""
+            if idx < len(snippets):
+                snippet = _normalize_text(unescape(_strip_html(snippets[idx])))
+            results.append({"title": title, "url": href, "snippet": snippet})
+            if len(results) >= limit:
+                break
+
+        print(json.dumps({"query": query, "site": site, "results": results}, ensure_ascii=False, indent=2))
+    except Exception as e:
+        print(json.dumps({"query": args.query, "site": args.site, "results": [], "error": str(e)}))
+
+
+def cmd_create_flow_agent(args):
+    from lib.operations import create_flow_agent
+    print(create_flow_agent(args.name, args.model_id))
+def cmd_compare_ui(args):
+    from lib.ui import set_comparison_mode, launch_ui
+    result = set_comparison_mode(args.baseline, args.improved)
+    print(result)
+    if "Error" in result or "required" in result.lower():
+        sys.exit(1)
+    ui_result = launch_ui(args.improved)
+    print(ui_result)
+    if "started" in ui_result.lower() or "running" in ui_result.lower():
+        try:
+            print("Press Ctrl+C to stop the UI server.", file=sys.stderr)
+            import time
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("\nStopping UI server.", file=sys.stderr)
+
+
+
+
+
+def cmd_create_agentic_pipeline(args):
+    from lib.operations import create_agentic_pipeline
+    print(create_agentic_pipeline(args.name, args.agent_id, args.index))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="OpenSearch operations CLI (standalone)", allow_abbrev=False)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # status
+    sub.add_parser("status", help="Check OpenSearch connectivity")
+
+    # preflight-check
+    p = sub.add_parser("preflight-check", help="Check if OpenSearch cluster is already running")
+    p.add_argument("--auth-mode", default="", choices=["", "none", "default", "custom"],
+                   help="Authentication mode: auto-detect (default), none, default, or custom")
+    p.add_argument("--username", default="", help="Username for custom auth mode")
+    p.add_argument("--password", default="", help="Password for custom auth mode")
+
+    # create-index
+    p = sub.add_parser("create-index", help="Create an index")
+    p.add_argument("--name", required=True)
+    p.add_argument("--body", default="{}", help="JSON index body")
+    p.add_argument("--replace", action="store_true", default=True)
+
+    # deploy-model
+    p = sub.add_parser("deploy-model", help="Deploy a local pretrained model")
+    p.add_argument("--name", required=True)
+
+    # deploy-bedrock
+    p = sub.add_parser("deploy-bedrock", help="Register a Bedrock embedding model")
+    p.add_argument("--name", required=True)
+
+    # create-pipeline
+    p = sub.add_parser("create-pipeline", help="Create and attach a pipeline")
+    p.add_argument("--name", required=True)
+    p.add_argument("--body", default="{}", help="JSON pipeline body")
+    p.add_argument("--index", required=True)
+    p.add_argument("--type", default="ingest", choices=["ingest", "search"])
+    p.add_argument("--hybrid", action="store_true")
+    p.add_argument("--weights", default=None, help="JSON [lexical, semantic]")
+
+    # index-doc
+    p = sub.add_parser("index-doc", help="Index a single document")
+    p.add_argument("--index", required=True)
+    p.add_argument("--doc", required=True, help="JSON document")
+    p.add_argument("--id", required=True)
+
+    # index-bulk
+    p = sub.add_parser("index-bulk", help="Bulk index docs from a file")
+    p.add_argument("--index", required=True)
+    p.add_argument("--count", type=int, default=20)
+    p.add_argument("--source-file", required=True, help="Local file path")
+
+    # launch-ui
+    p = sub.add_parser("launch-ui", help="Launch Search Builder UI")
+    p.add_argument("--index", default="")
+
+    # connect-ui
+    p = sub.add_parser("connect-ui", help="Connect UI to remote endpoint")
+    p.add_argument("--endpoint", required=True)
+    p.add_argument("--port", type=int, default=443)
+    p.add_argument("--no-ssl", action="store_true")
+    p.add_argument("--username", default="")
+    p.add_argument("--password", default="")
+    p.add_argument("--aws-region", default="")
+    p.add_argument("--aws-service", default="")
+    p.add_argument("--index", default="")
+
+    # search
+    p = sub.add_parser("search", help="Run a search query")
+    p.add_argument("--index", required=True)
+    p.add_argument("--body", default=None, help="JSON search body")
+    p.add_argument("--size", type=int, default=10)
+
+    # load-sample
+    p = sub.add_parser("load-sample", help="Load sample documents")
+    p.add_argument("-t", "--type", required=True,
+                    choices=["builtin_imdb", "local_file", "url", "localhost_index", "paste"])
+    p.add_argument("-v", "--value", default="")
+
+    # cleanup
+    sub.add_parser("cleanup", help="Stop UI and clean up")
+
+    # read-knowledge
+    p = sub.add_parser("read-knowledge", help="Read a knowledge base file")
+    p.add_argument("--file", required=True)
+
+    # deploy-agentic-model
+    p = sub.add_parser("deploy-agentic-model", help="Deploy Bedrock Claude for agentic search")
+    p.add_argument("--access-key", default="")
+    p.add_argument("--secret-key", default="")
+    p.add_argument("--region", default="us-east-1")
+    p.add_argument("--session-token", default="")
+    p.add_argument("--model-name", default="us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+    # compare-ui
+    p = sub.add_parser("compare-ui", help="Launch Search Builder UI in comparison mode")
+    p.add_argument("--baseline", required=True, help="Baseline index name (before evaluation)")
+    p.add_argument("--improved", required=True, help="Improved index name (after evaluation)")
+
+    # create-flow-agent
+    p = sub.add_parser("create-flow-agent", help="Create a flow agent for agentic search")
+    p.add_argument("--name", required=True)
+    p.add_argument("--model-id", required=True)
+
+    # search-docs
+    p = sub.add_parser("search-docs", help="Search documentation via DuckDuckGo")
+    p.add_argument("--query", required=True, help="Search query")
+    p.add_argument("--site", default="opensearch.org", help="Site to restrict search to (default: opensearch.org)")
+    p.add_argument("--count", type=int, default=5, help="Max results (1-10)")
+
+    # create-agentic-pipeline
+    p = sub.add_parser("create-agentic-pipeline", help="Create agentic search pipeline")
+    p.add_argument("--name", required=True)
+    p.add_argument("--agent-id", required=True)
+    p.add_argument("--index", required=True)
+
+    args = parser.parse_args()
+
+    dispatch = {
+        "status": cmd_status,
+        "preflight-check": cmd_preflight_check,
+        "create-index": cmd_create_index,
+        "deploy-model": cmd_deploy_model,
+        "deploy-bedrock": cmd_deploy_bedrock,
+        "create-pipeline": cmd_create_pipeline,
+        "index-doc": cmd_index_doc,
+        "index-bulk": cmd_index_bulk,
+        "launch-ui": cmd_launch_ui,
+        "connect-ui": cmd_connect_ui,
+        "compare-ui": cmd_compare_ui,
+        "search": cmd_search,
+        "load-sample": cmd_load_sample,
+        "cleanup": cmd_cleanup,
+        "read-knowledge": cmd_read_knowledge,
+        "deploy-agentic-model": cmd_deploy_agentic_model,
+        "create-flow-agent": cmd_create_flow_agent,
+        "create-agentic-pipeline": cmd_create_agentic_pipeline,
+        "search-docs": cmd_search_docs,
+    }
+
+    fn = dispatch.get(args.command)
+    if fn:
+        fn(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/opensearch-skills/scripts/start_opensearch.sh
+++ b/skills/opensearch-skills/scripts/start_opensearch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Start a local OpenSearch single-node cluster in Docker.
+# Usage: ./start_opensearch.sh [--security]
+#   --security  Enable the security plugin (HTTPS + auth). Default is disabled.
+#
+# Outputs JSON status to stdout.
+
+set -euo pipefail
+
+CONTAINER_NAME="opensearch-node"
+IMAGE="opensearchproject/opensearch:latest"
+PORT=9200
+DISABLE_SECURITY="true"
+PROTOCOL="http"
+CREDS=""
+
+if [[ "${1:-}" == "--security" ]]; then
+    DISABLE_SECURITY="false"
+    PROTOCOL="https"
+    CREDS=" (user: admin, pass: myStrongPassword123!)"
+fi
+
+# Already running?
+if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "{\"status\":\"already_running\",\"endpoint\":\"${PROTOCOL}://localhost:${PORT}\"}"
+    exit 0
+fi
+
+# Remove stopped container if leftover
+docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+echo "Starting OpenSearch..." >&2
+
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "${PORT}:9200" \
+    -p 9600:9600 \
+    -e "discovery.type=single-node" \
+    -e "DISABLE_SECURITY_PLUGIN=${DISABLE_SECURITY}" \
+    -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!" \
+    "$IMAGE" >/dev/null
+
+# Wait for healthy
+for i in $(seq 1 30); do
+    if curl -sk -o /dev/null -w "%{http_code}" "${PROTOCOL}://localhost:${PORT}" 2>/dev/null | grep -qE "200|401"; then
+        echo "{\"status\":\"started\",\"endpoint\":\"${PROTOCOL}://localhost:${PORT}\"${CREDS:+,\"credentials\":\"admin / myStrongPassword123!\"}}"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "{\"status\":\"error\",\"message\":\"OpenSearch did not start within 60 seconds\"}"
+exit 1

--- a/skills/opensearch-skills/scripts/ui/app.jsx
+++ b/skills/opensearch-skills/scripts/ui/app.jsx
@@ -1,0 +1,1158 @@
+const { useEffect, useState, useRef, useCallback } = React;
+
+const TEMPLATES = [
+  { id: "document", label: "Document" },
+  { id: "ecommerce", label: "E-Commerce" },
+  { id: "agentic-chat", label: "Conversational", disabled: true },
+  { id: "media", label: "Media", disabled: true },
+];
+
+function TemplateIcon({ id }) {
+  const size = 32;
+  if (id === "document") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+      </svg>
+    );
+  }
+  if (id === "ecommerce") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/>
+      </svg>
+    );
+  }
+  if (id === "agentic-chat") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+      </svg>
+    );
+  }
+  if (id === "media") {
+    return (
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/>
+      </svg>
+    );
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Field role inference for ecommerce/media templates
+// ---------------------------------------------------------------------------
+const TITLE_HINTS = ["title", "name", "label", "heading", "subject"];
+const IMAGE_HINTS = ["image", "img", "poster", "photo", "thumbnail", "picture", "cover", "avatar", "logo"];
+const DESC_HINTS = ["description", "summary", "overview", "abstract", "content", "body", "text", "plot"];
+
+function inferFieldRoles(source, schema, fieldOverrides) {
+  const roles = { title: null, image: null, description: null, tags: [], metrics: [] };
+  if (!source) return roles;
+
+  // Apply user overrides first
+  if (fieldOverrides) {
+    if (fieldOverrides.title && fieldOverrides.title !== "(none)" && source[fieldOverrides.title] != null) {
+      roles.title = { field: fieldOverrides.title, value: String(source[fieldOverrides.title]) };
+    }
+    if (fieldOverrides.description && fieldOverrides.description !== "(none)" && source[fieldOverrides.description] != null) {
+      roles.description = { field: fieldOverrides.description, value: String(source[fieldOverrides.description]) };
+    }
+    if (fieldOverrides.image && fieldOverrides.image !== "(none)" && source[fieldOverrides.image] != null) {
+      roles.image = { field: fieldOverrides.image, value: String(source[fieldOverrides.image]) };
+    }
+  }
+
+  const fieldCategories = schema?.field_categories || {};
+  const keywordFields = new Set(fieldCategories.keyword || []);
+  const numericFields = new Set(fieldCategories.numeric || []);
+
+  for (const [key, val] of Object.entries(source)) {
+    if (val == null || typeof val === "object") continue;
+    const lower = key.toLowerCase();
+    const strVal = String(val);
+
+    if (!roles.title && TITLE_HINTS.some((h) => lower.includes(h)) && strVal.length < 200) {
+      roles.title = { field: key, value: strVal };
+      continue;
+    }
+    if (!roles.image && (IMAGE_HINTS.some((h) => lower.includes(h)) || /^https?:\/\/.+\.(jpe?g|png|gif|webp|svg)/i.test(strVal))) {
+      roles.image = { field: key, value: strVal };
+      continue;
+    }
+    if (!roles.description && DESC_HINTS.some((h) => lower.includes(h)) && strVal.length > 20) {
+      roles.description = { field: key, value: strVal };
+      continue;
+    }
+    if (keywordFields.has(key) && strVal.length < 60) {
+      roles.tags.push({ field: key, value: strVal });
+    } else if (numericFields.has(key)) {
+      roles.metrics.push({ field: key, value: val });
+    }
+  }
+
+  // Fallback: use first short text as title, first long text as description
+  if (!roles.title || !roles.description) {
+    for (const [key, val] of Object.entries(source)) {
+      if (val == null || typeof val === "object") continue;
+      const strVal = String(val);
+      if (!roles.title && strVal.length >= 3 && strVal.length < 120 && /[a-zA-Z]/.test(strVal)) {
+        roles.title = { field: key, value: strVal };
+      } else if (!roles.description && strVal.length > 40) {
+        roles.description = { field: key, value: strVal.slice(0, 300) };
+      }
+      if (roles.title && roles.description) break;
+    }
+  }
+
+  return roles;
+}
+
+// ---------------------------------------------------------------------------
+// Template: Ecommerce (grid cards with images, tags, metrics)
+// ---------------------------------------------------------------------------
+function EcommerceResults({ results, loading, schema, fieldOverrides, filterSource }) {
+  if (loading) return null;
+  return (
+    <div className="ecommerce-grid">
+      {results.map((item, idx) => {
+        const displaySource = filterSource ? filterSource(item.source) : item.source;
+        const roles = inferFieldRoles(displaySource, schema, fieldOverrides);
+        return (
+          <article className="ecommerce-card" key={item.id || idx} style={{ animationDelay: `${idx * 40}ms` }}>
+            {roles.image && (
+              <div className="ecommerce-image">
+                <img src={roles.image.value} alt="" loading="lazy" onError={(e) => { e.target.style.display = "none"; }} />
+              </div>
+            )}
+            <div className="ecommerce-body">
+              <div className="ecommerce-title">{roles.title?.value || item.preview || item.id}</div>
+              {roles.description && (
+                <div className="ecommerce-desc">{roles.description.value}</div>
+              )}
+              {roles.tags.length > 0 && (
+                <div className="ecommerce-tags">
+                  {roles.tags.slice(0, 5).map((tag) => (
+                    <span key={tag.field} className="ecommerce-tag" title={tag.field}>{tag.value}</span>
+                  ))}
+                </div>
+              )}
+              <div className="ecommerce-footer">
+                {roles.metrics.slice(0, 3).map((m) => (
+                  <span key={m.field} className="ecommerce-metric" title={m.field}>
+                    {m.field}: <strong>{m.value}</strong>
+                  </span>
+                ))}
+                <span className="score">score {Number(item.score || 0).toFixed(3)}</span>
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template: Document Search (list with large previews, score bars)
+// ---------------------------------------------------------------------------
+function DocumentResults({ results, loading, filterSource }) {
+  if (loading) return null;
+  const maxScore = results.length > 0 ? Math.max(...results.map((r) => Number(r.score || 0)), 0.001) : 1;
+  return (
+    <div className="results doc-results">
+      {results.map((item, idx) => {
+        const pct = Math.round((Number(item.score || 0) / maxScore) * 100);
+        return (
+          <article className="doc-card" key={item.id || idx} style={{ animationDelay: `${idx * 35}ms` }}>
+            <div className="doc-score-col">
+              <div className="doc-score-bar-bg">
+                <div className="doc-score-bar-fill" style={{ height: `${pct}%` }} />
+              </div>
+              <span className="doc-score-label">{Number(item.score || 0).toFixed(2)}</span>
+            </div>
+            <div className="doc-content">
+              <div className="doc-id">ID: {item.id || "(none)"}</div>
+              <details>
+                <summary>Full document</summary>
+                <pre>{JSON.stringify(filterSource ? filterSource(item.source) : item.source, null, 2)}</pre>
+              </details>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Template: Agentic Chat
+// ---------------------------------------------------------------------------
+// Generate a conversational summary from search results
+function generateChatSummary(query, results, total) {
+  if (!results || results.length === 0) {
+    return `I couldn't find any results matching "${query}". Try rephrasing your question or using different keywords.`;
+  }
+
+  const count = total ?? results.length;
+  const topItems = results.slice(0, 5);
+
+  // Build a natural summary
+  let summary = `I found ${count} result${count !== 1 ? "s" : ""} for your query. `;
+
+  if (count <= 3) {
+    summary += `Here's what I found:\n\n`;
+  } else {
+    summary += `Here are the top matches:\n\n`;
+  }
+
+  topItems.forEach((item, i) => {
+    const s = item.source || {};
+    const title = s.title || s.name || s.primaryTitle || s.label || item.preview || "Untitled";
+    const year = s.year || s.startYear || "";
+    const desc = s.plot || s.description || s.overview || s.summary || item.preview || "";
+    const score = Number(item.score || 0);
+    const rating = s.rating ? ` \u2022 Rating: ${s.rating}` : "";
+    const genre = s.genre || s.genres || "";
+    const genreStr = genre ? ` \u2022 ${genre}` : "";
+
+    summary += `${i + 1}. **${title}**`;
+    if (year) summary += ` (${year})`;
+    summary += `${genreStr}${rating}`;
+    if (score > 0) summary += ` \u2022 Relevance: ${score.toFixed(2)}`;
+    summary += `\n`;
+    if (desc && desc !== title) {
+      const shortDesc = desc.length > 150 ? desc.slice(0, 147) + "..." : desc;
+      summary += `   ${shortDesc}\n`;
+    }
+    summary += `\n`;
+  });
+
+  if (count > 5) {
+    summary += `...and ${count - 5} more result${count - 5 !== 1 ? "s" : ""}.`;
+  }
+
+  return summary;
+}
+
+// Simple markdown-like rendering (bold only)
+function renderChatText(text) {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return <strong key={i}>{part.slice(2, -2)}</strong>;
+    }
+    return part;
+  });
+}
+
+function AgenticChat({ messages, loading }) {
+  const endRef = useRef(null);
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  return (
+    <div className="chat-messages">
+      {messages.length === 0 && (
+        <div className="chat-empty">
+          <div className="chat-empty-icon">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" style={{opacity: 0.3}}>
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+            </svg>
+          </div>
+          <div className="chat-empty-title">Conversational Search</div>
+          <div className="chat-empty-desc">Ask questions in natural language. I'll search the index and summarize what I find.</div>
+          <div className="chat-empty-examples">
+            Try: "Show me sci-fi movies rated above 8" or "What are the best films by Christopher Nolan?"
+          </div>
+        </div>
+      )}
+      {messages.map((msg, idx) => (
+        <div key={idx} className={`chat-bubble chat-${msg.role}`}>
+          {msg.role === "user" ? (
+            <div className="chat-user-text">{msg.text}</div>
+          ) : (
+            <div className="chat-assistant">
+              {msg.results && msg.results.length > 0 ? (
+                <>
+                  <div className="chat-summary">
+                    {renderChatText(msg.summary || generateChatSummary(msg.query, msg.results, msg.total))}
+                  </div>
+                  <div className="chat-meta-bar">
+                    <span>{msg.total ?? msg.results.length} result(s) \u2022 {msg.took_ms ?? 0}ms</span>
+                    {msg.capability && <span className="chat-cap-badge">{msg.capability}</span>}
+                  </div>
+                  <details className="chat-sources">
+                    <summary>View source documents ({msg.results.length})</summary>
+                    <div className="chat-source-list">
+                      {msg.results.slice(0, 10).map((item, i) => (
+                        <div key={i} className="chat-source-item">
+                          <span className="chat-source-num">{i + 1}</span>
+                          <div className="chat-source-body">
+                            <div className="chat-source-title">{item.source?.title || item.source?.name || item.preview || item.id}</div>
+                            <pre>{JSON.stringify(item.source, null, 2)}</pre>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </details>
+                </>
+              ) : msg.error ? (
+                <div className="chat-error">{msg.error}</div>
+              ) : (
+                <div className="chat-summary">I couldn't find any results for that query. Try rephrasing your question.</div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+      {loading && (
+        <div className="chat-bubble chat-assistant">
+          <div className="chat-typing">
+            <span className="chat-typing-dot"></span>
+            <span className="chat-typing-dot"></span>
+            <span className="chat-typing-dot"></span>
+          </div>
+        </div>
+      )}
+      <div ref={endRef} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Comparison Toggle
+// ---------------------------------------------------------------------------
+function ComparisonToggle({ enabled, onToggle }) {
+  return (
+    <div className="compare-toggle">
+      <span className="compare-toggle-label">Compare</span>
+      <div
+        role="switch"
+        aria-checked={enabled}
+        aria-label="Toggle comparison mode"
+        tabIndex={0}
+        className={`compare-toggle-track ${enabled ? "on" : ""}`}
+        onClick={() => onToggle(!enabled)}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onToggle(!enabled); } }}
+      >
+        <div className="compare-toggle-thumb" />
+      </div>
+    </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// ResultPane – one half of the comparison view
+// ---------------------------------------------------------------------------
+function ResultPane({ label, indexName, results, loading, error, stats, queryMode, capability, usedSemantic, fallbackReason, activeTemplate, schema, fieldOverrides, filterSource }) {
+  const capabilityLabel = {
+    exact: "Exact",
+    semantic: "Semantic",
+    structured: "Structured",
+    combined: "Combined",
+    autocomplete: "Autocomplete",
+    fuzzy: "Fuzzy",
+    manual: "Manual",
+  };
+
+  const isSecond = label === "Index 2";
+
+  return (
+    <div className="result-pane">
+      {/* Header */}
+      <div className={`result-pane-header ${isSecond ? "idx2" : "idx1"}`}>
+        <span className={`result-pane-label ${isSecond ? "idx2" : "idx1"}`}>{label}</span>
+        <span className="result-pane-index">{indexName}</span>
+      </div>
+
+      {/* Status row */}
+      <div className="result-pane-status">
+        <span>{stats}</span>
+        {queryMode && <span>mode: {queryMode}</span>}
+        {capability && <span>capability: {capabilityLabel[capability] || capability}</span>}
+        {!error && <span>semantic: {usedSemantic ? "on" : "off"}</span>}
+        {fallbackReason && <span>fallback: {fallbackReason}</span>}
+      </div>
+
+      {/* Loading indicator */}
+      {loading && (
+        <div className="result-pane-loading">
+          <div className="loading-bar"><div className="loading-bar-progress"></div></div>
+          <span className="loading-text">Searching...</span>
+        </div>
+      )}
+
+      {/* Error message */}
+      {error && (
+        <div className="result-pane-error">{error}</div>
+      )}
+
+      {/* Results */}
+      {!loading && !error && (
+        <div className="result-pane-results">
+          {activeTemplate === "ecommerce" || activeTemplate === "media" ? (
+            <EcommerceResults results={results} loading={false} schema={schema} fieldOverrides={fieldOverrides} filterSource={filterSource} />
+          ) : (
+            <DocumentResults results={results} loading={false} filterSource={filterSource} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Comparison View — side-by-side search across two selected indices
+// ---------------------------------------------------------------------------
+function ComparisonView({ query, searchSize, activeTemplate, schema, fieldOverrides, filterSource, compareIndex1, compareIndex2 }) {
+  // Index 1 pane state
+  const [index1Results, setIndex1Results] = useState([]);
+  const [index1Loading, setIndex1Loading] = useState(false);
+  const [index1Error, setIndex1Error] = useState("");
+  const [index1Stats, setIndex1Stats] = useState("Ready");
+  const [index1QueryMode, setIndex1QueryMode] = useState("");
+  const [index1Capability, setIndex1Capability] = useState("");
+  const [index1UsedSemantic, setIndex1UsedSemantic] = useState(false);
+  const [index1FallbackReason, setIndex1FallbackReason] = useState("");
+
+  // Index 2 pane state
+  const [index2Results, setIndex2Results] = useState([]);
+  const [index2Loading, setIndex2Loading] = useState(false);
+  const [index2Error, setIndex2Error] = useState("");
+  const [index2Stats, setIndex2Stats] = useState("Ready");
+  const [index2QueryMode, setIndex2QueryMode] = useState("");
+  const [index2Capability, setIndex2Capability] = useState("");
+  const [index2UsedSemantic, setIndex2UsedSemantic] = useState(false);
+  const [index2FallbackReason, setIndex2FallbackReason] = useState("");
+
+  const runComparisonSearch = async (queryText) => {
+    setIndex1Loading(true);
+    setIndex2Loading(true);
+    setIndex1Error("");
+    setIndex2Error("");
+
+    const makeRequest = (indexName) => {
+      const qs = new URLSearchParams();
+      qs.set("index", indexName);
+      qs.set("q", queryText);
+      qs.set("size", String(searchSize));
+      qs.set("debug", "1");
+      return fetch(`/api/search?${qs.toString()}`).then(r => r.json());
+    };
+
+    const [result1, result2] = await Promise.allSettled([
+      makeRequest(compareIndex1),
+      makeRequest(compareIndex2),
+    ]);
+
+    // Handle index 1 result
+    if (result1.status === "fulfilled") {
+      const data = result1.value;
+      if (data.error) {
+        setIndex1Error(data.error);
+        setIndex1Results([]);
+      } else {
+        setIndex1Results(data.hits || []);
+        setIndex1Stats(`${data.total ?? 0} hits — ${data.took_ms ?? 0}ms`);
+        setIndex1QueryMode(data.query_mode || "");
+        setIndex1Capability(data.capability || "");
+        setIndex1UsedSemantic(Boolean(data.used_semantic));
+        setIndex1FallbackReason(data.fallback_reason || "");
+      }
+    } else {
+      setIndex1Error(result1.reason?.message || "Request failed");
+      setIndex1Results([]);
+    }
+    setIndex1Loading(false);
+
+    // Handle index 2 result
+    if (result2.status === "fulfilled") {
+      const data = result2.value;
+      if (data.error) {
+        setIndex2Error(data.error);
+        setIndex2Results([]);
+      } else {
+        setIndex2Results(data.hits || []);
+        setIndex2Stats(`${data.total ?? 0} hits — ${data.took_ms ?? 0}ms`);
+        setIndex2QueryMode(data.query_mode || "");
+        setIndex2Capability(data.capability || "");
+        setIndex2UsedSemantic(Boolean(data.used_semantic));
+        setIndex2FallbackReason(data.fallback_reason || "");
+      }
+    } else {
+      setIndex2Error(result2.reason?.message || "Request failed");
+      setIndex2Results([]);
+    }
+    setIndex2Loading(false);
+  };
+
+  // Trigger search when query or searchSize changes
+  useEffect(() => {
+    if (query && query.trim()) {
+      runComparisonSearch(query.trim());
+    }
+  }, [query, searchSize]);
+
+  return (
+    <div>
+      {/* Side-by-side result panes */}
+      <div className="comparison-panes">
+        <ResultPane
+          label="Index 1"
+          indexName={compareIndex1}
+          results={index1Results}
+          loading={index1Loading}
+          error={index1Error}
+          stats={index1Stats}
+          queryMode={index1QueryMode}
+          capability={index1Capability}
+          usedSemantic={index1UsedSemantic}
+          fallbackReason={index1FallbackReason}
+          activeTemplate={activeTemplate}
+          schema={schema}
+          fieldOverrides={fieldOverrides}
+          filterSource={filterSource}
+        />
+        <ResultPane
+          label="Index 2"
+          indexName={compareIndex2}
+          results={index2Results}
+          loading={index2Loading}
+          error={index2Error}
+          stats={index2Stats}
+          queryMode={index2QueryMode}
+          capability={index2Capability}
+          usedSemantic={index2UsedSemantic}
+          fallbackReason={index2FallbackReason}
+          activeTemplate={activeTemplate}
+          schema={schema}
+          fieldOverrides={fieldOverrides}
+          filterSource={filterSource}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main App
+// ---------------------------------------------------------------------------
+function App() {
+  const [indexName, setIndexName] = useState("");
+  const [searchSize, setSearchSize] = useState("20");
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState([]);
+  const [showSuggestions, setShowSuggestions] = useState(true);
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [stats, setStats] = useState("Ready");
+  const [queryMode, setQueryMode] = useState("");
+  const [capability, setCapability] = useState("");
+  const [fallbackReason, setFallbackReason] = useState("");
+  const [usedSemantic, setUsedSemantic] = useState(false);
+  const [autocompleteField, setAutocompleteField] = useState("");
+  const [autocompleteOptions, setAutocompleteOptions] = useState([]);
+  const [backendType, setBackendType] = useState("");
+  const [backendEndpoint, setBackendEndpoint] = useState("");
+  const [backendConnected, setBackendConnected] = useState(false);
+
+  // Comparison mode state
+  const [comparisonAvailable, setComparisonAvailable] = useState(false);
+  const [comparisonEnabled, setComparisonEnabled] = useState(false);
+  const [compareIndex1, setCompareIndex1] = useState("");
+  const [compareIndex2, setCompareIndex2] = useState("");
+  const [availableIndices, setAvailableIndices] = useState([]);
+
+  // Template & settings state
+  const [schema, setSchema] = useState(null);
+  const [activeTemplate, setActiveTemplate] = useState("document");
+  const [chatMessages, setChatMessages] = useState([]);
+  const [showSettings, setShowSettings] = useState(false);
+
+  // Field mapping overrides
+  const [titleField, setTitleField] = useState("(none)");
+  const [descField, setDescField] = useState("(none)");
+  const [imgField, setImgField] = useState("(none)");
+  const [hiddenFields, setHiddenFields] = useState(new Set());
+
+  const fieldOverrides = {
+    title: titleField !== "(none)" ? titleField : null,
+    description: descField !== "(none)" ? descField : null,
+    image: imgField !== "(none)" ? imgField : null,
+  };
+
+  const toggleHiddenField = (field) => {
+    setHiddenFields((prev) => {
+      const next = new Set(prev);
+      if (next.has(field)) next.delete(field);
+      else next.add(field);
+      return next;
+    });
+  };
+
+  const filterSource = (source) => {
+    if (!source || hiddenFields.size === 0) return source;
+    const out = {};
+    for (const [k, v] of Object.entries(source)) {
+      if (!hiddenFields.has(k)) out[k] = v;
+    }
+    return out;
+  };
+
+  const capabilityLabel = {
+    exact: "Exact",
+    semantic: "Semantic",
+    structured: "Structured",
+    combined: "Combined",
+    autocomplete: "Autocomplete",
+    fuzzy: "Fuzzy",
+    manual: "Manual",
+  };
+
+  // ---- Schema fetch ----
+  const fetchSchema = useCallback(async (index) => {
+    if (!index) return;
+    try {
+      const res = await fetch(`/api/schema?index=${encodeURIComponent(index)}`);
+      const data = await res.json();
+      if (!data.error) {
+        setSchema(data);
+        setActiveTemplate(data.suggested_template || "document");
+      }
+    } catch (_) {}
+  }, []);
+
+  // ---- Suggestions ----
+  const loadSuggestions = async (index) => {
+    try {
+      const qs = new URLSearchParams();
+      if (index) qs.set("index", index);
+      const res = await fetch(`/api/suggestions?${qs.toString()}`);
+      const data = await res.json();
+      const raw = Array.isArray(data.suggestions) ? data.suggestions : [];
+      const mapped = raw
+        .map((entry) => ({
+          text: String(entry.text || "").trim(),
+          capability: String(entry.capability || "").trim().toLowerCase(),
+          query_mode: String(entry.query_mode || "default").trim(),
+          field: String(entry.field || "").trim(),
+          value: String(entry.value || "").trim(),
+          case_insensitive: Boolean(entry.case_insensitive),
+        }))
+        .filter((entry) => entry.text.length > 0 && entry.capability.length > 0);
+      setSuggestions(mapped);
+    } catch (_) { setSuggestions([]); }
+  };
+
+  // ---- Config ----
+  const loadConfig = async () => {
+    try {
+      const res = await fetch("/api/config");
+      const data = await res.json();
+      setBackendType(String(data.backend_type || "").trim());
+      setBackendEndpoint(String(data.endpoint || "").trim());
+      setBackendConnected(Boolean(data.connected));
+      const defaultIndex = (data.default_index || "").trim();
+      if (defaultIndex) {
+        setIndexName(defaultIndex);
+        await loadSuggestions(defaultIndex);
+        await fetchSchema(defaultIndex);
+        return;
+      }
+      await loadSuggestions("");
+    } catch (_err) {
+      await loadSuggestions("");
+    }
+  };
+
+  const loadComparisonConfig = async () => {
+    try {
+      const res = await fetch("/api/comparison-config");
+      const data = await res.json();
+      if (data.comparison_enabled) {
+        setComparisonAvailable(true);
+        setComparisonEnabled(true);
+        setCompareIndex1(data.baseline_index);
+        setCompareIndex2(data.improved_index);
+        // Use index 2 for suggestions and schema in comparison mode
+        await loadSuggestions(data.improved_index);
+        await fetchSchema(data.improved_index);
+      }
+    } catch (err) {
+      console.error("Failed to fetch comparison config:", err);
+    }
+  };
+
+  const loadIndices = async () => {
+    try {
+      const res = await fetch("/api/indices");
+      const data = await res.json();
+      const list = Array.isArray(data.indices) ? data.indices : [];
+      setAvailableIndices(list);
+      if (list.length >= 2) setComparisonAvailable(true);
+    } catch (_) {}
+  };
+
+  useEffect(() => { loadConfig(); loadComparisonConfig(); loadIndices(); }, []);
+
+  // Refetch schema when index changes (debounced)
+  useEffect(() => {
+    const idx = indexName.trim();
+    if (!idx) return;
+    const timer = setTimeout(() => fetchSchema(idx), 400);
+    return () => clearTimeout(timer);
+  }, [indexName, fetchSchema]);
+
+  // ---- Autocomplete ----
+  useEffect(() => {
+    const effectiveIndex = (comparisonEnabled && compareIndex2) ? compareIndex2 : indexName.trim();
+    const prefix = query.trim();
+    const autocompleteActive = effectiveIndex.length > 0 && prefix.length >= 2;
+
+    if (!autocompleteActive) {
+      setAutocompleteOptions([]);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const qs = new URLSearchParams();
+        qs.set("index", effectiveIndex);
+        qs.set("q", prefix);
+        qs.set("size", "8");
+        if (autocompleteField) {
+          qs.set("field", autocompleteField);
+        }
+        const res = await fetch(`/api/autocomplete?${qs.toString()}`);
+        const data = await res.json();
+        const resolvedField = String(data.field || "").trim();
+        const options = Array.isArray(data.options)
+          ? data.options
+              .map((value) => String(value || "").trim())
+              .filter((value) => value.length > 0)
+          : [];
+        if (!cancelled) {
+          if (resolvedField) {
+            setAutocompleteField((prev) => (prev === resolvedField ? prev : resolvedField));
+          }
+          setAutocompleteOptions(options);
+        }
+      } catch (_err) {
+        if (!cancelled) {
+          setAutocompleteOptions([]);
+        }
+      }
+    }, 120);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [indexName, query, capability, queryMode, autocompleteField, comparisonEnabled, compareIndex2]);
+
+  // ---- Search ----
+  const runSearch = async (overrideQuery = null, options = {}) => {
+    // In comparison mode, ComparisonView handles search via its own useEffect on query
+    if (comparisonEnabled) return;
+    const effectiveQuery = (overrideQuery !== null ? overrideQuery : query).trim();
+    const effectiveIndex = indexName.trim();
+    const effectiveSize = parseInt(searchSize, 10) || 20;
+    if (!effectiveIndex) { setError("Please enter an index name."); return; }
+
+    setError("");
+    setLoading(true);
+
+    if (activeTemplate === "agentic-chat" && effectiveQuery) {
+      setChatMessages((prev) => [...prev, { role: "user", text: effectiveQuery }]);
+    }
+
+    try {
+      const qs = new URLSearchParams();
+      qs.set("index", effectiveIndex);
+      qs.set("q", effectiveQuery);
+      qs.set("size", String(effectiveSize));
+      qs.set("debug", "1");
+      if (options.intent) qs.set("intent", options.intent);
+      if (options.field) qs.set("field", options.field);
+      const res = await fetch(`/api/search?${qs.toString()}`);
+      const data = await res.json();
+
+      if (data.error) {
+        setError(data.error);
+        setResults([]);
+        setStats("Search failed");
+        setQueryMode(""); setCapability(""); setFallbackReason(""); setUsedSemantic(false);
+        if (activeTemplate === "agentic-chat") {
+          setChatMessages((prev) => [...prev, { role: "assistant", error: data.error, results: [], total: 0, took_ms: 0 }]);
+        }
+      } else {
+        const hits = Array.isArray(data.hits) ? data.hits : [];
+        setResults(hits);
+        setStats(`Loaded ${data.total ?? 0} hit(s) in ${data.took_ms ?? 0} ms`);
+        setQueryMode(String(data.query_mode || ""));
+        setCapability(String(data.capability || ""));
+        setFallbackReason(String(data.fallback_reason || ""));
+        setUsedSemantic(Boolean(data.used_semantic));
+        if (activeTemplate === "agentic-chat") {
+          setChatMessages((prev) => [...prev, {
+            role: "assistant", results: hits, total: data.total, took_ms: data.took_ms,
+            capability: data.capability, query: effectiveQuery, error: null,
+          }]);
+        }
+        await loadSuggestions(effectiveIndex);
+      }
+    } catch (err) {
+      setError(`Request failed: ${err.message}`);
+      setResults([]);
+      setStats("Search failed");
+      setQueryMode(""); setCapability(""); setFallbackReason(""); setUsedSemantic(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onSuggestionClick = (entry) => {
+    const text = String(entry?.text || "").trim();
+    if (!text) return;
+    setAutocompleteField(String(entry?.capability || "").toLowerCase() === "autocomplete" ? String(entry?.field || "") : "");
+    setAutocompleteOptions([]);
+    setQuery(text);
+    runSearch(text);
+  };
+
+  const onAutocompleteOptionClick = (value) => {
+    const text = String(value || "").trim();
+    if (!text) return;
+    setAutocompleteOptions([]);
+    setQuery(text);
+    runSearch(text, { intent: "autocomplete_selection", field: autocompleteField });
+  };
+
+  const isChat = activeTemplate === "agentic-chat";
+
+  // Derive field lists from schema for field mapping dropdowns
+  const allFields = schema?.field_specs ? Object.keys(schema.field_specs).filter((f) => !f.endsWith(".keyword")) : [];
+  const textFields = (schema?.field_categories?.text || []);
+  const keywordFields = new Set(schema?.field_categories?.keyword || []);
+
+  return (
+    <div className={`shell template-${activeTemplate}`}>
+      <header className="topbar">
+        <div className="brand">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42.6667 42.6667" fill="none" aria-label="OpenSearch" role="img">
+            <path fill="#075985" d="M41.1583 15.6667C40.3252 15.6667 39.6499 16.342 39.6499 17.1751C39.6499 29.5876 29.5876 39.6499 17.1751 39.6499C16.342 39.6499 15.6667 40.3252 15.6667 41.1583C15.6667 41.9913 16.342 42.6667 17.1751 42.6667C31.2537 42.6667 42.6667 31.2537 42.6667 17.1751C42.6667 16.342 41.9913 15.6667 41.1583 15.6667Z"/>
+            <path fill="#082F49" d="M32.0543 25.3333C33.5048 22.967 34.9077 19.8119 34.6317 15.3947C34.06 6.24484 25.7726 -0.696419 17.9471 0.0558224C14.8835 0.350311 11.7379 2.84747 12.0173 7.32032C12.1388 9.26409 13.0902 10.4113 14.6363 11.2933C16.1079 12.1328 17.9985 12.6646 20.1418 13.2674C22.7308 13.9956 25.7339 14.8135 28.042 16.5144C30.8084 18.553 32.6994 20.9162 32.0543 25.3333Z"/>
+            <path fill="#075985" d="M2.6124 9.33333C1.16184 11.6997 -0.241004 14.8548 0.0349954 19.2719C0.606714 28.4218 8.89407 35.3631 16.7196 34.6108C19.7831 34.3164 22.9288 31.8192 22.6493 27.3463C22.5279 25.4026 21.5765 24.2554 20.0304 23.3734C18.5588 22.5339 16.6681 22.0021 14.5248 21.3992C11.9358 20.6711 8.93276 19.8532 6.62463 18.1522C3.85831 16.1136 1.96728 13.7505 2.6124 9.33333Z"/>
+          </svg>
+          OpenSearch
+        </div>
+        <div className="divider"></div>
+        <div className="title">Search Builder</div>
+        <div className="topbar-right">
+          {comparisonAvailable && (
+            <ComparisonToggle
+              enabled={comparisonEnabled}
+              onToggle={(on) => {
+                if (on) {
+                  setComparisonEnabled(true);
+                  setResults([]);
+                  setError("");
+                  setStats("Ready");
+                  // Prefill dropdowns if not already set
+                  if (!compareIndex1 || !compareIndex2) {
+                    const current = indexName.trim();
+                    const names = availableIndices.map((i) => i.name);
+                    const other = names.find((n) => n !== current) || "";
+                    if (!compareIndex1) setCompareIndex1(current || names[0] || "");
+                    if (!compareIndex2) setCompareIndex2(other || names[1] || "");
+                  }
+                } else {
+                  setComparisonEnabled(false);
+                  if (compareIndex2) {
+                    setIndexName(compareIndex2);
+                    loadSuggestions(compareIndex2);
+                    fetchSchema(compareIndex2);
+                  }
+                }
+              }}
+            />
+          )}
+          <div className={`conn-badge ${backendConnected ? "connected" : "disconnected"}`}>
+            <span className="conn-dot"></span>
+            <strong>{backendConnected ? "Connected" : "Disconnected"}</strong>
+            {backendEndpoint && <span className="conn-ep">{backendEndpoint}</span>}
+          </div>
+          <button className={`hdr-btn ${showSettings ? "on" : ""}`} onClick={() => setShowSettings(!showSettings)}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+            </svg>
+            <span>Settings</span>
+          </button>
+        </div>
+      </header>
+
+      {showSettings && (
+        <div className="settings-panel">
+          {/* Index / Size row */}
+          <div className="idx-row">
+            <div className="field-group">
+              <label>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>
+                </svg>
+                {comparisonEnabled ? "Index 1" : "Index"}
+              </label>
+              {availableIndices.length > 0 ? (
+                <select
+                  className="idx-input"
+                  value={comparisonEnabled ? compareIndex1 : indexName}
+                  onChange={(e) => {
+                    if (comparisonEnabled) {
+                      setCompareIndex1(e.target.value);
+                    } else {
+                      setIndexName(e.target.value);
+                      loadSuggestions(e.target.value);
+                      fetchSchema(e.target.value);
+                    }
+                  }}
+                >
+                  <option value="">Select index...</option>
+                  {availableIndices.map((idx) => (
+                    <option key={idx.name} value={idx.name}>{idx.name} ({idx.docs} docs)</option>
+                  ))}
+                </select>
+              ) : (
+                <input className="idx-input" value={indexName} onChange={(e) => setIndexName(e.target.value)} placeholder="e.g. movies-index" />
+              )}
+            </div>
+            {comparisonEnabled && (
+              <div className="field-group">
+                <label className="idx2-label">Index 2</label>
+                <select
+                  className="idx-input"
+                  value={compareIndex2}
+                  onChange={(e) => { setCompareIndex2(e.target.value); loadSuggestions(e.target.value); fetchSchema(e.target.value); }}
+                >
+                  <option value="">Select index...</option>
+                  {availableIndices.map((idx) => (
+                    <option key={idx.name} value={idx.name}>{idx.name} ({idx.docs} docs)</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <div className="field-group">
+              <label>Size</label>
+              <input className="size-input" value={searchSize} onChange={(e) => setSearchSize(e.target.value)} />
+            </div>
+            <div className="spacer"></div>
+            {schema && (
+              <span className="schema-caps">
+                {schema.capabilities.map((c) => (
+                  <span key={c} className={`cap-pill cap-${c}`}>{c}</span>
+                ))}
+              </span>
+            )}
+          </div>
+
+          <hr className="sep" />
+
+          {/* Template selection */}
+          <div className="sec-label">Template</div>
+          <div className="tpl-grid">
+            {TEMPLATES.map((t) => {
+              const disabled = !!t.disabled;
+              return (
+                <button
+                  key={t.id}
+                  className={`tpl-card ${activeTemplate === t.id ? "on" : ""} ${disabled ? "disabled" : ""}`}
+                  disabled={disabled}
+                  title=""
+                  onClick={() => {
+                    if (disabled) return;
+                    setActiveTemplate(t.id);
+                    if (t.id === "agentic-chat") setChatMessages([]);
+                  }}
+                >
+                  <div className="tpl-card-icon"><TemplateIcon id={t.id} /></div>
+                  <div className="tpl-card-label">{t.label}</div>
+                  {schema?.suggested_template === t.id && <span className="template-auto">auto</span>}
+                </button>
+              );
+            })}
+          </div>
+
+          <hr className="sep" />
+
+          {/* Field mapping */}
+          <div className="field-map-row">
+            <div className="field-map-group">
+              <label>Title</label>
+              <select value={titleField} onChange={(e) => setTitleField(e.target.value)}>
+                <option>(none)</option>
+                {textFields.map((f) => <option key={f}>{f}</option>)}
+              </select>
+            </div>
+            <div className="field-map-group">
+              <label>Description</label>
+              <select value={descField} onChange={(e) => setDescField(e.target.value)}>
+                <option>(none)</option>
+                {textFields.map((f) => <option key={f}>{f}</option>)}
+              </select>
+            </div>
+            <div className="field-map-group">
+              <label>Image</label>
+              <select value={imgField} onChange={(e) => setImgField(e.target.value)}>
+                <option>(none)</option>
+                {allFields.map((f) => <option key={f}>{f}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {/* Metadata chips */}
+          {allFields.length > 0 && (
+            <div className="meta-section">
+              <div className="sec-label">Metadata</div>
+              <div className="meta-chips">
+                {allFields.map((f) => (
+                  <button
+                    key={f}
+                    className={`meta-chip ${hiddenFields.has(f) ? "" : "selected"}`}
+                    onClick={() => toggleHiddenField(f)}
+                    title={hiddenFields.has(f) ? `${f} (hidden — click to show)` : `${f} (click to hide)`}
+                  >{f}</button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <section className="search-panel">
+        {/* Agentic chat template */}
+        {isChat ? (
+          <div className="chat-container">
+            <AgenticChat messages={chatMessages} loading={loading} />
+            <div className="chat-input-row">
+              <input
+                className="chat-input"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => { if (e.key === "Enter" && query.trim()) { runSearch(); setQuery(""); } }}
+                placeholder="Ask a question..."
+              />
+              <button className="search-btn" onClick={() => { if (query.trim()) { runSearch(); setQuery(""); } }} disabled={loading}>
+                {loading ? "..." : "Send"}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Standard search bar */}
+            <div className="search-row">
+              <div className="query-wrap">
+                <span className="query-icon">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                  </svg>
+                </span>
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") { setAutocompleteOptions([]); runSearch(); } }}
+                  placeholder="Search..."
+                />
+                {autocompleteOptions.length > 0 && (
+                  <div className="autocomplete-menu">
+                    {autocompleteOptions.map((option) => (
+                      <button key={option} type="button" className="autocomplete-option"
+                        onMouseDown={(e) => e.preventDefault()} onClick={() => onAutocompleteOptionClick(option)}>
+                        {option}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <button className="search-btn" onClick={() => runSearch()} disabled={loading}>
+                {loading ? "..." : "Search"}
+              </button>
+            </div>
+
+            {/* Suggestions */}
+            <div className="suggestions">
+              <button className="suggestion-toggle" onClick={() => setShowSuggestions(!showSuggestions)}>
+                Try these auto-generated queries
+                <span>{showSuggestions ? "\u25B4" : "\u25BE"}</span>
+              </button>
+              {showSuggestions && (
+                <div className="chips">
+                  {suggestions.map((item) => (
+                    <button key={`${item.text}-${item.capability || "none"}`} className="chip" onClick={() => onSuggestionClick(item)}>
+                      <span>{item.text}</span>
+                      {item.capability && (
+                        <span className={`cap-badge cap-${item.capability}`}>
+                          {(capabilityLabel[item.capability] || item.capability).toUpperCase()}
+                        </span>
+                      )}
+                      {item.query_mode && item.query_mode !== "default" && (
+                        <span className="mode-badge">{item.query_mode.toUpperCase()}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Results area: comparison view or standard single-index results */}
+            {comparisonEnabled ? (
+              <ComparisonView
+                query={query}
+                searchSize={searchSize}
+                activeTemplate={activeTemplate}
+                schema={schema}
+                fieldOverrides={fieldOverrides}
+                filterSource={filterSource}
+                compareIndex1={compareIndex1}
+                compareIndex2={compareIndex2}
+              />
+            ) : (
+              <>
+                {/* Status row */}
+                <div className="status-row">
+                  <span>{stats}</span>
+                  {queryMode && <span>mode: {queryMode}</span>}
+                  {capability && <span>capability: {capability}</span>}
+                  {!error && <span>semantic: {usedSemantic ? "on" : "off"}</span>}
+                  {fallbackReason && <span>fallback: {fallbackReason}</span>}
+                  {error && <span className="error">{error}</span>}
+                </div>
+
+                {/* Loading bar */}
+                {loading && (
+                  <div className="loading-container">
+                    <div className="loading-bar"><div className="loading-bar-progress"></div></div>
+                    <div className="loading-text">Searching...</div>
+                  </div>
+                )}
+
+                {/* Template-specific results */}
+                {(activeTemplate === "ecommerce" || activeTemplate === "media") && (
+                  <EcommerceResults results={results} loading={loading} schema={schema} fieldOverrides={fieldOverrides} filterSource={filterSource} />
+                )}
+                {activeTemplate === "document" && <DocumentResults results={results} loading={loading} filterSource={filterSource} />}
+              </>
+            )}
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(<App />);

--- a/skills/opensearch-skills/scripts/ui/index.html
+++ b/skills/opensearch-skills/scripts/ui/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenSearch Launchpad</title>
+  <link rel="stylesheet" href="/styles.css" />
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="/app.jsx"></script>
+</body>
+</html>

--- a/skills/opensearch-skills/scripts/ui/styles.css
+++ b/skills/opensearch-skills/scripts/ui/styles.css
@@ -1,0 +1,1275 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Inter+Mono:wght@400;500&display=swap");
+
+/* OUI Design Tokens */
+:root {
+  --background: 0 0% 100%;
+  --foreground: 0 0% 4%;
+  --card: 0 0% 100%;
+  --card-foreground: 0 0% 4%;
+  --primary: 200 86% 33%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 96%;
+  --secondary-foreground: 0 0% 9%;
+  --muted: 0 0% 96%;
+  --muted-foreground: 0 0% 45%;
+  --accent: 204 94% 94%;
+  --accent-foreground: 0 0% 9%;
+  --border: 0 0% 83%;
+  --input: 0 0% 90%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 98%;
+
+  --brand-primary: #075985;
+  --brand-secondary: #082f49;
+
+  --radius-md: 4px;
+  --radius-lg: 6px;
+  --radius-xl: 8px;
+  --radius-2xl: 16px;
+  --radius-full: 9999px;
+
+  --shadow-xs: 0 1px 2px 0 rgba(0,0,0,0.05);
+  --shadow-sm: 0 1px 2px -1px rgba(0,0,0,0.1), 0 1px 3px 0 rgba(0,0,0,0.1);
+  --shadow-lg: 0 4px 6px -4px rgba(0,0,0,0.1), 0 10px 15px -3px rgba(0,0,0,0.1);
+
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "Inter Mono", ui-monospace, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; }
+
+body {
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  color: hsl(var(--foreground));
+  background:
+    radial-gradient(circle at 12% -20%, rgba(255,255,255,0.67) 0%, transparent 40%),
+    radial-gradient(circle at 85% 0%, hsl(var(--accent)) 0%, transparent 35%),
+    linear-gradient(180deg, hsl(204 60% 95%), hsl(204 40% 90%));
+}
+
+/* ---- Shell ---- */
+.shell {
+  max-width: 1060px;
+  margin: 20px auto;
+  padding: 0 16px 32px;
+  animation: fade-in 260ms ease-out;
+}
+
+/* ---- Topbar ---- */
+.topbar {
+  background: hsl(var(--card) / 0.94);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-2xl);
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  box-shadow: var(--shadow-sm);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--brand-primary);
+  font-size: 18px;
+  line-height: 1;
+}
+
+.brand svg {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+}
+
+.divider {
+  width: 1px;
+  height: 28px;
+  background: hsl(var(--border));
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  color: hsl(var(--foreground));
+}
+
+.topbar-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* ---- Connection badge ---- */
+.conn-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+}
+
+.conn-badge.connected {
+  color: #1a5c2e;
+  background: #e0f5e8;
+  border: 1px solid #b0e0c2;
+}
+
+.conn-badge.disconnected {
+  color: #7a3030;
+  background: #fde8e8;
+  border: 1px solid #f0bfbf;
+}
+
+.conn-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.connected .conn-dot {
+  background: #22a94e;
+  box-shadow: 0 0 4px #22a94e88;
+}
+
+.disconnected .conn-dot {
+  background: hsl(var(--destructive));
+  box-shadow: 0 0 4px hsl(var(--destructive) / 0.5);
+}
+
+.conn-ep {
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+  font-weight: 400;
+}
+
+/* ---- Header buttons (Settings, Evaluate) ---- */
+.hdr-btn {
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  cursor: pointer;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: var(--radius-lg);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 150ms ease;
+  box-shadow: var(--shadow-xs);
+}
+
+.hdr-btn:hover {
+  background: hsl(var(--secondary));
+  border-color: hsl(var(--primary) / 0.3);
+}
+
+.hdr-btn.on {
+  color: hsl(var(--primary));
+  background: hsl(var(--accent));
+  border-color: hsl(var(--primary) / 0.4);
+}
+
+/* ---- Settings Panel ---- */
+.settings-panel {
+  margin-top: 12px;
+  background: hsl(var(--card) / 0.94);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-2xl);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  animation: fade-in 200ms ease-out;
+}
+
+/* Index row */
+.idx-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.field-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.field-group label {
+  font-size: 14px;
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.field-group input,
+.field-group select {
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius-lg);
+  padding: 8px 12px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  height: 36px;
+}
+
+.field-group select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23737373' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+  cursor: pointer;
+}
+
+.idx-input { width: 280px; }
+.size-input { width: 60px; text-align: center; }
+.spacer { flex: 1; }
+
+.sep {
+  border: 0;
+  border-top: 1px solid hsl(var(--border));
+  margin: 16px 0;
+}
+
+/* Section label */
+.sec-label {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 600;
+  color: hsl(var(--primary));
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 12px;
+}
+
+/* Template cards */
+.tpl-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.tpl-card {
+  border: 2px solid hsl(var(--border));
+  background: hsl(var(--card));
+  border-radius: var(--radius-xl);
+  padding: 20px 12px 14px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  font-family: var(--font-sans);
+  transition: all 150ms ease;
+  box-shadow: var(--shadow-xs);
+  position: relative;
+}
+
+.tpl-card:hover {
+  border-color: hsl(var(--primary) / 0.35);
+  background: hsl(var(--accent) / 0.2);
+}
+
+.tpl-card.on {
+  border-color: hsl(var(--primary));
+  background: hsl(var(--accent));
+}
+
+.tpl-card-icon {
+  color: hsl(var(--muted-foreground));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-lg);
+  background: hsl(var(--secondary));
+  transition: all 150ms ease;
+}
+
+.tpl-card.on .tpl-card-icon {
+  color: hsl(var(--primary));
+  background: hsl(var(--primary) / 0.1);
+}
+
+.tpl-card-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.tpl-card.on .tpl-card-label {
+  color: hsl(var(--primary));
+}
+
+.tpl-card.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  border-color: hsl(var(--border));
+  background: hsl(var(--secondary) / 0.5);
+  padding-bottom: 32px;
+}
+
+.tpl-card.disabled:hover {
+  border-color: hsl(var(--border));
+  background: hsl(var(--secondary) / 0.5);
+}
+
+.template-auto {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: hsl(var(--primary));
+  background: hsl(var(--accent));
+  padding: 2px 8px;
+  border-radius: var(--radius-md);
+  border: 1px solid hsl(var(--primary) / 0.2);
+}
+
+.template-requires {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 10px;
+  line-height: 14px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: hsl(var(--destructive));
+  background: hsl(var(--destructive) / 0.08);
+  border: 1px solid hsl(var(--destructive) / 0.15);
+  padding: 2px 8px;
+  border-radius: var(--radius-md);
+  white-space: nowrap;
+}
+
+/* Field mapping row */
+.field-map-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+.field-map-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-map-group label {
+  font-size: 12px;
+  font-weight: 600;
+  color: hsl(var(--primary));
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.field-map-group select {
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius-lg);
+  padding: 8px 12px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  height: 36px;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23737373' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+
+/* Metadata chips */
+.meta-section {
+  margin-top: 16px;
+}
+
+.meta-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.meta-chip {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: var(--radius-full);
+  border: 1px solid hsl(var(--border));
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: all 150ms ease;
+}
+
+.meta-chip:hover {
+  border-color: hsl(var(--primary) / 0.4);
+}
+
+.meta-chip.selected {
+  background: hsl(var(--accent));
+  color: hsl(var(--primary));
+  border-color: hsl(var(--primary) / 0.3);
+  font-weight: 600;
+}
+
+/* Schema capability pills */
+.schema-caps {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.cap-pill {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  border: 1px solid transparent;
+}
+
+.cap-pill.cap-lexical { color: #4a5568; background: #edf2f7; border-color: #cbd5e0; }
+.cap-pill.cap-semantic { color: hsl(var(--primary)); background: hsl(var(--accent)); border-color: hsl(204 80% 80%); }
+.cap-pill.cap-agentic { color: #553c9a; background: #e9d8fd; border-color: #d6bcfa; }
+.cap-pill.cap-structured { color: #6a3d0a; background: #ffe9ce; border-color: #ffd29e; }
+
+/* ---- Search Panel ---- */
+.search-panel {
+  margin-top: 12px;
+  background: hsl(var(--card) / 0.94);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-2xl);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+}
+
+.search-row {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+.query-wrap {
+  position: relative;
+  flex: 1;
+}
+
+.query-wrap input {
+  width: 100%;
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius-full);
+  padding: 12px 16px 12px 40px;
+  font-size: 16px;
+  font-family: var(--font-sans);
+  outline: none;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  height: 48px;
+}
+
+.query-wrap input:focus {
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.15);
+}
+
+.query-icon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: hsl(var(--muted-foreground));
+  line-height: 1;
+}
+
+.autocomplete-menu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 4px);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  background: hsl(var(--card));
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  z-index: 20;
+}
+
+.autocomplete-option {
+  width: 100%;
+  text-align: left;
+  border: 0;
+  border-top: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  color: hsl(var(--card-foreground));
+  padding: 8px 10px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.autocomplete-option:first-child { border-top: 0; }
+.autocomplete-option:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.search-btn {
+  border: 0;
+  padding: 0 24px;
+  border-radius: var(--radius-full);
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  height: 48px;
+  min-width: 100px;
+  box-shadow: var(--shadow-sm);
+  transition: opacity 150ms ease;
+}
+
+.search-btn:hover { opacity: 0.9; }
+.search-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Suggestions */
+.suggestions {
+  margin-top: 14px;
+}
+
+.suggestion-toggle {
+  border: 0;
+  background: transparent;
+  color: hsl(var(--foreground));
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chips {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  animation: fade-in 220ms ease-out;
+}
+
+.chip {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-full);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-size: 14px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 150ms ease;
+}
+
+.chip:hover {
+  background: hsl(var(--accent));
+  border-color: hsl(var(--primary) / 0.3);
+}
+
+/* Capability badge (on suggestion chips) */
+.cap-badge {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+}
+
+.cap-badge.cap-semantic { color: #fff; background: #0369a1; }
+.cap-badge.cap-exact { color: #fff; background: #16a34a; }
+.cap-badge.cap-combined { color: #fff; background: #7c3aed; }
+.cap-badge.cap-structured { color: #fff; background: #ea580c; }
+.cap-badge.cap-autocomplete { color: #fff; background: #0891b2; }
+.cap-badge.cap-fuzzy { color: #fff; background: #db2777; }
+
+/* Mode badge */
+.mode-badge {
+  font-size: 11px;
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-full);
+}
+
+/* Status row */
+.status-row {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+  font-size: 14px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.status-row .error {
+  color: hsl(var(--destructive));
+  font-weight: 700;
+}
+
+/* Loading */
+.loading-container {
+  margin-top: 16px;
+  margin-bottom: 8px;
+  animation: fade-in 200ms ease-out;
+}
+
+.loading-bar {
+  width: 100%;
+  height: 4px;
+  background: hsl(var(--secondary));
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  position: relative;
+}
+
+.loading-bar-progress {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, hsl(var(--primary)), hsl(var(--primary) / 0.6), hsl(var(--primary)));
+  background-size: 200% 100%;
+  border-radius: var(--radius-full);
+  animation: loading-slide 1.5s ease-in-out infinite;
+}
+
+.loading-text {
+  margin-top: 8px;
+  text-align: center;
+  color: hsl(var(--primary));
+  font-size: 14px;
+  font-weight: 600;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+/* Results area */
+.results {
+  margin-top: 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.score {
+  color: hsl(var(--primary));
+  font-weight: 700;
+}
+
+details {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+}
+
+pre {
+  margin: 6px 0 0;
+  padding: 8px;
+  border-radius: var(--radius-lg);
+  background: hsl(var(--secondary));
+  overflow: auto;
+  font-size: 12px;
+  line-height: 1.4;
+  color: hsl(var(--foreground));
+  font-family: var(--font-mono);
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---------------------------------------------------------------------------
+   Template: Document Search
+   --------------------------------------------------------------------------- */
+.doc-results { gap: 10px; }
+
+.doc-card {
+  display: flex;
+  gap: 12px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  padding: 14px;
+  box-shadow: var(--shadow-xs);
+  animation: slide-up 260ms ease-out both;
+}
+
+.doc-score-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 32px;
+}
+
+.doc-score-bar-bg {
+  width: 6px;
+  height: 60px;
+  background: hsl(var(--secondary));
+  border-radius: var(--radius-full);
+  position: relative;
+  overflow: hidden;
+}
+
+.doc-score-bar-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: hsl(var(--primary));
+  border-radius: var(--radius-full);
+  transition: height 400ms ease-out;
+}
+
+.doc-score-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: hsl(var(--primary));
+  font-family: var(--font-mono);
+}
+
+.doc-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.doc-id {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  margin-bottom: 4px;
+}
+
+.doc-preview {
+  font-size: 14px;
+  line-height: 1.5;
+  color: hsl(var(--foreground));
+  margin-bottom: 6px;
+}
+
+/* ---------------------------------------------------------------------------
+   Template: E-Commerce / Media
+   --------------------------------------------------------------------------- */
+.ecommerce-grid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.ecommerce-card {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  box-shadow: var(--shadow-xs);
+  animation: slide-up 260ms ease-out both;
+  display: flex;
+  flex-direction: column;
+}
+
+.ecommerce-image {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  background: hsl(var(--secondary));
+}
+
+.ecommerce-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.ecommerce-body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.ecommerce-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ecommerce-desc {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ecommerce-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.ecommerce-tag {
+  font-size: 11px;
+  font-weight: 500;
+  color: hsl(var(--primary));
+  background: hsl(var(--accent));
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+}
+
+.ecommerce-footer {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  padding-top: 6px;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.ecommerce-metric { font-size: 12px; }
+.ecommerce-metric strong { color: hsl(var(--foreground)); }
+
+/* ---------------------------------------------------------------------------
+   Template: Agentic Chat
+   --------------------------------------------------------------------------- */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 520px;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-empty {
+  text-align: center;
+  color: hsl(var(--muted-foreground));
+  padding: 60px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.chat-empty-icon { margin-bottom: 4px; }
+
+.chat-empty-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.chat-empty-desc {
+  font-size: 14px;
+  max-width: 400px;
+  line-height: 1.5;
+}
+
+.chat-empty-examples {
+  font-size: 13px;
+  color: hsl(var(--primary));
+  font-style: italic;
+  max-width: 420px;
+}
+
+.chat-bubble {
+  max-width: 85%;
+  animation: slide-up 200ms ease-out both;
+}
+
+.chat-bubble.chat-user { align-self: flex-end; }
+.chat-bubble.chat-assistant { align-self: flex-start; }
+
+.chat-user-text {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  padding: 10px 14px;
+  border-radius: var(--radius-2xl) var(--radius-2xl) var(--radius-md) var(--radius-2xl);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.chat-assistant {
+  background: hsl(var(--secondary));
+  padding: 12px 14px;
+  border-radius: var(--radius-2xl) var(--radius-2xl) var(--radius-2xl) var(--radius-md);
+  font-size: 14px;
+}
+
+.chat-summary {
+  font-size: 14px;
+  line-height: 1.6;
+  color: hsl(var(--foreground));
+  white-space: pre-line;
+  margin-bottom: 10px;
+}
+
+.chat-summary strong {
+  font-weight: 600;
+  color: hsl(var(--primary));
+}
+
+.chat-meta-bar {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px solid hsl(var(--border) / 0.5);
+}
+
+.chat-cap-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-full);
+  background: hsl(var(--accent));
+  color: hsl(var(--primary));
+}
+
+.chat-sources {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+  margin-top: 4px;
+}
+
+.chat-sources summary {
+  cursor: pointer;
+  font-weight: 500;
+  padding: 4px 0;
+}
+
+.chat-sources summary:hover {
+  color: hsl(var(--primary));
+}
+
+.chat-source-list {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chat-source-item {
+  display: flex;
+  gap: 8px;
+  padding: 6px 0;
+  border-top: 1px solid hsl(var(--border) / 0.5);
+}
+
+.chat-source-num {
+  font-size: 11px;
+  font-weight: 700;
+  color: hsl(var(--primary));
+  min-width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: hsl(var(--accent));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.chat-source-body { flex: 1; min-width: 0; }
+
+.chat-source-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  margin-bottom: 4px;
+}
+
+.chat-error {
+  color: hsl(var(--destructive));
+  font-weight: 600;
+}
+
+.chat-typing {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.chat-typing-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: hsl(var(--muted-foreground));
+  animation: typing-bounce 1.4s ease-in-out infinite;
+}
+
+.chat-typing-dot:nth-child(2) { animation-delay: 0.2s; }
+.chat-typing-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes typing-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+  30% { transform: translateY(-6px); opacity: 1; }
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid hsl(var(--border));
+  margin-top: auto;
+}
+
+.chat-input {
+  flex: 1;
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius-full);
+  padding: 10px 16px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  outline: none;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  height: 48px;
+}
+
+.chat-input:focus {
+  border-color: hsl(var(--primary));
+  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.2);
+}
+
+/* ---------------------------------------------------------------------------
+   Comparison Mode
+   --------------------------------------------------------------------------- */
+
+/* Toggle switch */
+.compare-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.compare-toggle-label {
+  font-size: 13px;
+  color: hsl(var(--muted-foreground));
+  user-select: none;
+  font-weight: 500;
+}
+
+.compare-toggle-track {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background-color: hsl(var(--input));
+  cursor: pointer;
+  transition: background-color 0.2s;
+  flex-shrink: 0;
+}
+
+.compare-toggle-track.on {
+  background-color: hsl(var(--primary));
+}
+
+.compare-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: hsl(var(--card));
+  transition: left 0.2s;
+  box-shadow: var(--shadow-xs);
+}
+
+.compare-toggle-track.on .compare-toggle-thumb {
+  left: 18px;
+}
+
+/* Index 2 label accent color */
+.idx2-label {
+  color: hsl(var(--primary));
+}
+
+/* Comparison panes layout */
+.comparison-panes {
+  display: flex;
+  gap: 12px;
+}
+
+/* Result pane */
+.result-pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.result-pane-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.result-pane-header.idx1 {
+  background: hsl(var(--secondary));
+}
+
+.result-pane-header.idx2 {
+  background: hsl(var(--accent));
+}
+
+.result-pane-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 8px;
+  border-radius: var(--radius-md);
+}
+
+.result-pane-label.idx1 {
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--secondary));
+  border: 1px solid hsl(var(--border));
+}
+
+.result-pane-label.idx2 {
+  color: hsl(var(--primary));
+  background: hsl(var(--accent));
+  border: 1px solid hsl(var(--primary) / 0.2);
+}
+
+.result-pane-index {
+  font-size: 13px;
+  color: hsl(var(--foreground));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-pane-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.result-pane-loading {
+  padding: 16px 12px;
+  text-align: center;
+}
+
+.result-pane-error {
+  margin: 8px 12px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  background: hsl(var(--destructive) / 0.08);
+  border: 1px solid hsl(var(--destructive) / 0.2);
+  color: hsl(var(--destructive));
+  font-size: 13px;
+}
+
+.result-pane-results {
+  flex: 1;
+  overflow: auto;
+  padding: 0 4px;
+}
+
+/* ---- Animations ---- */
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes loading-slide {
+  0% { left: -40%; background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { left: 100%; background-position: 0% 50%; }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .comparison-panes { flex-direction: column; }
+}
+
+@media (max-width: 640px) {
+  .search-row { flex-direction: column; }
+  .search-btn { min-height: 48px; }
+  .idx-row { flex-direction: column; align-items: stretch; }
+  .idx-input { width: 100%; }
+  .tpl-grid { grid-template-columns: repeat(2, 1fr); }
+  .field-map-row { grid-template-columns: 1fr; }
+  .ecommerce-grid { grid-template-columns: 1fr; }
+  .chat-container { height: 400px; }
+}


### PR DESCRIPTION
Add the opensearch-skills agent skill with search application building and observability workflows. Includes SKILL.md entry point, CLI scripts, AWS deployment guides, search knowledge references, and observability guides for log analytics and trace investigation.

Also adds repo scaffolding: README, Developer Guide, Contributing guide, Code of Conduct, License, CI workflows, and gitignore.

Copied over most of the skill information from https://github.com/opensearch-project/opensearch-launchpad/tree/main/skills/opensearch-launchpad and applied few refactoring.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
