### PR TITLE
feat: Add mcp.json for Cursor plugin MCP server setup

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -105,14 +105,5 @@
     "python": ">=3.11",
     "tools": ["uv", "docker"],
     "optional": ["aws-cli"]
-  },
-  "mcpServers": {
-    "opensearch-mcp-server": {
-      "command": "uvx",
-      "args": ["opensearch-mcp-server-py@latest"],
-      "env": {
-        "FASTMCP_LOG_LEVEL": "ERROR"
-      }
-    }
   }
 }

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,29 @@
+{
+  "mcpServers": {
+    "opensearch-mcp-server": {
+      "command": "uvx",
+      "args": ["opensearch-mcp-server-py@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    },
+    "ddg-search": {
+      "command": "uvx",
+      "args": ["duckduckgo-mcp-server"]
+    },
+    "awslabs.aws-api-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.aws-api-mcp-server@latest"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    },
+    "aws-knowledge-mcp-server": {
+      "command": "uvx",
+      "args": ["fastmcp", "run", "https://knowledge-mcp.global.api.aws"],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add mcp.json at the repo root so that installing the Cursor plugin automatically configures all required MCP servers:

- opensearch-mcp-server: direct OpenSearch API access (local + AOS/AOSS)
- ddg-search: documentation lookup via DuckDuckGo
- awslabs.aws-api-mcp-server: AWS API calls for deployment
- aws-knowledge-mcp-server: AWS documentation lookup

Remove redundant mcpServers from plugin.json since mcp.json is the standard file Cursor reads for MCP server definitions.

Doc: https://cursor.com/docs/plugins

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
