### PR TITLE
docs: Add per-skill install commands with --full-depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Install using [`npx skills`](https://agentskills.io):
 npx skills add opensearch-project/opensearch-agent-skills
 
 # Install a specific skill
-npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad
-npx skills add opensearch-project/opensearch-agent-skills@log-analytics
-npx skills add opensearch-project/opensearch-agent-skills@trace-analytics
-npx skills add opensearch-project/opensearch-agent-skills@aws-setup
+npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth
+npx skills add opensearch-project/opensearch-agent-skills@log-analytics --full-depth
+npx skills add opensearch-project/opensearch-agent-skills@trace-analytics --full-depth
+npx skills add opensearch-project/opensearch-agent-skills@aws-setup --full-depth
 ```
 
 ### Install options

--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -23,10 +23,10 @@ This is the top-level skill for OpenSearch. It contains three category skills th
 
 | Category | Skill | Install individually |
 |---|---|---|
-| [search](search/SKILL.md) | [opensearch-launchpad](search/opensearch-launchpad/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad` |
-| [observability](observability/SKILL.md) | [log-analytics](observability/log-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@log-analytics` |
-| [observability](observability/SKILL.md) | [trace-analytics](observability/trace-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@trace-analytics` |
-| [cloud](cloud/SKILL.md) | [aws-setup](cloud/aws-setup/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@aws-setup` |
+| [search](search/SKILL.md) | [opensearch-launchpad](search/opensearch-launchpad/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth` |
+| [observability](observability/SKILL.md) | [log-analytics](observability/log-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@log-analytics --full-depth` |
+| [observability](observability/SKILL.md) | [trace-analytics](observability/trace-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@trace-analytics --full-depth` |
+| [cloud](cloud/SKILL.md) | [aws-setup](cloud/aws-setup/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@aws-setup --full-depth` |
 
 ## Routing
 


### PR DESCRIPTION
## Changes
- README: Added per-skill install examples (\`@opensearch-launchpad\`, \`@log-analytics\`, \`@trace-analytics\`, \`@aws-setup\`)
- SKILL.md: Added install column to the skills table with per-skill commands

## Testing
- Verified \`npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth\` works
- All 242 tests pass

Signed-off-by: Arjun kumar Giri <arjung@amazon.com>"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
