### PR TITLE
Pull opensearch latest docker and show agentic search as search type

### DIFF
--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -214,7 +214,7 @@ Ask the user whether they want to process the entire document or specific page r
 
 ### Phase 2 — Gather Preferences
 
-Ask the user **one at a time**: query pattern (keyword, semantic, hybrid, agentic) and deployment preference. Skip questions that don't apply.
+Ask the user **one at a time**: search strategy and deployment preference. Always present all five strategies — `bm25` (keyword), `dense_vector` (semantic via embeddings), `neural_sparse` (semantic via learned sparse representations), `hybrid` (combines keyword + semantic), and `agentic` (LLM-driven multi-step retrieval, requires OpenSearch 3.2+) — regardless of cluster version. Skip questions that don't apply.
 
 ### Phase 3 — Plan
 

--- a/skills/opensearch-skills/scripts/start_opensearch.sh
+++ b/skills/opensearch-skills/scripts/start_opensearch.sh
@@ -32,6 +32,7 @@ docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 echo "Starting OpenSearch..." >&2
 
 docker run -d \
+    --pull always \
     --name "$CONTAINER_NAME" \
     -p "${PORT}:9200" \
     -p 9600:9600 \


### PR DESCRIPTION
### Description
Stale cache of docker opensearch might pull outdated version and not latest for a local container.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
