### PR TITLE
Add tests and Fix CI

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -89,26 +89,62 @@ uv run pytest tests/test_your_skill.py -v
 
 ## Testing
 
-All tests live in the `tests/` directory and run with [pytest](https://docs.pytest.org/) via `uv`:
+All tests live in the `tests/` directory and run with [pytest](https://docs.pytest.org/) via [uv](https://docs.astral.sh/uv/).
+
+### Prerequisites
+
+- Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (dependency manager / task runner)
+
+No additional setup is needed — `uv run` automatically creates a virtual environment and installs all dependencies (including `opensearch-py` and `pytest`) from `pyproject.toml` on first run.
+
+### Running the full test suite
 
 ```bash
-uv run pytest -q
+uv run pytest tests/ -v
 ```
 
-### Running a subset
+### Running a subset of tests
 
 ```bash
-# Only opensearch-skills tests
-uv run pytest tests/test_opensearch_skills_*.py -v
+# Run tests for a specific module
+uv run pytest tests/test_agent_skills_client.py -v
+uv run pytest tests/test_agent_skills_search.py -v
 
-# Single file
-uv run pytest tests/test_opensearch_skills_search.py -v
+# Run tests matching a keyword
+uv run pytest tests/ -v -k "preflight"
+
+# Run a single test
+uv run pytest tests/test_agent_skills_evaluate.py::test_ndcg_perfect_ranking -v
 ```
+
+### Available test files
+
+| Test file | Module under test |
+|---|---|
+| `test_agent_skills_client.py` | `lib/client.py` — connection, auth, text normalization |
+| `test_agent_skills_evaluate.py` | `lib/evaluate.py` — search quality metrics, diagnostics, reporting |
+| `test_agent_skills_operations.py` | `lib/operations.py` — index CRUD, bulk indexing, pipelines, model deployment |
+| `test_agent_skills_preflight.py` | `lib/client.py` — preflight cluster detection and credential management |
+| `test_agent_skills_samples.py` | `lib/samples.py` — file loading (JSON/CSV/TSV), text field inference |
+| `test_agent_skills_search.py` | `lib/search.py` — query building, suggestions, autocomplete, search UI |
+| `test_agent_skills_standalone_assets.py` | Verifies UI assets and sample data are bundled correctly |
 
 ### Writing new tests
 
-- Tests must not require a running OpenSearch cluster. Use fake/mock clients.
-- Import from skill scripts by inserting the scripts directory onto `sys.path` (see existing test patterns).
+- **No cluster required.** Tests must not require a running OpenSearch cluster. Use fake/mock clients (see existing tests for patterns).
+- **Naming convention.** Name test files `test_agent_skills_<module>.py` to match the skill's `scripts/lib/` modules.
+- **Importing skill code.** Insert the scripts directory onto `sys.path` at the top of your test file:
+  ```python
+  import sys
+  from pathlib import Path
+
+  _SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts"
+  sys.path.insert(0, str(_SCRIPTS_DIR))
+
+  from lib.client import normalize_text  # example import
+  ```
+- **Monkeypatching.** Use pytest's `monkeypatch` fixture to stub out `create_client` and other functions that would connect to a real cluster.
 
 ### CI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "opensearch-agent-skills"
+version = "0.1.0"
+description = "OpenSearch Agent Skills"
+requires-python = ">=3.11"
+dependencies = [
+    "opensearch-py",
+]
+
+[dependency-groups]
+dev = ["pytest>=7.0"]

--- a/tests/test_agent_skills_client.py
+++ b/tests/test_agent_skills_client.py
@@ -1,0 +1,203 @@
+"""Tests for skills/opensearch-skills/scripts/lib/client.py"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the scripts/lib package importable
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.client import (
+    normalize_text,
+    resolve_http_auth,
+    build_client,
+    can_connect,
+    OPENSEARCH_DEFAULT_USER,
+    OPENSEARCH_DEFAULT_PASSWORD,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_text
+# ---------------------------------------------------------------------------
+def test_normalize_text_collapses_whitespace():
+    assert normalize_text("  hello   world  ") == "hello world"
+
+
+def test_normalize_text_handles_none():
+    assert normalize_text(None) == ""
+
+
+def test_normalize_text_converts_non_string():
+    assert normalize_text(42) == "42"
+
+
+def test_normalize_text_handles_empty_string():
+    assert normalize_text("") == ""
+
+
+def test_normalize_text_preserves_single_word():
+    assert normalize_text("hello") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# resolve_http_auth
+# ---------------------------------------------------------------------------
+def test_resolve_http_auth_default_mode(monkeypatch):
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+    monkeypatch.delenv("OPENSEARCH_USER", raising=False)
+    monkeypatch.delenv("OPENSEARCH_PASSWORD", raising=False)
+
+    result = resolve_http_auth()
+
+    assert result == (OPENSEARCH_DEFAULT_USER, OPENSEARCH_DEFAULT_PASSWORD)
+
+
+def test_resolve_http_auth_none_mode(monkeypatch):
+    monkeypatch.setenv("OPENSEARCH_AUTH_MODE", "none")
+
+    result = resolve_http_auth()
+
+    assert result is None
+
+
+def test_resolve_http_auth_custom_mode(monkeypatch):
+    monkeypatch.setenv("OPENSEARCH_AUTH_MODE", "custom")
+    monkeypatch.setenv("OPENSEARCH_USER", "myuser")
+    monkeypatch.setenv("OPENSEARCH_PASSWORD", "mypass")
+
+    result = resolve_http_auth()
+
+    assert result == ("myuser", "mypass")
+
+
+def test_resolve_http_auth_custom_mode_missing_user(monkeypatch):
+    monkeypatch.setenv("OPENSEARCH_AUTH_MODE", "custom")
+    monkeypatch.delenv("OPENSEARCH_USER", raising=False)
+    monkeypatch.setenv("OPENSEARCH_PASSWORD", "mypass")
+
+    with pytest.raises(RuntimeError, match="requires OPENSEARCH_USER and OPENSEARCH_PASSWORD"):
+        resolve_http_auth()
+
+
+def test_resolve_http_auth_custom_mode_missing_password(monkeypatch):
+    monkeypatch.setenv("OPENSEARCH_AUTH_MODE", "custom")
+    monkeypatch.setenv("OPENSEARCH_USER", "myuser")
+    monkeypatch.delenv("OPENSEARCH_PASSWORD", raising=False)
+
+    with pytest.raises(RuntimeError, match="requires OPENSEARCH_USER and OPENSEARCH_PASSWORD"):
+        resolve_http_auth()
+
+
+def test_resolve_http_auth_case_insensitive(monkeypatch):
+    monkeypatch.setenv("OPENSEARCH_AUTH_MODE", "  None  ")
+
+    result = resolve_http_auth()
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_client
+# ---------------------------------------------------------------------------
+def test_build_client_ssl_with_auth(monkeypatch):
+    calls = []
+
+    class _FakeOpenSearch:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    import lib.client as client_mod
+    monkeypatch.setattr(client_mod, "OpenSearch", _FakeOpenSearch)
+
+    build_client(use_ssl=True, http_auth=("admin", "pass"))
+
+    assert len(calls) == 1
+    assert calls[0]["use_ssl"] is True
+    assert calls[0]["http_auth"] == ("admin", "pass")
+    assert calls[0]["verify_certs"] is False
+
+
+def test_build_client_no_ssl_no_auth(monkeypatch):
+    calls = []
+
+    class _FakeOpenSearch:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    import lib.client as client_mod
+    monkeypatch.setattr(client_mod, "OpenSearch", _FakeOpenSearch)
+
+    build_client(use_ssl=False, http_auth=None)
+
+    assert len(calls) == 1
+    assert calls[0]["use_ssl"] is False
+    assert "http_auth" not in calls[0]
+
+
+# ---------------------------------------------------------------------------
+# can_connect
+# ---------------------------------------------------------------------------
+def test_can_connect_success():
+    class _FakeClient:
+        def info(self):
+            return {"version": {"number": "2.17.0"}}
+
+    ok, auth_fail = can_connect(_FakeClient())
+
+    assert ok is True
+    assert auth_fail is False
+
+
+def test_can_connect_auth_failure():
+    class _FakeClient:
+        def info(self):
+            raise Exception("security_exception: missing authentication credentials")
+
+    ok, auth_fail = can_connect(_FakeClient())
+
+    assert ok is False
+    assert auth_fail is True
+
+
+def test_can_connect_generic_failure():
+    class _FakeClient:
+        def info(self):
+            raise Exception("Connection refused")
+
+    ok, auth_fail = can_connect(_FakeClient())
+
+    assert ok is False
+    assert auth_fail is False
+
+
+def test_can_connect_404_with_fallback_cat_success():
+    class _FakeCat:
+        def indices(self, format="json"):
+            return []
+
+    class _FakeClient:
+        def __init__(self):
+            self.cat = _FakeCat()
+
+        def info(self):
+            raise Exception("NotFoundError 404")
+
+    ok, auth_fail = can_connect(_FakeClient())
+
+    assert ok is True
+    assert auth_fail is False
+
+
+def test_can_connect_403_token_detected():
+    class _FakeClient:
+        def info(self):
+            raise Exception("403 Forbidden")
+
+    ok, auth_fail = can_connect(_FakeClient())
+
+    assert ok is False
+    assert auth_fail is True

--- a/tests/test_agent_skills_evaluate.py
+++ b/tests/test_agent_skills_evaluate.py
@@ -1,0 +1,808 @@
+"""Tests for skills/opensearch-skills/scripts/lib/evaluate.py"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts"
+sys.path.insert(0, str(_LIB_DIR))
+
+from lib.evaluate import (
+    GRADE_LABELS,
+    bar,
+    compute_query_metrics,
+    dcg,
+    diagnose_query,
+    evaluate_results,
+    format_completion,
+    format_findings,
+    format_report,
+    mrr,
+    ndcg,
+    precision_at_k,
+    star_rating,
+)
+
+
+# ---------------------------------------------------------------------------
+# Visual helpers
+# ---------------------------------------------------------------------------
+
+
+def test_star_rating_perfect():
+    assert star_rating(1.0) == "★★★★★"
+
+
+def test_star_rating_strong():
+    assert star_rating(0.85) == "★★★★☆"
+
+
+def test_star_rating_adequate():
+    assert star_rating(0.55) == "★★★☆☆"
+
+
+def test_star_rating_weak():
+    assert star_rating(0.30) == "★★☆☆☆"
+
+
+def test_star_rating_poor():
+    assert star_rating(0.10) == "★☆☆☆☆"
+
+
+def test_star_rating_zero():
+    assert star_rating(0.0) == "✗ 0.00"
+
+
+def test_bar_full():
+    assert bar(1.0) == "██████████"
+
+
+def test_bar_empty():
+    assert bar(0.0) == "░░░░░░░░░░"
+
+
+def test_bar_half():
+    result = bar(0.5)
+    assert result.count("█") == 5
+    assert result.count("░") == 5
+
+
+def test_bar_custom_width():
+    result = bar(0.5, width=4)
+    assert len(result) == 4
+
+
+def test_grade_labels():
+    assert GRADE_LABELS[3] == "perfect"
+    assert GRADE_LABELS[2] == "relevant"
+    assert GRADE_LABELS[1] == "marginal"
+    assert GRADE_LABELS[0] == ""
+
+
+# ---------------------------------------------------------------------------
+# Metrics: dcg
+# ---------------------------------------------------------------------------
+
+
+def test_dcg_perfect_single():
+    assert dcg([3], 1) == pytest.approx(3.0)
+
+
+def test_dcg_two_items():
+    result = dcg([3, 2], 2)
+    assert result == pytest.approx(3.0 + 2.0 / math.log2(3))
+
+
+def test_dcg_with_zeros():
+    assert dcg([0, 0, 3], 3) == pytest.approx(3.0 / math.log2(4))
+
+
+def test_dcg_respects_k():
+    assert dcg([3, 2, 1], 1) == pytest.approx(3.0)
+
+
+def test_dcg_empty():
+    assert dcg([], 5) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Metrics: ndcg
+# ---------------------------------------------------------------------------
+
+
+def test_ndcg_perfect_ranking():
+    assert ndcg([3, 2, 1], [3, 2, 1], 3) == pytest.approx(1.0)
+
+
+def test_ndcg_worst_ranking():
+    assert ndcg([0, 0, 0], [3], 3) == pytest.approx(0.0)
+
+
+def test_ndcg_reversed_ranking():
+    score = ndcg([1, 2, 3], [3, 2, 1], 3)
+    assert 0.0 < score < 1.0
+
+
+def test_ndcg_no_ideal():
+    assert ndcg([0, 0], [0, 0], 2) == 0.0
+
+
+def test_ndcg_k_truncates():
+    assert ndcg([0, 3], [3], 1) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Metrics: precision_at_k
+# ---------------------------------------------------------------------------
+
+
+def test_precision_all_relevant():
+    assert precision_at_k([3, 2, 1], 3) == pytest.approx(1.0)
+
+
+def test_precision_none_relevant():
+    assert precision_at_k([0, 0, 0], 3) == pytest.approx(0.0)
+
+
+def test_precision_mixed():
+    assert precision_at_k([3, 0, 1, 0, 0], 5) == pytest.approx(0.4)
+
+
+def test_precision_respects_k():
+    assert precision_at_k([1, 0, 1], 2) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Metrics: mrr
+# ---------------------------------------------------------------------------
+
+
+def test_mrr_first_position():
+    assert mrr([3, 0, 0]) == pytest.approx(1.0)
+
+
+def test_mrr_second_position():
+    assert mrr([0, 2, 0]) == pytest.approx(0.5)
+
+
+def test_mrr_third_position():
+    assert mrr([0, 0, 1]) == pytest.approx(1.0 / 3.0)
+
+
+def test_mrr_no_relevant():
+    assert mrr([0, 0, 0]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# compute_query_metrics
+# ---------------------------------------------------------------------------
+
+
+def _make_results(titles):
+    """Build a fake OpenSearch response from a list of titles."""
+    return {
+        "hits": {
+            "hits": [{"_id": t, "_source": {"title": t}} for t in titles],
+        }
+    }
+
+
+def test_compute_metrics_perfect():
+    results = _make_results(["Doc A", "Doc B"])
+    relevance = {"Doc A": 3, "Doc B": 2}
+    m = compute_query_metrics(results, relevance, "title", k=2)
+
+    assert m["ndcg"] == pytest.approx(1.0)
+    assert m["p@k"] == pytest.approx(1.0)
+    assert m["mrr"] == pytest.approx(1.0)
+    assert m["rels"] == [3, 2]
+    assert m["titles"] == ["Doc A", "Doc B"]
+    assert m["doc_ids"] == ["Doc A", "Doc B"]
+    assert len(m["dcg_contribs"]) == 2
+    assert m["dcg_contribs"][0] == pytest.approx(3.0 / math.log2(2))  # 3.0
+
+
+def test_compute_metrics_no_relevant():
+    results = _make_results(["X", "Y", "Z"])
+    relevance = {"Doc A": 3}
+    m = compute_query_metrics(results, relevance, "title", k=3)
+
+    assert m["ndcg"] == pytest.approx(0.0)
+    assert m["p@k"] == pytest.approx(0.0)
+    assert m["mrr"] == 0.0
+    assert m["rels"] == [0, 0, 0]
+
+
+def test_compute_metrics_partial():
+    results = _make_results(["X", "Doc A", "Y"])
+    relevance = {"Doc A": 3}
+    m = compute_query_metrics(results, relevance, "title", k=3)
+
+    assert m["mrr"] == pytest.approx(0.5)
+    assert m["p@k"] == pytest.approx(1.0 / 3.0)
+
+
+def test_compute_metrics_respects_k():
+    results = _make_results(["X", "Y", "Doc A"])
+    relevance = {"Doc A": 3}
+    m = compute_query_metrics(results, relevance, "title", k=2)
+
+    assert m["rels"] == [0, 0]
+    assert m["titles"] == ["X", "Y"]
+
+
+def test_compute_metrics_uses_title_field():
+    results = {
+        "hits": {
+            "hits": [{"_id": "1", "_source": {"name": "Doc A"}}],
+        }
+    }
+    relevance = {"Doc A": 3}
+    m = compute_query_metrics(results, relevance, "name", k=1)
+
+    assert m["rels"] == [3]
+
+
+def test_compute_metrics_falls_back_to_id():
+    results = {
+        "hits": {
+            "hits": [{"_id": "doc-1", "_source": {}}],
+        }
+    }
+    relevance = {"doc-1": 3}
+    m = compute_query_metrics(results, relevance, "title", k=1)
+
+    assert m["rels"] == [3]
+    assert m["titles"] == ["doc-1"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers for diagnose_query tests
+# ---------------------------------------------------------------------------
+
+
+def _make_metrics(ndcg_val, titles=None, rels=None):
+    """Helper to build a metrics dict for diagnosis tests."""
+    return {
+        "ndcg": ndcg_val,
+        "p@k": 0.0,
+        "mrr": 0.0,
+        "titles": titles or [],
+        "rels": rels or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# diagnose_query: Rule 1 -- all methods fail
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_rule1_semantic_all_fail():
+    test = {"type": "semantic", "query": "abstract concept", "relevance": {"A": 3}}
+    metrics = {m: _make_metrics(0.1, ["X"], [0]) for m in ["HYBRID", "BM25", "KNN"]}
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    assert len(findings) >= 1
+    assert findings[0][0] == "[MODEL_SELECTION]"
+    assert findings[0][1] == "HIGH"
+
+
+def test_diagnose_rule1_combined_all_fail():
+    test = {"type": "combined", "query": "structured query", "relevance": {"A": 3}}
+    metrics = {m: _make_metrics(0.1, ["X"], [0]) for m in ["HYBRID", "BM25", "KNN"]}
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    assert len(findings) >= 1
+    assert findings[0][0] == "[INDEX_MAPPING]"
+    assert findings[0][1] == "HIGH"
+
+
+def test_diagnose_rule1_generic_type_all_fail():
+    """Unrecognised query type still triggers rule 1 with INDEX_MAPPING."""
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    metrics = {"MethodA": _make_metrics(0.1, ["X"], [0])}
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    assert len(findings) >= 1
+    assert findings[0][0] == "[INDEX_MAPPING]"
+    assert findings[0][1] == "HIGH"
+
+
+def test_diagnose_rule1_not_triggered_when_one_succeeds():
+    test = {"type": "semantic", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "HYBRID": _make_metrics(0.1, ["X"], [0]),
+        "BM25": _make_metrics(0.6, ["A"], [3]),
+        "KNN": _make_metrics(0.1, ["X"], [0]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    rule1_findings = [f for f in findings if f[1] == "HIGH" and "All methods" in f[2]]
+    assert len(rule1_findings) == 0
+
+
+def test_diagnose_rule1_single_method_fails():
+    """Rule 1 works with a single method."""
+    test = {"type": "semantic", "query": "concept", "relevance": {"A": 3}}
+    metrics = {"OnlyMethod": _make_metrics(0.1, ["X"], [0])}
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    assert len(findings) >= 1
+    assert findings[0][1] == "HIGH"
+
+
+# ---------------------------------------------------------------------------
+# diagnose_query: Rule 2 -- pairwise method gaps (tag-aware)
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_rule2_vector_fails_lexical_succeeds():
+    test = {"type": "exact", "query": "entity lookup", "relevance": {"A": 3}}
+    metrics = {
+        "BM25": _make_metrics(0.8, ["A"], [3]),
+        "KNN": _make_metrics(0.1, ["X"], [0]),
+    }
+    tags = {"BM25": "lexical", "KNN": "vector"}
+
+    findings = diagnose_query(test, metrics, k=5, method_tags=tags)
+
+    model_findings = [f for f in findings if f[0] == "[MODEL_SELECTION]" and f[1] == "MEDIUM"]
+    assert len(model_findings) == 1
+    assert "KNN" in model_findings[0][2]
+
+
+def test_diagnose_rule2_lexical_fails_vector_succeeds():
+    test = {"type": "semantic", "query": "concept", "relevance": {"A": 3}}
+    metrics = {
+        "BM25": _make_metrics(0.1, ["X"], [0]),
+        "Dense": _make_metrics(0.8, ["A"], [3]),
+    }
+    tags = {"BM25": "lexical", "Dense": "vector"}
+
+    findings = diagnose_query(test, metrics, k=5, method_tags=tags)
+
+    mapping_findings = [f for f in findings if f[0] == "[INDEX_MAPPING]" and f[1] == "MEDIUM"]
+    assert len(mapping_findings) == 1
+    assert "BM25" in mapping_findings[0][2]
+
+
+def test_diagnose_rule2_untagged_pairwise_gap():
+    """Large gap between two untagged methods triggers QUERY_TUNING."""
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "MethodA": _make_metrics(0.9, ["A"], [3]),
+        "MethodB": _make_metrics(0.2, ["X"], [0]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    tuning = [f for f in findings if f[0] == "[QUERY_TUNING]"]
+    assert len(tuning) >= 1
+    assert "MethodB" in tuning[0][2]
+
+
+# ---------------------------------------------------------------------------
+# diagnose_query: Rule 3 -- hybrid worse than best single
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_rule3_hybrid_worse_than_lexical():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "Hybrid": _make_metrics(0.4, ["A", "X"], [3, 0]),
+        "BM25": _make_metrics(0.8, ["A"], [3]),
+        "KNN": _make_metrics(0.3, ["X"], [0]),
+    }
+    tags = {"Hybrid": "hybrid", "BM25": "lexical", "KNN": "vector"}
+
+    findings = diagnose_query(test, metrics, k=5, method_tags=tags)
+
+    pipeline_findings = [f for f in findings if f[0] == "[SEARCH_PIPELINE]"]
+    assert len(pipeline_findings) >= 1
+    assert pipeline_findings[0][1] == "MEDIUM"
+
+
+def test_diagnose_rule3_hybrid_worse_than_vector():
+    test = {"type": "semantic", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "Hybrid": _make_metrics(0.4, ["X", "A"], [0, 3]),
+        "BM25": _make_metrics(0.2, ["X"], [0]),
+        "KNN": _make_metrics(0.8, ["A"], [3]),
+    }
+    tags = {"Hybrid": "hybrid", "BM25": "lexical", "KNN": "vector"}
+
+    findings = diagnose_query(test, metrics, k=5, method_tags=tags)
+
+    pipeline_findings = [f for f in findings if f[0] == "[SEARCH_PIPELINE]"]
+    assert len(pipeline_findings) >= 1
+    assert pipeline_findings[0][1] == "LOW"
+
+
+def test_diagnose_rule3_not_triggered_when_close():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "Hybrid": _make_metrics(0.75, ["A"], [3]),
+        "BM25": _make_metrics(0.80, ["A"], [3]),
+        "KNN": _make_metrics(0.70, ["A"], [3]),
+    }
+    tags = {"Hybrid": "hybrid", "BM25": "lexical", "KNN": "vector"}
+
+    findings = diagnose_query(test, metrics, k=5, method_tags=tags)
+
+    pipeline_findings = [f for f in findings if f[0] == "[SEARCH_PIPELINE]"]
+    assert len(pipeline_findings) == 0
+
+
+def test_diagnose_rule3_not_triggered_without_hybrid_tag():
+    """Without hybrid tag, rule 3 doesn't fire (methods are untagged)."""
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "MethodA": _make_metrics(0.4, ["A", "X"], [3, 0]),
+        "MethodB": _make_metrics(0.8, ["A"], [3]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    pipeline_findings = [f for f in findings if f[0] == "[SEARCH_PIPELINE]"]
+    assert len(pipeline_findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# diagnose_query: Rule 4 -- irrelevant doc in top 2
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_rule4_noise_in_one_method():
+    test = {"type": "combined", "query": "test query", "relevance": {"A": 3}}
+    metrics = {
+        "Hybrid": _make_metrics(0.5, ["Noise", "A", "X", "Y", "Z"], [0, 3, 0, 0, 0]),
+        "BM25": _make_metrics(0.5, ["Noise", "A", "X"], [0, 3, 0]),
+        "KNN": _make_metrics(0.5, ["A", "B", "C"], [3, 0, 0]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    tuning_findings = [f for f in findings if f[0] == "[QUERY_TUNING]"]
+    assert len(tuning_findings) >= 1
+    assert "Noise" in tuning_findings[0][2]
+
+
+def test_diagnose_rule4_noise_across_all_methods():
+    test = {"type": "semantic", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "M1": _make_metrics(0.5, ["FalsePos", "A", "X", "Y", "Z"], [0, 3, 0, 0, 0]),
+        "M2": _make_metrics(0.5, ["FalsePos", "A", "D"], [0, 3, 0]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    model_findings = [f for f in findings if f[0] == "[MODEL_SELECTION]"]
+    assert len(model_findings) >= 1
+
+
+def test_diagnose_rule4_not_triggered_when_ndcg_high():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3, "B": 2}}
+    metrics = {
+        "M1": _make_metrics(0.9, ["X", "A", "B"], [0, 3, 2]),
+        "M2": _make_metrics(0.9, ["A", "B"], [3, 2]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    rule4_findings = [f for f in findings if f[0] == "[QUERY_TUNING]"]
+    assert len(rule4_findings) == 0
+
+
+def test_diagnose_rule4_single_method():
+    """Rule 4 works with a single method (no cross-method attribution)."""
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    metrics = {
+        "Only": _make_metrics(0.5, ["Noise", "A", "X"], [0, 3, 0]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    tuning = [f for f in findings if f[0] == "[QUERY_TUNING]"]
+    assert len(tuning) >= 1
+    assert "Noise" in tuning[0][2]
+
+
+# ---------------------------------------------------------------------------
+# diagnose_query: Rule 5 -- missed relevant docs
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_rule5_missed_docs():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3, "B": 2, "C": 2}}
+    metrics = {
+        "M1": _make_metrics(0.5, ["A"], [3]),
+        "M2": _make_metrics(0.5, ["A"], [3]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5, embedded_fields="title + text")
+
+    missed_findings = [f for f in findings if "not in any top" in f[2]]
+    assert len(missed_findings) == 1
+    assert "B" in missed_findings[0][2] or "C" in missed_findings[0][2]
+
+
+def test_diagnose_rule5_no_missed_when_all_found():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3, "B": 2}}
+    metrics = {
+        "M1": _make_metrics(1.0, ["A", "B"], [3, 2]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    missed_findings = [f for f in findings if "not in any top" in f[2]]
+    assert len(missed_findings) == 0
+
+
+def test_diagnose_rule5_ignores_marginal_docs():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3, "B": 1}}
+    metrics = {
+        "M1": _make_metrics(1.0, ["A"], [3]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    missed_findings = [f for f in findings if "not in any top" in f[2]]
+    assert len(missed_findings) == 0
+
+
+def test_diagnose_rule5_found_across_different_methods():
+    """Doc found by one method is not counted as missed."""
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3, "B": 2}}
+    metrics = {
+        "M1": _make_metrics(0.8, ["A"], [3]),
+        "M2": _make_metrics(0.8, ["B"], [2]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+
+    missed_findings = [f for f in findings if "not in any top" in f[2]]
+    assert len(missed_findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# diagnose_query: no findings when everything works
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_no_findings_when_all_good():
+    test = {"type": "exact", "query": "perfect query", "relevance": {"A": 3}}
+    metrics = {
+        "M1": _make_metrics(1.0, ["A"], [3]),
+        "M2": _make_metrics(1.0, ["A"], [3]),
+    }
+
+    findings = diagnose_query(test, metrics, k=5)
+    assert findings == []
+
+
+def test_diagnose_no_findings_single_method_good():
+    test = {"type": "exact", "query": "perfect query", "relevance": {"A": 3}}
+    metrics = {"Only": _make_metrics(1.0, ["A"], [3])}
+
+    findings = diagnose_query(test, metrics, k=5)
+    assert findings == []
+
+
+def test_diagnose_empty_methods():
+    test = {"type": "exact", "query": "test", "relevance": {"A": 3}}
+    findings = diagnose_query(test, {}, k=5)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# evaluate_results (integration)
+# ---------------------------------------------------------------------------
+
+
+def _make_os_response(titles):
+    """Build a minimal OpenSearch search response."""
+    return {
+        "hits": {
+            "hits": [{"_id": t, "_source": {"title": t}} for t in titles],
+        }
+    }
+
+
+def test_evaluate_results_basic():
+    tests = [
+        {"name": "Q1", "type": "exact", "query": "test", "relevance": {"A": 3, "B": 2}},
+    ]
+    results_by_method = {
+        "Alpha": [_make_os_response(["A", "B"])],
+        "Beta": [_make_os_response(["B", "A"])],
+    }
+
+    report = evaluate_results(tests, results_by_method, k=2, title_field="title")
+
+    assert report["methods"] == ["Alpha", "Beta"]
+    assert report["k"] == 2
+    assert len(report["metrics"]["Alpha"]) == 1
+    assert len(report["metrics"]["Beta"]) == 1
+    assert report["metrics"]["Alpha"][0]["ndcg"] == pytest.approx(1.0)
+    assert report["metrics"]["Beta"][0]["ndcg"] < 1.0
+    assert "Alpha" in report["summary"]
+    assert "Beta" in report["summary"]
+
+
+def test_evaluate_results_single_method():
+    tests = [
+        {"name": "Q1", "type": "exact", "query": "test", "relevance": {"A": 3}},
+    ]
+    results_by_method = {
+        "Only": [_make_os_response(["A"])],
+    }
+
+    report = evaluate_results(tests, results_by_method, k=1)
+
+    assert report["methods"] == ["Only"]
+    assert report["summary"]["Only"]["mean_ndcg"] == pytest.approx(1.0)
+
+
+def test_evaluate_results_multiple_queries():
+    tests = [
+        {"name": "Q1", "type": "exact", "query": "a", "relevance": {"A": 3}},
+        {"name": "Q2", "type": "semantic", "query": "b", "relevance": {"B": 3}},
+    ]
+    results_by_method = {
+        "M": [_make_os_response(["A"]), _make_os_response(["X"])],
+    }
+
+    report = evaluate_results(tests, results_by_method, k=1)
+
+    assert report["metrics"]["M"][0]["ndcg"] == pytest.approx(1.0)
+    assert report["metrics"]["M"][1]["ndcg"] == pytest.approx(0.0)
+    assert report["summary"]["M"]["mean_ndcg"] == pytest.approx(0.5)
+
+
+def test_evaluate_results_with_tags():
+    tests = [
+        {"name": "Q1", "type": "exact", "query": "test", "relevance": {"A": 3}},
+    ]
+    results_by_method = {
+        "BM25": [_make_os_response(["A"])],
+        "KNN": [_make_os_response(["X"])],
+    }
+    tags = {"BM25": "lexical", "KNN": "vector"}
+
+    report = evaluate_results(tests, results_by_method, k=1, method_tags=tags)
+
+    # KNN fails, BM25 succeeds -> should produce MODEL_SELECTION finding
+    flat_findings = [
+        (tag, sev) for _, findings in report["findings"] for tag, sev, _ in findings
+    ]
+    model_findings = [(t, s) for t, s in flat_findings if t == "[MODEL_SELECTION]"]
+    assert len(model_findings) >= 1
+
+
+def test_evaluate_results_findings_empty_when_perfect():
+    tests = [
+        {"name": "Q1", "type": "exact", "query": "test", "relevance": {"A": 3}},
+    ]
+    results_by_method = {
+        "M1": [_make_os_response(["A"])],
+        "M2": [_make_os_response(["A"])],
+    }
+
+    report = evaluate_results(tests, results_by_method, k=1)
+
+    assert report["findings"] == []
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_findings_empty():
+    output = format_findings([])
+    assert "None" in output
+    assert "performing well" in output
+
+
+def test_format_findings_with_data():
+    all_findings = [
+        ("Q1", [("[MODEL_SELECTION]", "HIGH", "Test message")]),
+    ]
+    output = format_findings(all_findings)
+    assert "MODEL_SELECTION" in output
+    assert "Test message" in output
+    assert "RECOMMENDED NEXT ACTION" in output
+
+
+def test_format_completion_target_met():
+    report = {
+        "metrics": {"M": [{"ndcg": 0.9, "p@k": 0.8, "mrr": 0.9}]},
+        "findings": [],
+        "k": 5,
+    }
+    output = format_completion(report)
+    assert "Target met" in output
+
+
+def test_format_completion_needs_work():
+    report = {
+        "metrics": {"M": [{"ndcg": 0.3, "p@k": 0.2, "mrr": 0.3}]},
+        "findings": [("Q1", [("[INDEX_MAPPING]", "HIGH", "bad")])],
+        "k": 5,
+    }
+    output = format_completion(report)
+    assert "optimization recommended" in output
+
+
+def test_format_report_runs_without_error():
+    tests = [
+        {"name": "Q1", "type": "exact", "query": "test", "relevance": {"A": 3}},
+    ]
+    report = {
+        "methods": ["M1", "M2"],
+        "tests": tests,
+        "metrics": {
+            "M1": [{"ndcg": 1.0, "p@k": 1.0, "mrr": 1.0, "rels": [3], "titles": ["A"],
+                     "doc_ids": ["a1"], "scores": [5.0], "dcg_contribs": [3.0]}],
+            "M2": [{"ndcg": 0.0, "p@k": 0.0, "mrr": 0.0, "rels": [0], "titles": ["X"],
+                     "doc_ids": ["x1"], "scores": [1.0], "dcg_contribs": [0.0]}],
+        },
+        "findings": [],
+        "summary": {
+            "M1": {"mean_ndcg": 1.0, "mean_pk": 1.0, "mean_mrr": 1.0},
+            "M2": {"mean_ndcg": 0.0, "mean_pk": 0.0, "mean_mrr": 0.0},
+        },
+        "k": 1,
+    }
+    output = format_report(report, config={"index": "test-index"})
+    assert "SEARCH QUALITY EVALUATION" in output
+    assert "test-index" in output
+    assert "M1" in output
+    assert "M2" in output
+
+
+# ---------------------------------------------------------------------------
+# Config schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_schema_validation():
+    """Validate that a well-formed config dict has all required fields."""
+    config = {
+        "index": "test-index",
+        "model": "sentence-transformers/all-MiniLM-L6-v2",
+        "bm25_fields": ["title^4", "text^2"],
+        "embedded_fields": "title + text",
+        "methods": [
+            {"name": "HYBRID", "mode": "hybrid", "tag": "hybrid"},
+            {"name": "BM25", "mode": "bm25", "tag": "lexical"},
+        ],
+        "tests": [
+            {
+                "name": "Q1: Test query",
+                "type": "semantic",
+                "query": "test query",
+                "relevance": {"Doc A": 3, "Doc B": 1},
+            },
+        ],
+    }
+    assert "index" in config
+    assert "model" in config
+    assert "bm25_fields" in config
+    assert len(config["tests"]) > 0
+    for test in config["tests"]:
+        assert "name" in test
+        assert "type" in test
+        assert "query" in test
+        assert "relevance" in test
+        assert isinstance(test["relevance"], dict)
+        assert test["type"] in ("semantic", "exact", "combined", "structured", "fuzzy")
+    for method in config["methods"]:
+        assert "name" in method

--- a/tests/test_agent_skills_operations.py
+++ b/tests/test_agent_skills_operations.py
@@ -1,0 +1,434 @@
+"""Tests for skills/opensearch-skills/scripts/lib/operations.py"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.operations import (
+    PRETRAINED_MODELS,
+    _wait_for_ml_task,
+    create_index,
+    index_doc,
+    index_bulk,
+    search,
+    create_pipeline,
+    deploy_local_model,
+    deploy_bedrock_model,
+    deploy_agentic_model,
+    create_flow_agent,
+    create_agentic_pipeline,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class _FakeIndices:
+    def __init__(self, exists=False):
+        self._exists = exists
+        self.created = []
+        self.deleted = []
+        self.refreshed = []
+        self.settings_calls = []
+
+    def exists(self, index):
+        return self._exists
+
+    def create(self, index, body):
+        self.created.append((index, body))
+
+    def delete(self, index, ignore=None):
+        self.deleted.append(index)
+
+    def refresh(self, index):
+        self.refreshed.append(index)
+
+    def put_settings(self, index, body):
+        self.settings_calls.append((index, body))
+
+
+class _FakeTransport:
+    def __init__(self, responses=None):
+        self._responses = responses or []
+        self._call_index = 0
+        self.calls = []
+
+    def perform_request(self, method, url, body=None, **kwargs):
+        self.calls.append((method, url, body))
+        if self._call_index < len(self._responses):
+            resp = self._responses[self._call_index]
+            self._call_index += 1
+            return resp
+        return {}
+
+
+class _FakeClient:
+    def __init__(self, exists=False, transport_responses=None):
+        self.indices = _FakeIndices(exists)
+        self.transport = _FakeTransport(transport_responses)
+        self._indexed = []
+        self._get_response = {}
+        self._search_response = {"hits": {"hits": [], "total": {"value": 0}}, "took": 1}
+        self._bulk_errors = []  # For simulating bulk errors
+
+    def index(self, index, body, id):
+        self._indexed.append((index, body, id))
+
+    def bulk(self, body):
+        """Simulate bulk indexing API"""
+        items = []
+        # Process bulk body (alternating action/doc pairs)
+        for i in range(0, len(body), 2):
+            action = body[i]
+            doc = body[i + 1]
+
+            # Check if this doc should error (for partial failure tests)
+            doc_id = action["index"]["_id"]
+            if doc_id in self._bulk_errors:
+                items.append({
+                    "index": {
+                        "_id": doc_id,
+                        "error": {"type": "simulated_error", "reason": "test error"}
+                    }
+                })
+            else:
+                items.append({
+                    "index": {
+                        "_id": doc_id,
+                        "_index": action["index"]["_index"],
+                        "result": "created"
+                    }
+                })
+                self._indexed.append((action["index"]["_index"], doc, doc_id))
+
+        return {"items": items, "errors": len(self._bulk_errors) > 0}
+
+    def get(self, index, id):
+        return self._get_response or {"_source": {}, "_id": id}
+
+    def search(self, index, body, size=10):
+        return self._search_response
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_ml_task
+# ---------------------------------------------------------------------------
+def test_wait_for_ml_task_completed():
+    client = MagicMock()
+    client.transport.perform_request.return_value = {"state": "COMPLETED", "model_id": "m-1"}
+
+    state, res = _wait_for_ml_task(client, "task-1", max_polls=2, interval=0)
+
+    assert state == "COMPLETED"
+    assert res["model_id"] == "m-1"
+
+
+def test_wait_for_ml_task_failed():
+    client = MagicMock()
+    client.transport.perform_request.return_value = {"state": "FAILED", "error": "oom"}
+
+    state, res = _wait_for_ml_task(client, "task-1", max_polls=2, interval=0)
+
+    assert state == "FAILED"
+    assert res["error"] == "oom"
+
+
+def test_wait_for_ml_task_timeout():
+    client = MagicMock()
+    client.transport.perform_request.return_value = {"state": "RUNNING"}
+
+    state, res = _wait_for_ml_task(client, "task-1", max_polls=2, interval=0)
+
+    assert state == "TIMEOUT"
+
+
+def test_wait_for_ml_task_missing_task_id():
+    client = MagicMock()
+
+    state, res = _wait_for_ml_task(client, "", max_polls=2, interval=0)
+
+    assert state == "FAILED"
+    assert "Missing task_id" in res["error"]
+
+
+# ---------------------------------------------------------------------------
+# create_index
+# ---------------------------------------------------------------------------
+def test_create_index_new_index(monkeypatch):
+    fake = _FakeClient(exists=False)
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = create_index("test-index", {"mappings": {}})
+
+    assert "created successfully" in result
+    assert fake.indices.created == [("test-index", {"mappings": {}})]
+
+
+def test_create_index_replace_existing(monkeypatch):
+    fake = _FakeClient(exists=True)
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = create_index("test-index", {}, replace_if_exists=True)
+
+    assert "recreated" in result
+    assert "test-index" in fake.indices.deleted
+
+
+def test_create_index_skip_existing(monkeypatch):
+    fake = _FakeClient(exists=True)
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = create_index("test-index", {}, replace_if_exists=False)
+
+    assert "already exists" in result
+    assert fake.indices.created == []
+
+
+def test_create_index_connection_failure(monkeypatch):
+    monkeypatch.setattr("lib.operations.create_client", lambda: (_ for _ in ()).throw(RuntimeError("no docker")))
+
+    result = create_index("test-index")
+
+    assert "Failed to create index" in result
+
+
+# ---------------------------------------------------------------------------
+# index_doc
+# ---------------------------------------------------------------------------
+def test_index_doc_success(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = index_doc("my-index", {"title": "Hello"}, "doc-1")
+
+    assert fake._indexed == [("my-index", {"title": "Hello"}, "doc-1")]
+    assert "my-index" in fake.indices.refreshed
+    parsed = json.loads(result)
+    assert parsed["_id"] == "doc-1"
+
+
+def test_index_doc_failure(monkeypatch):
+    class _FailClient(_FakeClient):
+        def index(self, index, body, id):
+            raise Exception("mapping error")
+
+    monkeypatch.setattr("lib.operations.create_client", lambda: _FailClient())
+
+    result = index_doc("my-index", {"title": "Hello"}, "doc-1")
+
+    assert "Failed to index document" in result
+
+
+# ---------------------------------------------------------------------------
+# index_bulk
+# ---------------------------------------------------------------------------
+def test_index_bulk_success(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    docs = [{"a": 1}, {"a": 2}, {"a": 3}]
+    result = json.loads(index_bulk("bulk-index", docs, id_prefix="test"))
+
+    assert result["indexed_count"] == 3
+    assert result["doc_ids"] == ["test-1", "test-2", "test-3"]
+    assert result["errors"] == []
+    assert "bulk-index" in fake.indices.refreshed
+
+
+def test_index_bulk_partial_failure(monkeypatch):
+    fake = _FakeClient()
+    fake._bulk_errors = ["doc-2"]  # Simulate doc-2 failing
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    docs = [{"a": 1}, {"a": 2}, {"a": 3}]
+    result = json.loads(index_bulk("bulk-index", docs))
+
+    assert result["indexed_count"] == 2
+    assert len(result["errors"]) == 1
+    assert "doc-2" in result["errors"][0]
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+def test_search_default_match_all():
+    fake = _FakeClient()
+
+    result = search(fake, "my-index")
+
+    assert result["took"] == 1
+
+
+def test_search_with_custom_body():
+    fake = _FakeClient()
+    body = {"query": {"term": {"status": "active"}}}
+
+    search(fake, "my-index", body=body, size=5)
+    # Just verify it doesn't raise
+
+
+# ---------------------------------------------------------------------------
+# create_pipeline
+# ---------------------------------------------------------------------------
+def test_create_pipeline_hybrid_search_auto_body(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = create_pipeline(
+        pipeline_name="hybrid-pipe",
+        pipeline_body={},
+        index_name="my-index",
+        pipeline_type="search",
+        is_hybrid=True,
+        hybrid_weights=[0.3, 0.7],
+    )
+
+    assert "created and attached" in result
+    assert fake.transport.calls
+    method, url, body = fake.transport.calls[0]
+    assert method == "PUT"
+    assert "/_search/pipeline/hybrid-pipe" in url
+    assert body["phase_results_processors"][0]["normalization-processor"]["combination"]["parameters"]["weights"] == [0.3, 0.7]
+
+
+def test_create_pipeline_ingest_requires_body(monkeypatch):
+    result = create_pipeline(
+        pipeline_name="ingest-pipe",
+        pipeline_body={},
+        index_name="my-index",
+        pipeline_type="ingest",
+    )
+
+    assert "Error: pipeline_body required" in result
+
+
+def test_create_pipeline_requires_index_name():
+    result = create_pipeline(
+        pipeline_name="pipe",
+        pipeline_body={"processors": []},
+        index_name="",
+    )
+
+    assert "Error: index_name is required" in result
+
+
+# ---------------------------------------------------------------------------
+# deploy_local_model
+# ---------------------------------------------------------------------------
+def test_deploy_local_model_unsupported():
+    result = deploy_local_model("not-a-real-model")
+
+    assert "not supported" in result
+    assert "Supported:" in result
+
+
+def test_deploy_local_model_success(monkeypatch):
+    fake = _FakeClient(transport_responses=[
+        {},                                            # set_ml_settings (PUT /_cluster/settings)
+        {"task_id": "reg-task-1"},                    # register
+        {"state": "COMPLETED", "model_id": "m-1"},    # poll register
+        {"task_id": "dep-task-1"},                    # deploy
+        {"state": "COMPLETED"},                        # poll deploy
+    ])
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    model = list(PRETRAINED_MODELS.keys())[0]
+    result = deploy_local_model(model)
+
+    assert "deployed successfully" in result
+    assert "m-1" in result
+
+
+# ---------------------------------------------------------------------------
+# deploy_bedrock_model
+# ---------------------------------------------------------------------------
+def test_deploy_bedrock_model_unsupported():
+    result = deploy_bedrock_model("wrong-model")
+
+    assert "Only amazon.titan-embed-text-v2:0 is supported" in result
+
+
+def test_deploy_bedrock_model_missing_credentials(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    result = deploy_bedrock_model("amazon.titan-embed-text-v2:0")
+
+    assert "AWS credentials" in result
+
+
+# ---------------------------------------------------------------------------
+# deploy_agentic_model
+# ---------------------------------------------------------------------------
+def test_deploy_agentic_model_missing_credentials():
+    result = deploy_agentic_model(access_key="", secret_key="")
+
+    assert "Error: AWS credentials required" in result
+
+
+def test_deploy_agentic_model_success(monkeypatch):
+    fake = _FakeClient(transport_responses=[
+        {},  # set_ml_settings
+        {"model_id": "agentic-m-1"},  # register+deploy
+    ])
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = deploy_agentic_model(access_key="AK", secret_key="SK", region="us-west-2")
+
+    assert result == "agentic-m-1"
+
+
+# ---------------------------------------------------------------------------
+# create_flow_agent
+# ---------------------------------------------------------------------------
+def test_create_flow_agent_missing_model_id():
+    result = create_flow_agent("my-agent", "")
+
+    assert "Error: model_id required" in result
+
+
+def test_create_flow_agent_success(monkeypatch):
+    fake = _FakeClient(transport_responses=[{"agent_id": "agent-1"}])
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = create_flow_agent("my-agent", "model-1")
+
+    assert "created successfully" in result
+    assert "agent-1" in result
+
+
+# ---------------------------------------------------------------------------
+# create_agentic_pipeline
+# ---------------------------------------------------------------------------
+def test_create_agentic_pipeline_missing_params():
+    assert "Error:" in create_agentic_pipeline("pipe", "", "idx")
+    assert "Error:" in create_agentic_pipeline("pipe", "agent-1", "")
+
+
+def test_create_agentic_pipeline_success(monkeypatch):
+    fake = _FakeClient()
+    monkeypatch.setattr("lib.operations.create_client", lambda: fake)
+
+    result = create_agentic_pipeline("agentic-pipe", "agent-1", "my-index")
+
+    assert "attached to" in result
+    assert fake.transport.calls
+    assert fake.indices.settings_calls
+
+
+# ---------------------------------------------------------------------------
+# PRETRAINED_MODELS registry
+# ---------------------------------------------------------------------------
+def test_pretrained_models_has_entries():
+    assert len(PRETRAINED_MODELS) > 10
+
+
+def test_pretrained_models_all_have_versions():
+    for name, version in PRETRAINED_MODELS.items():
+        assert version, f"Model {name} has empty version"

--- a/tests/test_agent_skills_preflight.py
+++ b/tests/test_agent_skills_preflight.py
@@ -1,0 +1,364 @@
+"""Tests for Agent Skills preflight cluster check functionality."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add agent skills scripts to path
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts")
+)
+
+from lib.client import preflight_check_cluster, clear_cluster_credentials
+
+
+class _ConnectableClient:
+    """Simulates a cluster that responds successfully."""
+
+    def info(self):
+        return {"version": {"number": "2.19.0"}}
+
+
+class _AuthFailureClient:
+    """Simulates a cluster that rejects credentials."""
+
+    def info(self):
+        raise RuntimeError("401 Unauthorized")
+
+
+class _UnreachableClient:
+    """Simulates no cluster listening."""
+
+    def info(self):
+        from opensearchpy.exceptions import ConnectionError as OSConnectionError
+
+        raise OSConnectionError("N/A", "Connection refused", Exception("refused"))
+
+
+def test_preflight_detects_no_auth_cluster(monkeypatch):
+    """No-auth insecure cluster is detected as available."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if not use_ssl and http_auth is None:
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "none"
+    assert "security disabled" in result["message"]
+
+
+def test_preflight_detects_ssl_no_auth_cluster(monkeypatch):
+    """No-auth SSL cluster is detected as available."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if use_ssl and http_auth is None:
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "none"
+
+
+def test_preflight_detects_default_creds_cluster(monkeypatch):
+    """Cluster reachable with default admin creds is detected as available."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if http_auth is None:
+            return _UnreachableClient()
+        if http_auth == ("admin", "myStrongPassword123!"):
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "default"
+    assert "default credentials" in result["message"]
+
+
+def test_preflight_detects_auth_required(monkeypatch):
+    """Cluster that rejects both no-auth and default creds returns auth_required."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        return _AuthFailureClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "auth_required"
+    assert "authentication failed" in result["message"].lower()
+
+
+def test_preflight_ssl_cluster_with_custom_creds_not_misdetected(monkeypatch):
+    """HTTPS cluster with non-default creds: no-auth gets auth failure,
+    default creds also get auth failure. Should return auth_required, not no_cluster."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if not use_ssl:
+            return _UnreachableClient()
+        return _AuthFailureClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "auth_required"
+    assert "authentication failed" in result["message"].lower()
+    assert len(result["auth_modes_tried"]) == 4
+
+
+def test_preflight_ssl_default_creds_succeeds_after_noauth_authfail(monkeypatch):
+    """HTTPS cluster where no-auth returns 401 but default creds work.
+    This is the common Docker OpenSearch case."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if not use_ssl:
+            return _UnreachableClient()
+        if http_auth is None:
+            return _AuthFailureClient()
+        if http_auth == ("admin", "myStrongPassword123!"):
+            return _ConnectableClient()
+        return _AuthFailureClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "default"
+    assert "SSL" in result["message"]
+
+
+def test_preflight_detects_no_cluster(monkeypatch):
+    """Nothing listening returns no_cluster."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "no_cluster"
+    assert "no opensearch cluster detected" in result["message"].lower()
+    assert result["is_local"] is True
+
+
+def test_preflight_returns_host_port_info(monkeypatch):
+    """Result always includes host, port, and is_local."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster()
+
+    assert result["host"] == "localhost"
+    assert result["port"] == 9200
+    assert result["is_local"] is True
+    assert "auth_modes_tried" in result
+
+
+def test_preflight_custom_creds_success_sets_env_vars(monkeypatch):
+    """Custom creds that succeed set OPENSEARCH_AUTH_MODE/USER/PASSWORD env vars."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if http_auth == ("myuser", "mypass"):
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+    monkeypatch.delenv("OPENSEARCH_USER", raising=False)
+    monkeypatch.delenv("OPENSEARCH_PASSWORD", raising=False)
+
+    result = preflight_check_cluster(
+        auth_mode="custom", username="myuser", password="mypass"
+    )
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "custom"
+    assert "myuser" not in result["message"]  # creds not leaked in message
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") == "custom"
+    assert os.environ.get("OPENSEARCH_USER") == "myuser"
+    assert os.environ.get("OPENSEARCH_PASSWORD") == "mypass"
+
+
+def test_preflight_custom_creds_failure(monkeypatch):
+    """Custom creds that fail return auth_required without setting env vars."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        return _AuthFailureClient() if http_auth else _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+    monkeypatch.delenv("OPENSEARCH_USER", raising=False)
+    monkeypatch.delenv("OPENSEARCH_PASSWORD", raising=False)
+
+    result = preflight_check_cluster(
+        auth_mode="custom", username="bad", password="wrong"
+    )
+
+    assert result["status"] == "auth_required"
+    assert "rejected" in result["message"].lower()
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") is None
+    assert os.environ.get("OPENSEARCH_USER") is None
+
+
+def test_preflight_custom_creds_missing_returns_error(monkeypatch):
+    """Custom mode without username/password returns error."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster(auth_mode="custom", username="", password="")
+
+    assert result["status"] == "error"
+    assert "requires" in result["message"].lower()
+
+
+def test_preflight_none_mode_success_sets_env(monkeypatch):
+    """Explicit none mode that succeeds sets OPENSEARCH_AUTH_MODE=none."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if http_auth is None:
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+
+    result = preflight_check_cluster(auth_mode="none")
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "none"
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") == "none"
+    assert os.environ.get("OPENSEARCH_USER") is None
+
+
+def test_preflight_none_mode_failure(monkeypatch):
+    """Explicit none mode that fails returns auth_required."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        return _AuthFailureClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+
+    result = preflight_check_cluster(auth_mode="none")
+
+    assert result["status"] == "auth_required"
+
+
+def test_preflight_default_mode_success(monkeypatch):
+    """Explicit default mode that succeeds sets OPENSEARCH_AUTH_MODE=default."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if http_auth == ("admin", "myStrongPassword123!"):
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+
+    result = preflight_check_cluster(auth_mode="default")
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "default"
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") == "default"
+
+
+def test_clear_cluster_credentials(monkeypatch):
+    """clear_cluster_credentials removes all auth env vars."""
+
+    monkeypatch.setenv("OPENSEARCH_AUTH_MODE", "custom")
+    monkeypatch.setenv("OPENSEARCH_USER", "admin")
+    monkeypatch.setenv("OPENSEARCH_PASSWORD", "secret")
+
+    clear_cluster_credentials()
+
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") is None
+    assert os.environ.get("OPENSEARCH_USER") is None
+    assert os.environ.get("OPENSEARCH_PASSWORD") is None
+
+
+def test_clear_cluster_credentials_noop_when_unset():
+    """clear_cluster_credentials is safe to call when env vars are not set."""
+
+    os.environ.pop("OPENSEARCH_AUTH_MODE", None)
+    os.environ.pop("OPENSEARCH_USER", None)
+    os.environ.pop("OPENSEARCH_PASSWORD", None)
+
+    # Should not raise
+    clear_cluster_credentials()
+
+
+def test_autodetect_sets_env_for_default_creds(monkeypatch):
+    """Auto-detect mode that finds default creds sets OPENSEARCH_AUTH_MODE=default."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if http_auth == ("admin", "myStrongPassword123!") and use_ssl:
+            return _ConnectableClient()
+        if http_auth is None:
+            return _AuthFailureClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "default"
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") == "default"
+
+
+def test_autodetect_sets_env_for_none_mode(monkeypatch):
+    """Auto-detect mode that finds no-auth cluster sets OPENSEARCH_AUTH_MODE=none."""
+
+    def _build(use_ssl: bool, http_auth=None):
+        if not use_ssl and http_auth is None:
+            return _ConnectableClient()
+        return _UnreachableClient()
+
+    from lib import client as client_module
+    monkeypatch.setattr(client_module, "build_client", _build)
+    monkeypatch.delenv("OPENSEARCH_AUTH_MODE", raising=False)
+
+    result = preflight_check_cluster()
+
+    assert result["status"] == "available"
+    assert result["auth_mode"] == "none"
+    assert os.environ.get("OPENSEARCH_AUTH_MODE") == "none"
+    assert os.environ.get("OPENSEARCH_USER") is None

--- a/tests/test_agent_skills_samples.py
+++ b/tests/test_agent_skills_samples.py
@@ -1,0 +1,235 @@
+"""Tests for skills/opensearch-skills/scripts/lib/samples.py"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.samples import (
+    _load_records_from_file,
+    _infer_text_fields,
+    load_sample_from_file,
+    load_sample_from_paste,
+)
+
+
+# ---------------------------------------------------------------------------
+# _infer_text_fields
+# ---------------------------------------------------------------------------
+def test_infer_text_fields_detects_multiword_strings():
+    doc = {
+        "id": "1",
+        "title": "The quick brown fox jumps",
+        "count": 42,
+    }
+    result = _infer_text_fields(doc)
+
+    assert "title" in result
+    assert "id" not in result
+    assert "count" not in result
+
+
+def test_infer_text_fields_ignores_short_strings():
+    doc = {"code": "AB", "name": "ok then"}
+
+    result = _infer_text_fields(doc)
+
+    assert "code" not in result
+
+
+def test_infer_text_fields_empty_doc():
+    assert _infer_text_fields({}) == []
+
+
+def test_infer_text_fields_non_string_values():
+    doc = {"count": 100, "flag": True, "tags": ["a", "b"]}
+
+    assert _infer_text_fields(doc) == []
+
+
+# ---------------------------------------------------------------------------
+# _load_records_from_file — JSON
+# ---------------------------------------------------------------------------
+def test_load_records_json_array(tmp_path):
+    f = tmp_path / "data.json"
+    f.write_text(json.dumps([{"a": 1}, {"a": 2}, {"a": 3}]))
+
+    records, error = _load_records_from_file(f, limit=2)
+
+    assert error is None
+    assert len(records) == 2
+    assert records[0]["a"] == 1
+
+
+def test_load_records_jsonl(tmp_path):
+    f = tmp_path / "data.jsonl"
+    f.write_text('{"x":1}\n{"x":2}\n{"x":3}\n')
+
+    records, error = _load_records_from_file(f, limit=10)
+
+    assert error is None
+    assert len(records) == 3
+
+
+def test_load_records_json_empty_lines_skipped(tmp_path):
+    f = tmp_path / "data.ndjson"
+    f.write_text('{"x":1}\n\n{"x":2}\n\n')
+
+    records, error = _load_records_from_file(f, limit=10)
+
+    assert error is None
+    assert len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# _load_records_from_file — CSV/TSV
+# ---------------------------------------------------------------------------
+def test_load_records_csv(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text("id,name,score\n1,Alice,95\n2,Bob,87\n3,Carol,91\n")
+
+    records, error = _load_records_from_file(f, limit=2)
+
+    assert error is None
+    assert len(records) == 2
+    assert records[0]["name"] == "Alice"
+
+
+def test_load_records_tsv(tmp_path):
+    f = tmp_path / "data.tsv"
+    f.write_text("tconst\tprimaryTitle\n" "tt001\tCarmencita\n" "tt002\tClown\n")
+
+    records, error = _load_records_from_file(f, limit=10)
+
+    assert error is None
+    assert len(records) == 2
+    assert records[0]["tconst"] == "tt001"
+
+
+# ---------------------------------------------------------------------------
+# _load_records_from_file — unsupported
+# ---------------------------------------------------------------------------
+def test_load_records_unsupported_format(tmp_path):
+    f = tmp_path / "data.xml"
+    f.write_text("<root/>")
+
+    records, error = _load_records_from_file(f, limit=10)
+
+    assert records == []
+    assert "Unsupported file format" in error
+
+
+# ---------------------------------------------------------------------------
+# load_sample_from_file
+# ---------------------------------------------------------------------------
+def test_load_sample_from_file_success(tmp_path):
+    f = tmp_path / "movies.json"
+    f.write_text(json.dumps([
+        {"title": "The Matrix is a great movie", "year": 1999},
+        {"title": "Inception is mind bending", "year": 2010},
+    ]))
+
+    result = json.loads(load_sample_from_file(str(f)))
+
+    assert result["status"] == "loaded"
+    assert result["record_count"] == 2
+    assert result["sample_doc"]["title"] == "The Matrix is a great movie"
+    assert "title" in result["text_fields"]
+    assert result["text_search_required"] is True
+
+
+def test_load_sample_from_file_not_found():
+    result = json.loads(load_sample_from_file("/nonexistent/path.json"))
+
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+
+
+def test_load_sample_from_file_empty_records(tmp_path):
+    f = tmp_path / "empty.json"
+    f.write_text("[]")
+
+    result = json.loads(load_sample_from_file(str(f)))
+
+    assert "error" in result
+    assert "No records" in result["error"]
+
+
+def test_load_sample_from_file_numeric_only(tmp_path):
+    f = tmp_path / "numeric.json"
+    f.write_text(json.dumps([{"id": 1, "score": 99.5}]))
+
+    result = json.loads(load_sample_from_file(str(f)))
+
+    assert result["status"] == "loaded"
+    assert result["text_fields"] == []
+    assert result["text_search_required"] is False
+
+
+# ---------------------------------------------------------------------------
+# load_sample_from_paste
+# ---------------------------------------------------------------------------
+def test_load_sample_from_paste_valid_json():
+    doc = '{"title": "Test document with enough words", "id": 1}'
+
+    result = json.loads(load_sample_from_paste(doc))
+
+    assert result["status"] == "loaded"
+    assert result["source"] == "paste"
+    assert result["record_count"] == 1
+    assert result["sample_doc"]["id"] == 1
+
+
+def test_load_sample_from_paste_invalid_json():
+    result = json.loads(load_sample_from_paste("not json at all"))
+
+    assert "error" in result
+    assert "Invalid JSON" in result["error"]
+
+
+def test_load_sample_from_paste_non_object():
+    result = json.loads(load_sample_from_paste("[1, 2, 3]"))
+
+    assert "error" in result
+    assert "must be a JSON object" in result["error"]
+
+
+def test_load_sample_from_paste_text_field_detection():
+    doc = json.dumps({
+        "title": "A document with several words here",
+        "code": "XY",
+    })
+
+    result = json.loads(load_sample_from_paste(doc))
+
+    assert "title" in result["text_fields"]
+    assert "code" not in result["text_fields"]
+
+
+# ---------------------------------------------------------------------------
+# _load_records_from_file — limit enforcement
+# ---------------------------------------------------------------------------
+def test_load_records_respects_limit_csv(tmp_path):
+    rows = "id,val\n" + "\n".join(f"{i},v{i}" for i in range(50))
+    f = tmp_path / "big.csv"
+    f.write_text(rows)
+
+    records, error = _load_records_from_file(f, limit=5)
+
+    assert error is None
+    assert len(records) == 5
+
+
+def test_load_records_respects_limit_jsonl(tmp_path):
+    lines = "\n".join(json.dumps({"i": i}) for i in range(50))
+    f = tmp_path / "big.jsonl"
+    f.write_text(lines)
+
+    records, error = _load_records_from_file(f, limit=3)
+
+    assert error is None
+    assert len(records) == 3

--- a/tests/test_agent_skills_search.py
+++ b/tests/test_agent_skills_search.py
@@ -1,0 +1,824 @@
+"""Tests for skills/opensearch-skills/scripts/lib/search.py"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.search import (
+    _value_shape,
+    _text_richness_score,
+    extract_index_field_specs,
+    _resolve_text_query_fields,
+    _resolve_field_spec_for_doc_key,
+    _build_default_lexical_query,
+    _build_default_lexical_body,
+    _build_neural_clause,
+    _suggestion_candidates_from_doc,
+    _is_vector_value,
+    _strip_vector_fields,
+    preview_text,
+    generate_suggestions,
+    detect_index_profile,
+    _resolve_autocomplete_fields,
+    _source_field_variants,
+    _extract_values_from_source_by_path,
+    autocomplete,
+    search_ui_search,
+    _search_configs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared field specs
+# ---------------------------------------------------------------------------
+def _base_field_specs():
+    return {
+        "primaryTitle": {"type": "text", "normalizer": ""},
+        "primaryTitle.keyword": {"type": "keyword", "normalizer": ""},
+        "embedding_vector": {"type": "knn_vector", "normalizer": ""},
+        "genres": {"type": "keyword", "normalizer": ""},
+        "startYear": {"type": "integer", "normalizer": ""},
+        "isAdult": {"type": "boolean", "normalizer": ""},
+    }
+
+
+class _FakeClient:
+    def __init__(self, search_response=None):
+        self.calls = []
+        self._search_response = search_response or {
+            "hits": {"hits": [], "total": {"value": 0}},
+            "took": 1,
+        }
+
+    def search(self, index, body, size=10):
+        self.calls.append({"index": index, "body": body})
+        return self._search_response
+
+
+# ---------------------------------------------------------------------------
+# _value_shape
+# ---------------------------------------------------------------------------
+def test_value_shape_basic():
+    shape = _value_shape("Hello World 123")
+
+    assert shape["token_count"] == 3
+    assert shape["looks_numeric"] is False
+    assert shape["looks_date"] is False
+
+
+def test_value_shape_numeric():
+    shape = _value_shape("42.5")
+
+    assert shape["looks_numeric"] is True
+
+
+def test_value_shape_date():
+    shape = _value_shape("2024-01-15")
+
+    assert shape["looks_date"] is True
+
+
+def test_value_shape_empty():
+    shape = _value_shape("")
+
+    assert shape["length"] == 0
+    assert shape["alpha_ratio"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _text_richness_score
+# ---------------------------------------------------------------------------
+def test_text_richness_score_rich_text():
+    score = _text_richness_score("The quick brown fox jumps over the lazy dog")
+
+    assert score > 50
+
+
+def test_text_richness_score_short_text():
+    score = _text_richness_score("X")
+
+    assert score == 0.0
+
+
+def test_text_richness_score_numeric_text():
+    score = _text_richness_score("12345")
+
+    # Numeric text has low alpha ratio so lower score
+    assert score < 30
+
+
+# ---------------------------------------------------------------------------
+# extract_index_field_specs
+# ---------------------------------------------------------------------------
+def test_extract_index_field_specs_walks_properties():
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {
+                "my-index": {
+                    "mappings": {
+                        "properties": {
+                            "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+                            "year": {"type": "integer"},
+                            "nested": {"properties": {"inner": {"type": "text"}}},
+                        }
+                    }
+                }
+            }
+
+    class _Client:
+        indices = _FakeIndices()
+
+    specs = extract_index_field_specs(_Client(), "my-index")
+
+    assert specs["title"]["type"] == "text"
+    assert specs["title.keyword"]["type"] == "keyword"
+    assert specs["year"]["type"] == "integer"
+    assert specs["nested.inner"]["type"] == "text"
+
+
+def test_extract_index_field_specs_handles_exception():
+    class _FakeIndices:
+        def get_mapping(self, index):
+            raise Exception("connection failed")
+
+    class _Client:
+        indices = _FakeIndices()
+
+    specs = extract_index_field_specs(_Client(), "missing-index")
+
+    assert specs == {}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_text_query_fields
+# ---------------------------------------------------------------------------
+def test_resolve_text_query_fields_prefers_text_type():
+    specs = _base_field_specs()
+
+    fields = _resolve_text_query_fields(specs)
+
+    assert "primaryTitle" in fields
+    assert "primaryTitle.keyword" not in fields
+
+
+def test_resolve_text_query_fields_falls_back_to_keyword():
+    specs = {"genre": {"type": "keyword", "normalizer": ""}}
+
+    fields = _resolve_text_query_fields(specs)
+
+    assert "genre" in fields
+
+
+def test_resolve_text_query_fields_empty_specs():
+    fields = _resolve_text_query_fields({})
+
+    assert fields == ["*"]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_field_spec_for_doc_key
+# ---------------------------------------------------------------------------
+def test_resolve_field_spec_exact_match():
+    specs = _base_field_specs()
+    name, spec = _resolve_field_spec_for_doc_key("genres", specs)
+
+    assert name == "genres"
+    assert spec["type"] == "keyword"
+
+
+def test_resolve_field_spec_case_insensitive():
+    specs = _base_field_specs()
+    name, spec = _resolve_field_spec_for_doc_key("GENRES", specs)
+
+    assert name == "genres"
+
+
+def test_resolve_field_spec_leaf_match():
+    specs = {"nested.field.name": {"type": "text", "normalizer": ""}}
+    name, spec = _resolve_field_spec_for_doc_key("name", specs)
+
+    assert name == "nested.field.name"
+
+
+def test_resolve_field_spec_no_match():
+    specs = _base_field_specs()
+    name, spec = _resolve_field_spec_for_doc_key("nonexistent", specs)
+
+    assert name == ""
+    assert spec == {}
+
+
+# ---------------------------------------------------------------------------
+# Query builders
+# ---------------------------------------------------------------------------
+def test_build_default_lexical_query():
+    q = _build_default_lexical_query("hello world", ["title", "body"])
+
+    assert q["multi_match"]["query"] == "hello world"
+    assert q["multi_match"]["fields"] == ["title", "body"]
+    assert q["multi_match"]["fuzziness"] == "AUTO"
+
+
+def test_build_default_lexical_query_wildcard_no_fuzziness():
+    q = _build_default_lexical_query("test", ["*"])
+
+    assert "fuzziness" not in q["multi_match"]
+
+
+def test_build_default_lexical_body():
+    body = _build_default_lexical_body("test", 20, ["title"])
+
+    assert body["size"] == 20
+    assert "multi_match" in body["query"]
+
+
+def test_build_neural_clause():
+    clause = _build_neural_clause("search text", "vec_field", "model-1", 5)
+
+    assert "neural" in clause
+    neural = clause["neural"]["vec_field"]
+    assert neural["query_text"] == "search text"
+    assert neural["model_id"] == "model-1"
+    assert neural["k"] == 10  # max(5, 10)
+
+
+def test_build_neural_clause_large_size():
+    clause = _build_neural_clause("text", "vec", "m", 50)
+
+    assert clause["neural"]["vec"]["k"] == 50
+
+
+# ---------------------------------------------------------------------------
+# Preview & suggestions
+# ---------------------------------------------------------------------------
+def test_suggestion_candidates_from_doc():
+    doc = {
+        "id": 1,
+        "title": "The Matrix is a great movie",
+        "year": 1999,
+        "embedding": [0.1, 0.2],
+    }
+    candidates = _suggestion_candidates_from_doc(doc)
+
+    assert any("Matrix" in c for c in candidates)
+
+
+def test_suggestion_candidates_skips_numeric_and_short():
+    doc = {"id": "1", "x": "42.5", "date": "2024-01-01"}
+    candidates = _suggestion_candidates_from_doc(doc)
+
+    assert candidates == []
+
+
+def test_preview_text_returns_best_candidate():
+    source = {"title": "A great movie about adventure", "id": 1}
+
+    text = preview_text(source)
+
+    assert "great movie" in text
+
+
+def test_preview_text_empty_source():
+    assert preview_text({}) == "(No preview text)"
+
+
+def test_preview_text_non_dict_values():
+    source = {"data": None, "nested": {"a": 1}, "list": [1, 2]}
+
+    assert preview_text(source) == "(No preview text)"
+
+
+def test_generate_suggestions_returns_dicts_with_capability(monkeypatch):
+    client = _FakeClient(search_response={
+        "hits": {
+            "hits": [
+                {"_source": {"title": "The Matrix movie classic", "genre": "Action"}},
+                {"_source": {"title": "Inception is mind bending", "genre": "Sci-Fi"}},
+                {"_source": {"title": "The Godfather classic film", "genre": "Drama"}},
+                {"_source": {"title": "Pulp Fiction great movie", "genre": "Crime"}},
+                {"_source": {"title": "Forrest Gump heartwarming", "genre": "Drama"}},
+                {"_source": {"title": "The Dark Knight rises", "genre": "Action"}},
+            ],
+            "total": {"value": 6},
+        },
+        "took": 1,
+    })
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"movies": {"mappings": {"properties": {
+                "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+                "genre": {"type": "keyword"},
+            }}}}
+        def get_settings(self, index):
+            return {"movies": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = generate_suggestions(client, "movies", max_count=6)
+
+    suggestions = result["suggestions"]
+    assert len(suggestions) > 0
+    for s in suggestions:
+        assert isinstance(s, dict)
+        assert "text" in s
+        assert "capability" in s
+        assert s["capability"] in ("exact", "semantic", "structured", "combined", "autocomplete", "fuzzy")
+        assert "query_mode" in s
+
+
+def test_generate_suggestions_returns_deduped(monkeypatch):
+    client = _FakeClient(search_response={
+        "hits": {
+            "hits": [
+                {"_source": {"title": "The Matrix movie classic"}},
+                {"_source": {"title": "the matrix movie classic"}},  # duplicate
+                {"_source": {"title": "Inception is mind bending"}},
+                {"_source": {"title": "The Godfather classic film"}},
+                {"_source": {"title": "Pulp Fiction great movie"}},
+                {"_source": {"title": "Forrest Gump heartwarming"}},
+            ],
+            "total": {"value": 6},
+        },
+        "took": 1,
+    })
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"movies": {"mappings": {"properties": {
+                "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+            }}}}
+        def get_settings(self, index):
+            return {"movies": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = generate_suggestions(client, "movies", max_count=6)
+
+    texts_lowered = [s["text"].lower() for s in result["suggestions"]]
+    assert len(texts_lowered) == len(set(texts_lowered))
+
+
+def test_generate_suggestions_empty_index():
+    client = _FakeClient()
+
+    result = generate_suggestions(client, "", max_count=6)
+
+    assert result["suggestions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Autocomplete helpers
+# ---------------------------------------------------------------------------
+def test_resolve_autocomplete_fields_prefers_text():
+    specs = {
+        "title": {"type": "text", "normalizer": ""},
+        "genre": {"type": "keyword", "normalizer": ""},
+    }
+    fields = _resolve_autocomplete_fields(specs)
+
+    assert fields[0] == "title"
+
+
+def test_resolve_autocomplete_fields_with_preferred():
+    specs = {
+        "title": {"type": "text", "normalizer": ""},
+        "genre": {"type": "keyword", "normalizer": ""},
+    }
+    fields = _resolve_autocomplete_fields(specs, preferred_field="title")
+
+    assert fields[0] == "title"
+
+
+def test_source_field_variants_keyword_suffix():
+    variants = _source_field_variants("title.keyword")
+
+    assert variants == ["title", "title.keyword"]
+
+
+def test_source_field_variants_plain():
+    variants = _source_field_variants("title")
+
+    assert variants == ["title"]
+
+
+def test_source_field_variants_empty():
+    assert _source_field_variants("") == []
+
+
+def test_extract_values_from_source_simple():
+    source = {"title": "Hello", "year": 2024}
+
+    values = _extract_values_from_source_by_path(source, "title")
+
+    assert values == ["Hello"]
+
+
+def test_extract_values_from_source_nested():
+    source = {"meta": {"author": {"name": "Alice"}}}
+
+    values = _extract_values_from_source_by_path(source, "meta.author.name")
+
+    assert values == ["Alice"]
+
+
+def test_extract_values_from_source_list():
+    source = {"tags": ["python", "java"]}
+
+    values = _extract_values_from_source_by_path(source, "tags")
+
+    assert "python" in values
+    assert "java" in values
+
+
+def test_extract_values_from_source_missing_path():
+    values = _extract_values_from_source_by_path({"a": 1}, "b.c")
+
+    assert values == []
+
+
+# ---------------------------------------------------------------------------
+# autocomplete
+# ---------------------------------------------------------------------------
+def test_autocomplete_empty_prefix():
+    client = _FakeClient()
+
+    result = autocomplete(client, "my-index", "")
+
+    assert result["options"] == []
+    assert result["error"] == ""
+
+
+def test_autocomplete_empty_index():
+    client = _FakeClient()
+
+    result = autocomplete(client, "", "test")
+
+    assert result["options"] == []
+
+
+def test_autocomplete_returns_matching_options():
+    client = _FakeClient(search_response={
+        "hits": {
+            "hits": [
+                {"_source": {"genre": "Comedy"}},
+                {"_source": {"genre": "Crime"}},
+                {"_source": {"genre": "Action"}},
+            ],
+            "total": {"value": 3},
+        },
+        "took": 1,
+    })
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {"genre": {"type": "keyword"}}}}}
+
+    client.indices = _FakeIndices()
+
+    result = autocomplete(client, "idx", "C", preferred_field="genre")
+
+    assert "Comedy" in result["options"]
+    assert "Crime" in result["options"]
+    assert "Action" not in result["options"]  # doesn't start with "C"
+
+
+# ---------------------------------------------------------------------------
+# search_ui_search — integration
+# ---------------------------------------------------------------------------
+def test_search_ui_search_match_all_no_query(monkeypatch):
+    client = _FakeClient()
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {"title": {"type": "text"}}}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = search_ui_search(client, "idx", "")
+
+    assert result["error"] == ""
+    assert result["query_mode"] == "match_all"
+
+
+def test_search_ui_search_missing_index():
+    client = _FakeClient()
+
+    result = search_ui_search(client, "", "test query")
+
+    assert result["error"] == "Missing index name."
+
+
+def test_search_ui_search_bm25_default(monkeypatch):
+    _search_configs.clear()
+    client = _FakeClient()
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {"title": {"type": "text"}}}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = search_ui_search(client, "idx", "hello world")
+
+    assert result["error"] == ""
+    assert result["query_mode"] == "bm25"
+    assert result["capability"] == "bm25"
+
+
+def test_search_ui_search_structured_filter(monkeypatch):
+    _search_configs.clear()
+    client = _FakeClient()
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "startYear": {"type": "integer"},
+                "genres": {"type": "keyword"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = search_ui_search(client, "idx", "startYear: 1999 and genres: Comedy")
+
+    assert result["query_mode"] == "bm25"
+    assert result["capability"] == "bm25"
+
+
+def test_search_ui_search_dense_vector_no_search_pipeline(monkeypatch):
+    _search_configs.clear()
+    class _FakeIngest:
+        def get_pipeline(self, id):
+            return {id: {"processors": [
+                {"text_embedding": {
+                    "model_id": "model-1",
+                    "field_map": {"title": "embedding"},
+                }}
+            ]}}
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "title": {"type": "text"},
+                "embedding": {"type": "knn_vector"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {
+                "default_pipeline": "my-ingest",
+            }}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+    client.ingest = _FakeIngest()
+
+    result = search_ui_search(client, "idx", "semantic search test")
+
+    assert result["query_mode"] == "dense_vector"
+    assert result["capability"] == "dense_vector"
+
+
+def test_search_ui_search_hybrid_with_search_pipeline(monkeypatch):
+    _search_configs.clear()
+    class _FakeTransport:
+        def perform_request(self, method, url):
+            return {"hybrid-pipeline": {
+                "phase_results_processors": [
+                    {"normalization-processor": {
+                        "normalization": {"technique": "min_max"},
+                        "combination": {"technique": "arithmetic_mean"},
+                    }}
+                ]
+            }}
+
+    class _FakeIngest:
+        def get_pipeline(self, id):
+            return {id: {"processors": [
+                {"text_embedding": {
+                    "model_id": "model-1",
+                    "field_map": {"title": "embedding"},
+                }}
+            ]}}
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "title": {"type": "text"},
+                "embedding": {"type": "knn_vector"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {
+                "default_pipeline": "my-ingest",
+                "search": {"default_pipeline": "hybrid-pipeline"},
+            }}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+    client.ingest = _FakeIngest()
+    client.transport = _FakeTransport()
+
+    result = search_ui_search(client, "idx", "hybrid search test")
+
+    assert result["query_mode"] == "hybrid"
+    assert result["capability"] == "hybrid"
+
+
+# ---------------------------------------------------------------------------
+# _is_vector_value / _strip_vector_fields
+# ---------------------------------------------------------------------------
+def test_is_vector_value_dense():
+    vec = [0.1] * 128
+    assert _is_vector_value(vec) is True
+
+
+def test_is_vector_value_short_list():
+    assert _is_vector_value([1, 2, 3]) is False
+
+
+def test_is_vector_value_sparse():
+    sparse = {str(i): 0.5 for i in range(32)}
+    assert _is_vector_value(sparse) is True
+
+
+def test_is_vector_value_small_dict():
+    assert _is_vector_value({"a": 1, "b": 2}) is False
+
+
+def test_is_vector_value_sparse_token_weights():
+    """Neural sparse token-weight vectors with word keys should be detected."""
+    sparse = {"movie": 0.33, "comedy": 0.12, "funny": 0.08, "film": 0.05}
+    assert _is_vector_value(sparse) is True
+
+
+def test_is_vector_value_small_sparse():
+    """Sparse vectors with fewer than 16 but >= 4 entries should be detected."""
+    sparse = {str(i): 0.5 for i in range(5)}
+    assert _is_vector_value(sparse) is True
+
+
+def test_is_vector_value_string():
+    assert _is_vector_value("not a vector") is False
+
+
+def test_is_vector_value_none():
+    assert _is_vector_value(None) is False
+
+
+def test_strip_vector_fields_removes_embeddings():
+    source = {
+        "title": "The Matrix",
+        "year": 1999,
+        "embedding": [0.1] * 128,
+    }
+    cleaned = _strip_vector_fields(source)
+
+    assert "title" in cleaned
+    assert "year" in cleaned
+    assert "embedding" not in cleaned
+
+
+def test_strip_vector_fields_removes_sparse_vectors():
+    source = {
+        "title": "Test",
+        "sparse_vec": {str(i): 0.5 for i in range(32)},
+    }
+    cleaned = _strip_vector_fields(source)
+
+    assert "title" in cleaned
+    assert "sparse_vec" not in cleaned
+
+
+def test_strip_vector_fields_keeps_all_when_no_vectors():
+    source = {"title": "Test", "genre": "Action", "rating": 8.5}
+    cleaned = _strip_vector_fields(source)
+
+    assert cleaned == source
+
+
+# ---------------------------------------------------------------------------
+# detect_index_profile
+# ---------------------------------------------------------------------------
+def test_detect_index_profile_document_search():
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "title": {"type": "text"},
+                "body": {"type": "text"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+
+    profile = detect_index_profile(client, "idx")
+
+    assert profile["suggested_template"] == "document"
+    assert "lexical" in profile["capabilities"]
+    assert profile["has_semantic"] is False
+    assert profile["has_agentic"] is False
+    assert "title" in profile["field_categories"]["text"]
+
+
+def test_detect_index_profile_media_template_disabled():
+    """Media template is disabled; falls back to document-search."""
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "title": {"type": "text"},
+                "poster": {"type": "text"},
+                "genre": {"type": "keyword"},
+                "rating": {"type": "float"},
+                "year": {"type": "integer"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+
+    profile = detect_index_profile(client, "idx")
+
+    # Media is disabled; falls back to document
+    assert profile["suggested_template"] == "document"
+    assert "structured" in profile["capabilities"]
+
+
+def test_detect_index_profile_catalog_template():
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "name": {"type": "text"},
+                "category": {"type": "keyword"},
+                "brand": {"type": "keyword"},
+                "price": {"type": "float"},
+                "stock": {"type": "integer"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+
+    profile = detect_index_profile(client, "idx")
+
+    assert profile["suggested_template"] == "ecommerce"
+
+
+def test_detect_index_profile_hides_vector_fields():
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "title": {"type": "text"},
+                "embedding_vector": {"type": "knn_vector"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {}}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+
+    profile = detect_index_profile(client, "idx")
+
+    assert "embedding_vector" not in profile["fields"]
+    assert "embedding_vector" in profile["field_categories"]["vector"]
+
+
+def test_detect_index_profile_semantic_capability():
+    class _FakeIngest:
+        def get_pipeline(self, id):
+            return {id: {"processors": [
+                {"text_embedding": {
+                    "model_id": "model-1",
+                    "field_map": {"title": "embedding"},
+                }}
+            ]}}
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"idx": {"mappings": {"properties": {
+                "title": {"type": "text"},
+                "embedding": {"type": "knn_vector"},
+            }}}}
+        def get_settings(self, index):
+            return {"idx": {"settings": {"index": {
+                "default_pipeline": "my-ingest",
+            }}}}
+
+    client = _FakeClient()
+    client.indices = _FakeIndices()
+    client.ingest = _FakeIngest()
+
+    profile = detect_index_profile(client, "idx")
+
+    assert profile["has_semantic"] is True
+    assert "semantic" in profile["capabilities"]

--- a/tests/test_agent_skills_standalone_assets.py
+++ b/tests/test_agent_skills_standalone_assets.py
@@ -1,0 +1,125 @@
+"""Tests that the agent skill is fully standalone — UI and sample data are
+bundled inside skills/opensearch-skills/ and resolve without depending on
+the repo-root opensearch_orchestrator/ tree."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SKILL_ROOT = Path(__file__).resolve().parents[1] / "skills" / "opensearch-skills"
+_SCRIPTS_DIR = _SKILL_ROOT / "scripts"
+
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+# ---------------------------------------------------------------------------
+# UI static assets
+# ---------------------------------------------------------------------------
+class TestUIAssetsStandalone:
+    """Verify the UI files exist inside the skill and that ui.py resolves them."""
+
+    EXPECTED_UI_FILES = ["index.html", "styles.css", "app.jsx"]
+
+    def test_ui_directory_exists(self):
+        ui_dir = _SCRIPTS_DIR / "ui"
+        assert ui_dir.is_dir(), f"UI directory missing: {ui_dir}"
+
+    @pytest.mark.parametrize("filename", EXPECTED_UI_FILES)
+    def test_ui_file_exists(self, filename):
+        path = _SCRIPTS_DIR / "ui" / filename
+        assert path.is_file(), f"UI file missing: {path}"
+
+    @pytest.mark.parametrize("filename", EXPECTED_UI_FILES)
+    def test_ui_file_not_empty(self, filename):
+        path = _SCRIPTS_DIR / "ui" / filename
+        assert path.stat().st_size > 0, f"UI file is empty: {path}"
+
+    def test_ui_py_resolves_to_local_dir(self):
+        from lib.ui import SEARCH_UI_STATIC_DIR
+
+        assert SEARCH_UI_STATIC_DIR.exists(), (
+            f"SEARCH_UI_STATIC_DIR does not exist: {SEARCH_UI_STATIC_DIR}"
+        )
+        # Must point inside the skill, not to opensearch_orchestrator/
+        assert "opensearch_orchestrator" not in str(SEARCH_UI_STATIC_DIR), (
+            f"SEARCH_UI_STATIC_DIR still points outside the skill: {SEARCH_UI_STATIC_DIR}"
+        )
+
+    def test_ui_py_static_dir_contains_all_files(self):
+        from lib.ui import SEARCH_UI_STATIC_DIR
+
+        for filename in self.EXPECTED_UI_FILES:
+            assert (SEARCH_UI_STATIC_DIR / filename).is_file(), (
+                f"SEARCH_UI_STATIC_DIR is missing {filename}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+class TestSampleDataStandalone:
+    """Verify IMDB sample data is bundled and samples.py finds it locally."""
+
+    IMDB_TSV = _SCRIPTS_DIR / "sample_data" / "imdb.title.basics.tsv"
+
+    def test_sample_data_directory_exists(self):
+        assert (_SCRIPTS_DIR / "sample_data").is_dir()
+
+    def test_imdb_tsv_exists(self):
+        assert self.IMDB_TSV.is_file(), f"IMDB TSV missing: {self.IMDB_TSV}"
+
+    def test_imdb_tsv_not_empty(self):
+        assert self.IMDB_TSV.stat().st_size > 0
+
+    def test_imdb_tsv_has_header_row(self):
+        with open(self.IMDB_TSV, "r") as f:
+            header = f.readline().strip()
+        assert "tconst" in header, f"Unexpected header: {header}"
+
+    def test_load_sample_builtin_imdb_succeeds(self):
+        import json
+        from lib.samples import load_sample_builtin_imdb
+
+        result = json.loads(load_sample_builtin_imdb())
+        assert "error" not in result, f"load_sample_builtin_imdb failed: {result}"
+        assert result["status"] == "loaded"
+        assert result["record_count"] > 0
+
+    def test_builtin_imdb_resolves_to_local_path(self):
+        import json
+        from lib.samples import load_sample_builtin_imdb
+
+        result = json.loads(load_sample_builtin_imdb())
+        source = result.get("source", "")
+        # Must resolve inside the skill, not opensearch_orchestrator/
+        assert "opensearch_orchestrator" not in source, (
+            f"IMDB sample resolved outside the skill: {source}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Simulated install location (mimics .claude/skills/)
+# ---------------------------------------------------------------------------
+class TestResolvedPathsAreRelative:
+    """Ensure path resolution uses only relative traversal from __file__,
+    not hardcoded repo-root assumptions."""
+
+    def test_ui_static_dir_is_under_skill_root(self):
+        from lib.ui import SEARCH_UI_STATIC_DIR
+
+        resolved = SEARCH_UI_STATIC_DIR.resolve()
+        assert str(resolved).startswith(str(_SCRIPTS_DIR)), (
+            f"SEARCH_UI_STATIC_DIR escapes the scripts dir: {resolved}"
+        )
+
+    def test_samples_imdb_candidates_are_under_skill_root(self):
+        """Check that the candidate paths in load_sample_builtin_imdb
+        stay within the skill tree."""
+        import inspect
+        from lib.samples import load_sample_builtin_imdb
+
+        source = inspect.getsource(load_sample_builtin_imdb)
+        assert "opensearch_orchestrator" not in source, (
+            "load_sample_builtin_imdb still references opensearch_orchestrator path"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,347 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "events"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/ed/e47dec0626edd468c84c04d97769e7ab4ea6457b7f54dcb3f72b17fcd876/Events-0.5-py3-none-any.whl", hash = "sha256:a7286af378ba3e46640ac9825156c93bdba7502174dd696090fdfcd4d80a1abd", size = 6758, upload-time = "2023-07-31T08:23:13.645Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "opensearch-agent-skills"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "opensearch-py" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "opensearch-py" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=7.0" }]
+
+[[package]]
+name = "opensearch-protobufs"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e2/8a09dbdbfe51e30dfecb625a0f5c524a53bfa4b1fba168f73ac85621dba2/opensearch_protobufs-0.19.0-py3-none-any.whl", hash = "sha256:5137c9c2323cc7debb694754b820ca4cfb5fc8eb180c41ff125698c3ee11bfc2", size = 39778, upload-time = "2025-09-29T20:05:52.379Z" },
+]
+
+[[package]]
+name = "opensearch-py"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "events" },
+    { name = "opensearch-protobufs" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/9f/d4969f7e8fa221bfebf254cc3056e7c743ce36ac9874e06110474f7c947d/opensearch_py-3.1.0.tar.gz", hash = "sha256:883573af13175ff102b61c80b77934a9e937bdcc40cda2b92051ad53336bc055", size = 258616, upload-time = "2025-11-20T16:37:36.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/a1/293c8ad81768ad625283d960685bde07c6302abf20a685e693b48ab6eb91/opensearch_py-3.1.0-py3-none-any.whl", hash = "sha256:e5af83d0454323e6ea9ddee8c0dcc185c0181054592d23cb701da46271a3b65b", size = 385729, upload-time = "2025-11-20T16:37:34.941Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
- CI was failing on all platforms (Linux, macOS, Windows) because `uv run pytest` could not resolve `pytest` — no `pyproject.toml` existed and no test files were
  present
  - Add `pyproject.toml` with `opensearch-py` as a dependency and `pytest` as a dev dependency
  - Port 7 relevant test suites (234 tests) from [opensearch-launchpad](https://github.com/opensearch-project/opensearch-launchpad), updating import paths from
  `opensearch-launchpad` to `opensearch-skills`
  - Update `DEVELOPER_GUIDE.md` with accurate test instructions, prerequisites, and a table of test files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
