### PR TITLE
Update Cursor plugin manifest for multi-skill architecture

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "opensearch-agent-skills",
   "displayName": "OpenSearch Agent Skills",
-  "version": "0.1.0",
-  "description": "Build search applications and analyze observability data with OpenSearch. Includes semantic, hybrid, neural sparse, and agentic search strategies with optional AWS deployment.",
+  "version": "0.2.0",
+  "description": "Use this plugin to build search applications (semantic, hybrid, neural sparse, agentic) and analyze observability data (logs and traces) with OpenSearch. Install all skills at once or pick individual ones — just ask your AI assistant to set up a search app, query logs, investigate traces, or deploy to AWS.",
   "author": "opensearch-project",
   "license": "Apache-2.0",
   "repository": "https://github.com/opensearch-project/opensearch-agent-skills",
@@ -14,7 +14,7 @@
       "name": "opensearch-skills",
       "path": "skills/opensearch-skills",
       "entryPoint": "skills/opensearch-skills/SKILL.md",
-      "description": "Build search apps (semantic, hybrid, neural, agentic) and analyze logs/traces with OpenSearch. Includes local execution and optional AWS deployment.",
+      "description": "All-in-one skill bundle: build search apps, analyze logs and traces, and deploy to AWS with OpenSearch.",
       "keywords": [
         "opensearch",
         "search",
@@ -29,6 +29,75 @@
         "observability",
         "PPL",
         "OpenTelemetry"
+      ]
+    },
+    {
+      "name": "opensearch-launchpad",
+      "path": "skills/opensearch-skills/search/opensearch-launchpad",
+      "entryPoint": "skills/opensearch-skills/search/opensearch-launchpad/SKILL.md",
+      "description": "Build search applications from scratch with semantic, hybrid, neural sparse, and agentic search strategies.",
+      "keywords": [
+        "opensearch",
+        "search",
+        "semantic-search",
+        "vector-search",
+        "hybrid-search",
+        "neural-sparse",
+        "agentic-search",
+        "RAG",
+        "embeddings",
+        "KNN",
+        "document-processing"
+      ]
+    },
+    {
+      "name": "log-analytics",
+      "path": "skills/opensearch-skills/observability/log-analytics",
+      "entryPoint": "skills/opensearch-skills/observability/log-analytics/SKILL.md",
+      "description": "Query and analyze logs in OpenSearch using PPL and Query DSL for error patterns, anomaly detection, and log investigation.",
+      "keywords": [
+        "opensearch",
+        "log-analytics",
+        "PPL",
+        "observability",
+        "Fluent-Bit",
+        "Fluentd",
+        "Logstash",
+        "syslog",
+        "error-rate",
+        "anomaly-detection"
+      ]
+    },
+    {
+      "name": "trace-analytics",
+      "path": "skills/opensearch-skills/observability/trace-analytics",
+      "entryPoint": "skills/opensearch-skills/observability/trace-analytics/SKILL.md",
+      "description": "Investigate distributed traces and spans in OpenSearch for latency analysis, error debugging, and service dependency mapping.",
+      "keywords": [
+        "opensearch",
+        "trace-analytics",
+        "OpenTelemetry",
+        "distributed-tracing",
+        "spans",
+        "latency",
+        "service-map",
+        "observability"
+      ]
+    },
+    {
+      "name": "aws-setup",
+      "path": "skills/opensearch-skills/cloud/aws-setup",
+      "entryPoint": "skills/opensearch-skills/cloud/aws-setup/SKILL.md",
+      "description": "Deploy OpenSearch search applications to Amazon OpenSearch Service or Amazon OpenSearch Serverless with Bedrock connectors.",
+      "keywords": [
+        "opensearch",
+        "aws",
+        "Amazon-OpenSearch-Service",
+        "OpenSearch-Serverless",
+        "Bedrock",
+        "SigV4",
+        "IAM",
+        "cloud-deployment"
       ]
     }
   ],


### PR DESCRIPTION
Add user-facing description field and expand skills array to list each sub-skill (opensearch-launchpad, log-analytics, trace-analytics, aws-setup) individually alongside the all-in-one bundle.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
