### PR TITLE
feat(sync): framework for mirroring upstream skills (pr-mode default, CI-gated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
   pull_request:
+  # Allows sync-skills.yml to re-dispatch CI against a PR branch after
+  # the bot pushes to it (GITHUB_TOKEN pushes don't retrigger pull_request).
+  workflow_dispatch:
 
 jobs:
   test-linux:

--- a/.github/workflows/sync-bot-ci.yml
+++ b/.github/workflows/sync-bot-ci.yml
@@ -1,0 +1,64 @@
+name: Sync Bot CI
+
+# Tests and lints the skill-sync engine (sync-bot/). Kept deliberately
+# separate from the repo-wide CI workflow so that:
+#   * Failures here block sync-bot changes without blocking skill edits.
+#   * Skill-only PRs don't pay the cost of upstream-clone integration tests.
+#
+# Scoped with `paths:` so it only fires when sync-bot code, its config
+# surface, or this workflow itself changes.
+
+on:
+  push:
+    paths:
+      - 'sync-bot/**'
+      - 'sync/sources/**'
+      - '.github/workflows/sync-bot-ci.yml'
+  pull_request:
+    paths:
+      - 'sync-bot/**'
+      - 'sync/sources/**'
+      - '.github/workflows/sync-bot-ci.yml'
+  # Allow sync-skills.yml to re-dispatch after a bot push to a PR branch
+  # (GITHUB_TOKEN pushes don't retrigger pull_request).
+  workflow_dispatch:
+
+concurrency:
+  group: sync-bot-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        # sync-bot is a CLI tool that runs on the Linux scheduled runner,
+        # so Linux is the contract. macOS is covered to catch path / git
+        # subtleties before they hit a contributor's laptop. Windows is
+        # intentionally excluded: sync-bot shells out to `git am` and
+        # uses POSIX-style paths, and we don't support Windows runners.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install sync-bot (locked)
+        # Use --frozen so CI fails if sync-bot/uv.lock is out-of-date
+        # relative to sync-bot/pyproject.toml. Protects against a
+        # dep bump landing without a refreshed lock.
+        working-directory: sync-bot
+        run: uv sync --frozen
+
+      - name: Run tests
+        working-directory: sync-bot
+        run: uv run pytest -v

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -275,7 +275,7 @@ jobs:
           ---
 
           **Reviewing or editing a synced skill?** Read
-          [\`sync/SYNCED_SKILL_POLICY.md\`](../blob/${BASE}/sync/SYNCED_SKILL_POLICY.md)
+          [\`sync/SYNCED_SKILL_POLICY.md\`](https://github.com/${{ github.repository }}/blob/${BASE}/sync/SYNCED_SKILL_POLICY.md)
           first. TL;DR: fixes belong **upstream**, not on this PR branch —
           any commit pushed here is overwritten on the next sync run.
           EOF

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -2,20 +2,21 @@ name: Sync Skills
 
 # Mirrors skill directories from upstream repos into this one.
 #
-# Every hour the workflow runs `opensearch-skills-sync` (the CLI
-# shipped by sync-bot/), which walks each source repo's history since
-# the last-synced commit and replays new commits that touched the
-# configured subdirectory into a destination directory here. Original
-# authorship is preserved (author field + Co-authored-by trailer) and
-# provenance trailers (Source-Repo / Source-Commit) are appended.
+# The workflow runs `opensearch-skills-sync` (the CLI shipped by
+# sync-bot/) on the schedule below, which walks each source repo's
+# history since the last-synced commit and replays new commits that
+# touched the configured subdirectory into a destination directory
+# here. Original authorship is preserved (author field +
+# Co-authored-by trailer) and provenance trailers (Source-Repo /
+# Source-Commit) are appended.
 #
 # If any source fails the workflow still commits + pushes successful
 # sources, then fails the job at the end so the failure is visible.
 
 on:
   schedule:
-    # Every 20 minutes. Note: GitHub often delays scheduled workflows
-    # under load; treat this as "at least every ~hour" in practice.
+    # Every 20 minutes. GitHub may delay scheduled workflows under
+    # load, so actual cadence can stretch longer.
     - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -215,6 +215,30 @@ jobs:
             DESTPATH=$(jq -r --arg n "$NAME" '.[] | select(.name == $n) | .dest_path' sync-results.json)
             COMMITS=$(jq -r --arg n "$NAME" '.[] | select(.name == $n) | .commits_imported' sync-results.json)
             echo "::group::pr-mode: ${NAME} (${COMMITS} commits) -> ${BRANCH}"
+            # Idempotency guard: if the remote branch already exists and its
+            # tip tree matches the locally-rebuilt tree, nothing content-wise
+            # has changed. Skip the force-push (and skip PR body update) so
+            # repeated cron runs with no upstream changes don't churn the
+            # branch SHA, retrigger CI, or spam subscribers on open PRs.
+            #
+            # We compare *tree* SHAs, not commit SHAs: the squashed commit is
+            # rebuilt every run with a fresh committer timestamp, so its SHA
+            # always differs even when content is byte-identical. The tree
+            # SHA is a pure content hash and is stable across rebuilds.
+            LOCAL_TREE=$(git rev-parse "${BRANCH}^{tree}")
+            # Fetch the remote tip (if any) and read *its* tree SHA. We
+            # can't use `git ls-remote` here because that returns the
+            # commit SHA, not the tree SHA. `|| true` swallows the error
+            # when the branch doesn't exist remotely yet (first run).
+            REMOTE_TREE=""
+            if git fetch origin "${BRANCH}" --depth=1 2>/dev/null; then
+              REMOTE_TREE=$(git rev-parse "FETCH_HEAD^{tree}" 2>/dev/null || echo "")
+            fi
+            if [[ -n "${REMOTE_TREE}" && "${LOCAL_TREE}" == "${REMOTE_TREE}" ]]; then
+              echo "Remote ${BRANCH} tree matches local tree (${LOCAL_TREE:0:12}); skipping push + PR update."
+              echo "::endgroup::"
+              continue
+            fi
             # Force-push the per-source branch. --force-with-lease would
             # be safer, but the branch is bot-owned and reset to HEAD
             # every run, so a plain --force is intentional: it discards

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -246,6 +246,13 @@ jobs:
           Author attribution is preserved via \`Co-authored-by\` trailers
           and \`Source-Repo\` / \`Source-Commit\` provenance trailers on
           each imported commit.
+
+          ---
+
+          **Reviewing or editing a synced skill?** Read
+          [\`sync/SYNCED_SKILL_POLICY.md\`](../blob/${BASE}/sync/SYNCED_SKILL_POLICY.md)
+          first. TL;DR: fixes belong **upstream**, not on this PR branch —
+          any commit pushed here is overwritten on the next sync run.
           EOF
           )
             if gh pr view "${BRANCH}" --json number --jq .number >/dev/null 2>&1; then

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,173 @@
+name: Sync Skills
+
+# Mirrors skill directories from upstream repos into this one.
+#
+# Every hour the workflow runs `opensearch-skills-sync` (the CLI
+# shipped by sync-bot/), which walks each source repo's history since
+# the last-synced commit and replays new commits that touched the
+# configured subdirectory into a destination directory here. Original
+# authorship is preserved (author field + Co-authored-by trailer) and
+# provenance trailers (Source-Repo / Source-Commit) are appended.
+#
+# If any source fails the workflow still commits + pushes successful
+# sources, then fails the job at the end so the failure is visible.
+
+on:
+  schedule:
+    # Every hour at minute 0. Note: GitHub often delays scheduled workflows
+    # under load; treat this as "at least every ~2 hours".
+    - cron: '0 * * * *'
+  workflow_dispatch:
+    inputs:
+      only:
+        description: 'Sync only this source name (optional)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry-run (no commits, no push)'
+        required: false
+        type: boolean
+        default: false
+  # Auto-fire on PRs that add/edit a source YAML or touch the sync
+  # engine. This lets a contributor just commit
+  # `sync/sources/<name>.yaml` and have the mirrored content appear on
+  # their branch without any manual dispatch.
+  #
+  # Ignores PRs from forks (head.repo != base.repo) since GITHUB_TOKEN
+  # can't push to a fork. Forked-PR authors still get dry-run validation
+  # via validate-skills.yml.
+  pull_request:
+    paths:
+      - 'sync/sources/**'
+      - 'sync-bot/**'
+      - '.github/workflows/sync-skills.yml'
+
+# Prevent overlapping runs on the same ref. Cron and PR runs use
+# different groups so a slow cron doesn't block PR feedback.
+concurrency:
+  group: sync-skills-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  # Needed so the sync engine can open/update/close failure-tracking
+  # issues on the default branch, or post PR comments on non-default
+  # branches, via `gh ...`. The reporter silently skips if auth is
+  # missing.
+  issues: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Skip fork PRs: GITHUB_TOKEN can't push to the contributor's fork
+    # and can't re-dispatch checks on it either. Dry-run still runs in
+    # validate-skills.yml on the fork PR, so config breakage is caught.
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # On cron / workflow_dispatch this checks out the branch the
+          # workflow was dispatched on. On pull_request we need the PR
+          # head (not the merge ref) because we're going to push back to
+          # the PR branch.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          # Need full history so `git am` lands on top of the real branch tip.
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install sync-bot (locked)
+        # --frozen: CI fails if sync-bot/uv.lock is stale relative to
+        # sync-bot/pyproject.toml. Guard against a dep bump sneaking in
+        # without a refreshed lockfile.
+        working-directory: sync-bot
+        run: uv sync --frozen
+
+      - name: Cache upstream clones
+        uses: actions/cache@v4
+        with:
+          path: .sync-cache
+          key: sync-cache-${{ runner.os }}-${{ hashFiles('sync/sources/*.yaml') }}
+          restore-keys: |
+            sync-cache-${{ runner.os }}-
+
+      - name: Resolve target branch
+        id: target
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run sync
+        id: sync
+        env:
+          SYNC_BOT_NAME: 'opensearch-ci'
+          SYNC_BOT_EMAIL: '83309141+opensearch-ci-bot@users.noreply.github.com'
+          # `gh` CLI authentication for the in-script issue reporter.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ARGS=()
+          if [[ -n "${{ inputs.only }}" ]]; then
+            ARGS+=(--only "${{ inputs.only }}")
+          fi
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            ARGS+=(--dry-run)
+          fi
+          uv run --project sync-bot opensearch-skills-sync "${ARGS[@]}"
+
+      - name: Push
+        id: push
+        if: ${{ inputs.dry_run != 'true' }}
+        run: |
+          set -euo pipefail
+          BRANCH='${{ steps.target.outputs.branch }}'
+          if git diff --quiet "origin/${BRANCH}" HEAD; then
+            echo "No new commits to push."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Fast-forward push. If the branch moved underneath us between
+          # the checkout and now, fail loudly — next cron tick (or the
+          # PR's next push) will retry cleanly.
+          git push origin "HEAD:${BRANCH}"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # After we push bot commits to a PR branch, GitHub's infinite-loop
+      # guard suppresses the normal pull_request re-run of CI and
+      # validate-skills (because the push was authenticated with
+      # GITHUB_TOKEN). Re-dispatch them explicitly so PR checks reflect
+      # the post-sync tree.
+      - name: Re-trigger PR checks on post-sync HEAD
+        if: ${{ github.event_name == 'pull_request' && steps.push.outputs.pushed == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH='${{ steps.target.outputs.branch }}'
+          # workflow_dispatch requires the workflow to define that trigger.
+          for wf in ci.yml validate-skills.yml sync-bot-ci.yml; do
+            if gh workflow view "$wf" --json on --jq '.on | keys[]' 2>/dev/null | grep -q workflow_dispatch; then
+              echo "Dispatching $wf on $BRANCH"
+              gh workflow run "$wf" --ref "$BRANCH" || echo "Dispatch of $wf failed (non-fatal)"
+            else
+              echo "Skipping $wf (no workflow_dispatch trigger; add one to enable post-sync rechecks)"
+            fi
+          done

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -14,9 +14,9 @@ name: Sync Skills
 
 on:
   schedule:
-    # Every hour at minute 0. Note: GitHub often delays scheduled workflows
-    # under load; treat this as "at least every ~2 hours".
-    - cron: '0 * * * *'
+    # Every 20 minutes. Note: GitHub often delays scheduled workflows
+    # under load; treat this as "at least every ~hour" in practice.
+    - cron: '*/20 * * * *'
   workflow_dispatch:
     inputs:
       only:
@@ -28,6 +28,19 @@ on:
         required: false
         type: boolean
         default: false
+      mode:
+        description: >-
+          Sync mode. push = land imports directly on the target branch (hub
+          mirror behaviour, used by cron). pr = isolate each source on a
+          `skills-sync/<name>` branch, force-push it, and open/update a PR
+          from that branch into the target branch (one PR per source, one
+          failing source doesn't block others).
+        required: false
+        type: choice
+        default: push
+        options:
+          - push
+          - pr
   # Auto-fire on PRs that add/edit a source YAML or touch the sync
   # engine. This lets a contributor just commit
   # `sync/sources/<name>.yaml` and have the mirrored content appear on
@@ -106,10 +119,15 @@ jobs:
 
       - name: Resolve target branch
         id: target
+        env:
+          # Pass untrusted refs through env to avoid script injection
+          # via crafted branch names.
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            echo "branch=${PR_HEAD_REF}" >> "$GITHUB_OUTPUT"
           else
             echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
@@ -121,20 +139,34 @@ jobs:
           SYNC_BOT_EMAIL: '83309141+opensearch-ci-bot@users.noreply.github.com'
           # `gh` CLI authentication for the in-script issue reporter.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass inputs through env to avoid direct interpolation into
+          # bash scripts (GitHub security best practice).
+          ONLY_INPUT: ${{ inputs.only }}
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
+          # inputs.mode is only set for workflow_dispatch; default to
+          # push for cron and pull_request triggers.
+          MODE_INPUT: ${{ inputs.mode || 'push' }}
         run: |
           set -euo pipefail
           ARGS=()
-          if [[ -n "${{ inputs.only }}" ]]; then
-            ARGS+=(--only "${{ inputs.only }}")
+          if [[ -n "${ONLY_INPUT}" ]]; then
+            ARGS+=(--only "${ONLY_INPUT}")
           fi
-          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+          if [[ "${DRY_RUN_INPUT}" == "true" ]]; then
             ARGS+=(--dry-run)
           fi
+          ARGS+=(--mode "${MODE_INPUT}")
+          # Always write results.json — push-mode ignores it, pr-mode
+          # iterates it in the next step.
+          ARGS+=(--results-json sync-results.json)
           uv run --project sync-bot opensearch-skills-sync "${ARGS[@]}"
+          echo "mode=${MODE_INPUT}" >> "$GITHUB_OUTPUT"
 
       - name: Push
         id: push
-        if: ${{ inputs.dry_run != 'true' }}
+        # Skip in pr-mode: pr-mode force-pushes per-source branches in a
+        # later step and must not touch the target branch directly.
+        if: ${{ inputs.dry_run != 'true' && steps.sync.outputs.mode != 'pr' }}
         run: |
           set -euo pipefail
           BRANCH='${{ steps.target.outputs.branch }}'
@@ -150,13 +182,102 @@ jobs:
           echo "pushed=true" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      # pr-mode: for every source that imported >=1 commit, force-push its
+      # `skills-sync/<name>` branch and open (or update) a PR from it
+      # into the target branch. One failing source doesn't block the
+      # others — we iterate with || true on per-source errors and keep
+      # track of failures to surface at the end.
+      - name: Open/update PRs (pr-mode)
+        id: prmode
+        if: ${{ inputs.dry_run != 'true' && steps.sync.outputs.mode == 'pr' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BASE='${{ steps.target.outputs.branch }}'
+          if [[ ! -f sync-results.json ]]; then
+            echo "sync-results.json not produced; nothing to do."
+            exit 0
+          fi
+          # jq filter: only sources that actually synced and have a branch.
+          mapfile -t SYNCED < <(
+            jq -r '.[] | select(.status == "synced" and .dest_branch != "") | .name' sync-results.json
+          )
+          if [[ ${#SYNCED[@]} -eq 0 ]]; then
+            echo "No synced sources in pr-mode; nothing to push."
+            exit 0
+          fi
+          FAIL=0
+          for NAME in "${SYNCED[@]}"; do
+            BRANCH="skills-sync/${NAME}"
+            URL=$(jq -r --arg n "$NAME" '.[] | select(.name == $n) | .url' sync-results.json)
+            SRCPATH=$(jq -r --arg n "$NAME" '.[] | select(.name == $n) | .src_path' sync-results.json)
+            DESTPATH=$(jq -r --arg n "$NAME" '.[] | select(.name == $n) | .dest_path' sync-results.json)
+            COMMITS=$(jq -r --arg n "$NAME" '.[] | select(.name == $n) | .commits_imported' sync-results.json)
+            echo "::group::pr-mode: ${NAME} (${COMMITS} commits) -> ${BRANCH}"
+            # Force-push the per-source branch. --force-with-lease would
+            # be safer, but the branch is bot-owned and reset to HEAD
+            # every run, so a plain --force is intentional: it discards
+            # any stale state from a previous (possibly partial) attempt.
+            if ! git push --force origin "${BRANCH}:${BRANCH}"; then
+              echo "::error::failed to push ${BRANCH}"
+              FAIL=1
+              echo "::endgroup::"
+              continue
+            fi
+            # Open-or-update the PR. `gh pr create` errors if a PR
+            # already exists for the branch; in that case we just edit
+            # the existing one so the body stays in sync.
+            TITLE="[sync] ${NAME}: import ${COMMITS} commit(s) from upstream"
+            BODY=$(cat <<EOF
+          Automated by the skills-sync framework (pr-mode).
+
+          Source repository: ${URL}
+          Source path: \`${SRCPATH}\`
+          Destination path: \`${DESTPATH}\`
+          Commits imported: ${COMMITS}
+
+          This PR was opened from branch \`${BRANCH}\`, which is reset to
+          \`${BASE}\` at the start of every run and then has the upstream
+          commits replayed on top of it. Any manual commits on this
+          branch will be overwritten on the next sync run — edit the
+          upstream skill instead, or convert this sync to push-mode.
+
+          Author attribution is preserved via \`Co-authored-by\` trailers
+          and \`Source-Repo\` / \`Source-Commit\` provenance trailers on
+          each imported commit.
+          EOF
+          )
+            if gh pr view "${BRANCH}" --json number --jq .number >/dev/null 2>&1; then
+              echo "PR already open; updating title/body."
+              gh pr edit "${BRANCH}" --title "${TITLE}" --body "${BODY}" || {
+                echo "::error::failed to edit PR for ${BRANCH}"
+                FAIL=1
+              }
+            else
+              gh pr create \
+                --base "${BASE}" \
+                --head "${BRANCH}" \
+                --title "${TITLE}" \
+                --body "${BODY}" || {
+                  echo "::error::failed to create PR for ${BRANCH}"
+                  FAIL=1
+                }
+            fi
+            echo "::endgroup::"
+          done
+          if [[ "${FAIL}" -ne 0 ]]; then
+            echo "::error::one or more pr-mode sources failed to publish; see logs above"
+            exit 1
+          fi
+
       # After we push bot commits to a PR branch, GitHub's infinite-loop
       # guard suppresses the normal pull_request re-run of CI and
       # validate-skills (because the push was authenticated with
       # GITHUB_TOKEN). Re-dispatch them explicitly so PR checks reflect
       # the post-sync tree.
       - name: Re-trigger PR checks on post-sync HEAD
-        if: ${{ github.event_name == 'pull_request' && steps.push.outputs.pushed == 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.push.outputs.pushed == 'true' && steps.sync.outputs.mode != 'pr' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,94 @@
+name: Validate Skills Sync (dry-run)
+
+# Runs the skill-sync engine in --dry-run mode on every PR and on every
+# branch push (except main, which is covered by the scheduled Sync Skills
+# workflow).
+#
+# Purpose: catch broken sync configuration — unreachable upstreams, wrong
+# branch names, typo'd src_path, etc. — before the change lands on main
+# and the cron starts failing every 5 minutes.
+#
+# Dry-run contract:
+#   * `opensearch-skills-sync --dry-run` still exits 1 if any source fails
+#     to mirror, so CI is red when the config is broken.
+#   * No commits are created, nothing is pushed, and the issue reporter
+#     is fully skipped (main() gates it on `not args.dry_run`).
+
+on:
+  pull_request:
+    # Re-run when the workflow itself or anything the sync depends on changes.
+    paths:
+      - 'sync/sources/**'
+      - 'sync-bot/**'
+      - '.github/workflows/validate-skills.yml'
+      - '.github/workflows/sync-skills.yml'
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - 'sync/sources/**'
+      - 'sync-bot/**'
+      - '.github/workflows/validate-skills.yml'
+      - '.github/workflows/sync-skills.yml'
+  # Allows sync-skills.yml to re-dispatch validation against a PR branch
+  # after the bot pushes to it (GITHUB_TOKEN pushes don't retrigger pull_request).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# If the same branch gets a rapid burst of pushes, cancel stale runs.
+concurrency:
+  group: validate-skills-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The sync engine only needs history of its own repo for
+          # origin/main diffs, not for the upstream repos (which it
+          # clones fresh). Keep shallow.
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install sync-bot (locked)
+        # --frozen: CI fails if sync-bot/uv.lock is stale relative to
+        # sync-bot/pyproject.toml. This is our guard against a dep bump
+        # sneaking in without a refreshed lockfile.
+        working-directory: sync-bot
+        run: uv sync --frozen
+
+      - name: Cache upstream clones
+        uses: actions/cache@v4
+        with:
+          # Separate cache key from the production sync so a broken PR
+          # config can't poison the main-branch cache.
+          path: .sync-cache
+          key: validate-sync-cache-${{ runner.os }}-${{ hashFiles('sync/sources/*.yaml') }}
+          restore-keys: |
+            validate-sync-cache-${{ runner.os }}-
+
+      - name: Run sync (dry-run)
+        env:
+          # Bot identity is set even in dry-run because the sync creates
+          # commits locally (just never pushes them) to compute diffs.
+          SYNC_BOT_NAME: 'opensearch-ci'
+          SYNC_BOT_EMAIL: '83309141+opensearch-ci-bot@users.noreply.github.com'
+          # Deliberately NOT setting GH_TOKEN: dry-run skips the issue
+          # reporter anyway, and omitting the token makes that guarantee
+          # mechanical (no accidental gh-CLI mutations from a PR).
+        run: |
+          set -euo pipefail
+          uv run --project sync-bot opensearch-skills-sync --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ local/
 # OS files
 .DS_Store
 Thumbs.db
+
+# Skill sync cache (upstream clones) — regenerable
+.sync-cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,3 +112,4 @@ uv run pytest tests/test_agent_skills_evaluate.py::test_ndcg_perfect_ranking -v
 - The main CLI (`opensearch_ops.py`) uses PEP 723 inline script dependencies and is designed to be run directly by AI agents via `uv run`.
 - The React UI (`scripts/ui/`) is served by a lightweight Python HTTP server (`lib/ui.py`) on port 8765.
 - MCP server integration is optional and configured per-IDE.
+- **Skill sync framework** (`sync/`, `sync-bot/`): skills can be authored in this repo under `skills/`, or mirrored from an upstream project's repo via a YAML source under `sync/sources/`. A scheduled GitHub Actions workflow replays upstream commits (preserving authorship via `Co-authored-by` trailers) into `skills/` every hour. Do not hand-edit synced skills — check `sync/sources/` before modifying files under `skills/`. See [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) ("Mirroring an Upstream Skill") and [`sync/README.md`](sync/README.md) for details.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,6 +2,11 @@
 
 This guide covers how to contribute new skills, local development, testing, and conventions.
 
+Two ways to contribute a skill:
+
+1. **Author it here** — write a skill directly in this repo under `skills/`. See *Contributing a New Skill* below.
+2. **Mirror it from an upstream repo** — register a YAML source under `sync/sources/` and the sync framework replays the upstream history into `skills/` every hour. See *Mirroring an Upstream Skill* further down.
+
 ---
 
 ## Contributing a New Skill
@@ -149,6 +154,85 @@ uv run pytest tests/test_agent_skills_evaluate.py::test_ndcg_perfect_ranking -v
 ### CI
 
 GitHub Actions runs the full test suite on every push and PR across Linux, macOS, and Windows. See `.github/workflows/ci.yml`.
+
+---
+
+## Mirroring an Upstream Skill
+
+Some skills live in their home project's repo (e.g. an integration skill shipped alongside the tool it wraps). Rather than duplicating the content here and letting it rot, this repo can **sync subdirectories from upstream repos** directly into `skills/` on a schedule, preserving per-commit authorship and history. Synced skills sit side-by-side with skills authored here — from an agent's perspective they're all just entries under `skills/`.
+
+### How it works (1-minute version)
+
+- One YAML file per upstream source under `sync/sources/` declares `url`, `branch`, `src_path`, `dest_path`.
+- A scheduled GitHub Action (`Sync Skills`) runs every hour.
+- For each source, the engine enumerates upstream commits that touched `src_path` since the last-synced SHA, replays each as its own commit here via `git format-patch | git am --directory=<dest_path>`, prefixes the subject with `[<source-name>]`, and appends `Source-Repo` / `Source-Commit` / `Co-authored-by` trailers. The original author and date survive — the GitHub contributor graph credits upstream authors.
+- `sync/state.json` tracks the last-synced SHA per source so subsequent runs are incremental.
+- Each source is isolated: a failure in one (bad patch, spec violation, upstream outage) opens a tracking issue and does not block the others.
+
+Full engine semantics are documented in [`sync/README.md`](sync/README.md). Engine source + tests live in [`sync-bot/`](sync-bot/).
+
+### Adding a new upstream source
+
+The entire flow is: drop one YAML file, open a PR.
+
+1. Create `sync/sources/<short-name>.yaml`:
+
+   ```yaml
+   # Sync source: <short-name>
+   name: <short-name>                              # unique id (state key + commit-subject prefix)
+   url: https://github.com/<org>/<repo>.git
+   branch: main
+   src_path: skills/<upstream-skill-dir>           # subdir in upstream to mirror
+   dest_path: skills/<upstream-skill-dir>          # where it lands here (sibling of authored skills)
+   ```
+
+   Rules:
+   - `name` must be unique across `sync/sources/` (hard error otherwise).
+   - `dest_path`'s **leaf** directory name must equal the upstream `SKILL.md`'s `name:` field — the Agent Skills Spec validator enforces this and rolls back the import on mismatch.
+   - Files are processed in lexicographic order, so filenames double as a sync-order knob.
+
+2. Commit the YAML on a branch, push, open a PR.
+
+3. `Sync Skills` auto-fires on PRs that touch `sync/sources/**`. It replays the upstream history into `dest_path`, pushes those commits onto your PR branch, and re-runs CI + dry-run spec validation against the post-sync HEAD. Review the replayed commits, then merge.
+
+PRs opened from forks skip the auto-push (GitHub denies write tokens to forks) but still run dry-run validation, so config mistakes surface before merge.
+
+### Running the sync locally
+
+The engine is a standalone [uv](https://docs.astral.sh/uv/)-managed Python package under `sync-bot/`.
+
+```bash
+# Dry run (prints planned imports, writes nothing)
+uv run --project sync-bot opensearch-skills-sync --dry-run
+
+# Full sync (writes state.json + creates commits)
+uv run --project sync-bot opensearch-skills-sync
+
+# Sync a single source
+uv run --project sync-bot opensearch-skills-sync --only <source-name>
+
+# Custom sources directory (useful for experimentation)
+uv run --project sync-bot opensearch-skills-sync --sources-dir path/to/sources
+```
+
+Tests for the engine itself:
+
+```bash
+uv run --project sync-bot pytest
+```
+
+A dedicated CI workflow (`sync-bot-ci.yml`) runs these tests on Linux and macOS against the pinned `uv.lock` — independently of the skill-contents test suite.
+
+### Resetting a source
+
+To force a full re-import of an upstream (e.g. you changed `src_path` or the upstream did a history rewrite), delete that source's entry from `sync/state.json.sources` and commit. The next run treats it as a first-time sync and replays the upstream history bounded by the blob-filtered clone.
+
+### Conventions for synced skills
+
+- **Do not hand-edit** files in a synced skill's directory. Which skills are synced is declared in `sync/sources/*.yaml` — check there before editing. Changes to a synced skill will be overwritten on the next sync, or — worse — cause `git am` conflicts that abort the source. Fix issues upstream and let the sync pull them in.
+- **Synced commits are prefixed** with `[<source-name>]` in the subject line (LLVM-monorepo style) so mixed history is greppable: `git log --oneline | grep '^\w* \[anthropic-skill-creator\]'`.
+- **Sync-bot commits** (state.json advances, framework housekeeping) are authored by `opensearch-ci-bot` with a stable noreply email. Content commits keep their upstream author.
+- `sync/state.json` is committed to the repo. Do not add it to `.gitignore` — incremental sync depends on it being in HEAD.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,4 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-]
-
-# The skill-sync tool lives in sync-bot/ as a separately-versioned uv project
-# with its own dependencies (pyyaml, skills-ref) and lockfile. See
-# sync-bot/README.md for build/test instructions, or run:
-#     uv run --project sync-bot pytest
-#     uv run --project sync-bot opensearch-skills-sync --dry-run
+dev = ["pytest>=9.0.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,12 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=9.0.3"]
+dev = [
+    "pytest>=9.0.3",
+]
+
+# The skill-sync tool lives in sync-bot/ as a separately-versioned uv project
+# with its own dependencies (pyyaml, skills-ref) and lockfile. See
+# sync-bot/README.md for build/test instructions, or run:
+#     uv run --project sync-bot pytest
+#     uv run --project sync-bot opensearch-skills-sync --dry-run

--- a/sync-bot/README.md
+++ b/sync-bot/README.md
@@ -1,0 +1,76 @@
+# sync-bot
+
+Installable Python package that implements the skill-sync workflow for
+`opensearch-agent-skills`. For *what* the sync does and the *data* it
+operates on, see [`../sync/README.md`](../sync/README.md). This directory
+contains only the executable code and its tests.
+
+## Layout
+
+```
+sync-bot/
+├── pyproject.toml        ← declares runtime deps (pyyaml, skills-ref)
+├── uv.lock               ← pinned resolution
+├── src/
+│   └── skills_sync/
+│       ├── __init__.py   ← re-exports + console-script entry
+│       ├── __main__.py   ← enables `python -m skills_sync`
+│       └── main.py       ← all sync logic
+└── tests/
+    ├── conftest.py
+    ├── test_sync_unit.py
+    └── test_sync_integration.py
+```
+
+The data it manages stays at the repo root:
+
+- `../sync/state.json` — committed high-water-mark of synced SHAs
+- `../sync/sources/*.yaml` — source manifests (one file per upstream)
+
+## Running
+
+From the repository root:
+
+```bash
+# One-off dry run
+uv run --project sync-bot opensearch-skills-sync --dry-run
+
+# Full sync (writes state.json + creates commits)
+uv run --project sync-bot opensearch-skills-sync
+
+# Single source
+uv run --project sync-bot opensearch-skills-sync --only <source-name>
+
+# Tests
+uv run --project sync-bot pytest
+```
+
+Equivalent invocations:
+
+```bash
+uv run --project sync-bot python -m skills_sync --dry-run
+```
+
+## Repo-root resolution
+
+The sync code lives in this package; the data (`sync/state.json`,
+`sync/sources/`) lives at the repository root. The tool resolves the
+root in this order:
+
+1. `SYNC_REPO_ROOT` env var (absolute path) — used by tests and for
+   out-of-tree invocations.
+2. `git rev-parse --show-toplevel` from the current working directory.
+3. The current working directory.
+
+In CI and in normal `uv run --project sync-bot …` from the repo root,
+path 2 always matches.
+
+## Updating dependencies
+
+```bash
+# Add / bump a runtime dep
+uv add --project sync-bot pyyaml@^7.0
+
+# Regenerate the lockfile after editing pyproject.toml by hand
+uv lock --project sync-bot
+```

--- a/sync-bot/pyproject.toml
+++ b/sync-bot/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "opensearch-skills-sync"
+version = "0.1.0"
+description = "Import skill subdirectories from upstream repos into opensearch-agent-skills, preserving history."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "OpenSearch Contributors" },
+]
+# Runtime deps only. Anything not listed here must not be imported by
+# src/skills_sync/.
+dependencies = [
+    "pyyaml>=6.0",
+    "skills-ref>=0.1.1",
+]
+
+[project.scripts]
+# Installed into the venv bin/ so workflows can call it directly after
+# `uv sync --project sync-bot`.
+opensearch-skills-sync = "skills_sync:_cli"
+
+[project.urls]
+Homepage = "https://github.com/opensearch-project/opensearch-agent-skills"
+Issues = "https://github.com/opensearch-project/opensearch-agent-skills/issues"
+
+[dependency-groups]
+# Test-only deps. Kept in a separate group so `uv sync --no-dev` produces
+# a lean production install on the scheduled-runner image.
+dev = [
+    "pytest>=9.0.3",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/skills_sync"]
+
+# --------------------------------------------------------------------------
+# pytest
+# --------------------------------------------------------------------------
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Make src/ imports work without installing the package first — handy for
+# `uv run --project sync-bot pytest` in dev.
+pythonpath = ["src"]
+addopts = [
+    "-ra",
+    "--strict-markers",
+]

--- a/sync-bot/src/skills_sync/__init__.py
+++ b/sync-bot/src/skills_sync/__init__.py
@@ -1,0 +1,54 @@
+"""
+skills_sync — import skill subdirectories from upstream repos into this one.
+
+The executable entry point is `opensearch-skills-sync` (installed as a
+console_script by this package's pyproject.toml) or equivalently
+`python -m skills_sync`.
+
+The module-level constants (REPO_ROOT, STATE_FILE, CACHE_DIR, SYNC_BOT_NAME,
+SYNC_BOT_EMAIL, SOURCE_LABEL_PREFIX, …) are re-exported here so tests can
+patch them without caring about the submodule layout.
+"""
+
+from __future__ import annotations
+
+# Re-exports so tests and external callers can do `from skills_sync import X`
+# without caring about the submodule layout.
+#
+# IMPORTANT: do NOT re-export `main` (the function) here. Doing so binds
+# the name `main` in the package namespace and shadows the `skills_sync.main`
+# submodule, making `import skills_sync.main` resolve to the function
+# instead of the module. The CLI entry point `_cli` imports `main`
+# lazily from `.main` so it doesn't need it at package level.
+from .main import (  # noqa: F401  (re-exports for tests & external use)
+    CACHE_DIR,
+    DEFAULT_SOURCES_DIR,
+    REPO_ROOT,
+    SOURCE_LABEL_PREFIX,
+    STATE_FILE,
+    SYNC_BOT_EMAIL,
+    SYNC_BOT_NAME,
+    Source,
+    _error_hash,
+    _source_name_from_issue,
+    commits_touching_path,
+    fetch_upstream,
+    format_validation_failures,
+    load_sources_from_dir,
+    prefix_subject,
+    sync_one,
+    validate_skill_tree,
+)
+
+
+def _cli() -> None:
+    """Console-script entry point (pyproject.toml -> [project.scripts])."""
+    import sys
+
+    from .main import main
+
+    sys.exit(main())
+
+
+if __name__ == "__main__":  # pragma: no cover — `python -m skills_sync`
+    _cli()

--- a/sync-bot/src/skills_sync/__main__.py
+++ b/sync-bot/src/skills_sync/__main__.py
@@ -1,0 +1,9 @@
+"""Enable `python -m skills_sync` invocation."""
+from __future__ import annotations
+
+import sys
+
+from .main import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sync-bot/src/skills_sync/main.py
+++ b/sync-bot/src/skills_sync/main.py
@@ -231,6 +231,22 @@ class SourceResult:
     new_head: str = ""
     message: str = ""
     errors: list[str] = field(default_factory=list)
+    # In mode=pr, the per-source branch that sync_one left the imports on
+    # (e.g. "skills-sync/opensearch-dashboards-assistant"). Empty in mode=push.
+    # The workflow reads this to force-push and open/update a PR.
+    dest_branch: str = ""
+
+
+# Sync modes. "push" = land commits on the current branch + write state.json
+# (hub-repo behaviour: this is how opensearch-agent-skills mirrors upstream).
+# "pr"   = land commits on a per-source branch off origin/<base>, DO NOT
+#          write state.json (only the hub owns sync state), so the workflow
+#          can open/update a PR proposing the change upstream. Used when the
+#          sync engine runs FROM an upstream repo proposing itself back to
+#          the hub, or from the hub proposing changes to downstream forks.
+MODE_PUSH = "push"
+MODE_PR = "pr"
+ALL_MODES = (MODE_PUSH, MODE_PR)
 
 
 # ---------- state ----------
@@ -638,8 +654,31 @@ def squash_imported_commits(
     return run(["git", "rev-parse", "HEAD"], cwd=dest_repo).stdout.strip()
 
 
-def sync_one(source: Source, state: dict, dest_repo: Path, dry_run: bool) -> SourceResult:
+def sync_one(
+    source: Source,
+    state: dict,
+    dest_repo: Path,
+    dry_run: bool,
+    mode: str = MODE_PUSH,
+) -> SourceResult:
+    """Import one source's new commits into dest_repo.
+
+    mode=push (default): commits land on the CURRENT branch of dest_repo,
+    state.json is updated and committed. This is the hub-repo mirror path.
+
+    mode=pr: commits land on a fresh per-source branch `skills-sync/<name>`
+    that is reset to the current HEAD at the start of the run, and state.json
+    is NOT touched (the hub owns sync state, not the repo we're proposing into).
+    The workflow reads `result.dest_branch` to force-push + open/update a PR.
+    Per-source branches mean one failing source doesn't block the others, and
+    each upstream PR is independently reviewable/revertable.
+    """
+    if mode not in ALL_MODES:
+        raise ValueError(f"unknown sync mode {mode!r} (expected one of {ALL_MODES})")
     result = SourceResult(source=source, status="up-to-date")
+    # Track the branch we were on before switching, so we can restore even
+    # on failure. In push-mode this stays empty (no switching happens).
+    original_branch: str = ""
     try:
         cache, head_sha = fetch_upstream(source)
         last = state["sources"].get(source.state_key, {}).get("last_sha")
@@ -689,6 +728,24 @@ def sync_one(source: Source, state: dict, dest_repo: Path, dry_run: bool) -> Sou
         ensure_git_identity(dest_repo)
         pre_head = run(["git", "rev-parse", "HEAD"], cwd=dest_repo).stdout.strip()
 
+        # In pr-mode, isolate this source's imports on a dedicated branch
+        # `skills-sync/<name>` forked from the current HEAD. We reset the
+        # branch to HEAD each run so a prior failed/stale attempt never
+        # poisons a subsequent one — the branch is a view of "what the
+        # current base would look like WITH this source's imports applied".
+        # Switching branches must happen BEFORE any commits land, so the
+        # imports + optional squash target the per-source branch.
+        dest_branch_name = ""
+        if mode == MODE_PR:
+            original_branch = run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=dest_repo
+            ).stdout.strip()
+            dest_branch_name = f"skills-sync/{source.name}"
+            # -B creates-or-resets the branch to HEAD. Equivalent to
+            # `git branch -f NAME HEAD && git checkout NAME`.
+            run(["git", "checkout", "-B", dest_branch_name], cwd=dest_repo)
+            result.dest_branch = dest_branch_name
+
         imported = 0
         imported_upstream_shas: list[str] = []
         for sha in shas:
@@ -734,41 +791,46 @@ def sync_one(source: Source, state: dict, dest_repo: Path, dry_run: bool) -> Sou
         # pure rename OUT of src_path — tracked by log but producing no
         # patch for `git am`), we still bump `last_sha` so we don't
         # rescan the same range next run.
-        state["sources"].setdefault(source.state_key, {}).update(
-            {
-                "last_sha": new_last_sha,
-                "url": source.url,
-                "branch": source.branch,
-                "src_path": source.src_path,
-                "dest_path": source.dest_path,
-            }
-        )
-        save_state(state)
-        # Commit the state bump (on top of the imported commits, or as its
-        # own commit if nothing was imported). Use a simple identity-signed
-        # sync commit.
-        run(["git", "add", str(STATE_FILE.relative_to(REPO_ROOT))], cwd=dest_repo)
-        if run_ok(["git", "diff", "--cached", "--quiet"], cwd=dest_repo):
-            # no state change (first-run identical) -- nothing to commit
-            pass
-        else:
-            msg = (
-                f"[{source.name}] chore(sync): advance state to {new_last_sha[:12]}\n\n"
-                f"Source-Repo: {source.url}\n"
-                f"Source-Branch: {source.branch}\n"
-                f"Source-Commit: {new_last_sha}\n"
-                f"Signed-off-by: {SYNC_BOT_NAME} <{SYNC_BOT_EMAIL}>\n"
+        #
+        # Only persisted in push-mode: in pr-mode the hub repo owns the
+        # canonical sync state and this run is proposing a one-off PR into
+        # another repo that must NOT carry the hub's state.json.
+        if mode == MODE_PUSH:
+            state["sources"].setdefault(source.state_key, {}).update(
+                {
+                    "last_sha": new_last_sha,
+                    "url": source.url,
+                    "branch": source.branch,
+                    "src_path": source.src_path,
+                    "dest_path": source.dest_path,
+                }
             )
-            run(
-                ["git", "commit", "-m", msg],
-                cwd=dest_repo,
-                env={
-                    "GIT_COMMITTER_NAME": SYNC_BOT_NAME,
-                    "GIT_COMMITTER_EMAIL": SYNC_BOT_EMAIL,
-                    "GIT_AUTHOR_NAME": SYNC_BOT_NAME,
-                    "GIT_AUTHOR_EMAIL": SYNC_BOT_EMAIL,
-                },
-            )
+            save_state(state)
+            # Commit the state bump (on top of the imported commits, or as its
+            # own commit if nothing was imported). Use a simple identity-signed
+            # sync commit.
+            run(["git", "add", str(STATE_FILE.relative_to(REPO_ROOT))], cwd=dest_repo)
+            if run_ok(["git", "diff", "--cached", "--quiet"], cwd=dest_repo):
+                # no state change (first-run identical) -- nothing to commit
+                pass
+            else:
+                msg = (
+                    f"[{source.name}] chore(sync): advance state to {new_last_sha[:12]}\n\n"
+                    f"Source-Repo: {source.url}\n"
+                    f"Source-Branch: {source.branch}\n"
+                    f"Source-Commit: {new_last_sha}\n"
+                    f"Signed-off-by: {SYNC_BOT_NAME} <{SYNC_BOT_EMAIL}>\n"
+                )
+                run(
+                    ["git", "commit", "-m", msg],
+                    cwd=dest_repo,
+                    env={
+                        "GIT_COMMITTER_NAME": SYNC_BOT_NAME,
+                        "GIT_COMMITTER_EMAIL": SYNC_BOT_EMAIL,
+                        "GIT_AUTHOR_NAME": SYNC_BOT_NAME,
+                        "GIT_AUTHOR_EMAIL": SYNC_BOT_EMAIL,
+                    },
+                )
 
         result.status = "synced" if imported > 0 else "up-to-date"
         result.commits_imported = imported
@@ -788,8 +850,24 @@ def sync_one(source: Source, state: dict, dest_repo: Path, dry_run: bool) -> Sou
         result.status = "failed"
         result.message = str(e)
         result.errors.append(str(e))
+        # On failure in pr-mode, the per-source branch now points at the
+        # unchanged base (pre_head) so there's nothing to propose; clear
+        # dest_branch so the workflow doesn't try to open an empty PR.
+        result.dest_branch = ""
         log(f"{source.name}: FAILED -> {e}")
         return result
+    finally:
+        # In pr-mode, always return dest_repo to the branch we were on
+        # before this source ran, so the NEXT source forks its own
+        # `skills-sync/<name>` branch off the same clean base (the
+        # workflow-checked-out branch). The per-source branches we created
+        # remain intact; the workflow reads result.dest_branch to push them.
+        if mode == MODE_PR and original_branch:
+            run(
+                ["git", "checkout", original_branch],
+                cwd=dest_repo,
+                check=False,
+            )
 
 
 # ---------- github failure reporter ----------
@@ -1363,6 +1441,28 @@ def main() -> int:
     )
     ap.add_argument("--only", type=str, default=None, help="sync only this source name")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--mode",
+        choices=list(ALL_MODES),
+        default=MODE_PUSH,
+        help=(
+            "push (default): commit imports on the current branch and "
+            "update state.json. pr: isolate each source on a "
+            "`skills-sync/<name>` branch, skip state.json writes, and "
+            "let the workflow open/update a PR per source."
+        ),
+    )
+    ap.add_argument(
+        "--results-json",
+        type=Path,
+        default=None,
+        help=(
+            "If set, write a structured JSON summary of per-source results "
+            "to this path. Workflow (mode=pr) reads this to iterate sources "
+            "and open/update a PR per skills-sync/<name> branch. Fields: "
+            "name, status, commits_imported, new_head, dest_branch, message."
+        ),
+    )
     args = ap.parse_args()
 
     sources_dir: Path = args.sources_dir
@@ -1389,10 +1489,11 @@ def main() -> int:
     results: list[SourceResult] = []
     for s in sources:
         log(f"--- syncing: {s.name} ({s.src_path} -> {s.dest_path}) ---")
-        results.append(sync_one(s, state, REPO_ROOT, args.dry_run))
+        results.append(sync_one(s, state, REPO_ROOT, args.dry_run, mode=args.mode))
 
     # Persist state one more time at the end (covers the no-op branches).
-    if not args.dry_run:
+    # Only relevant in push-mode; pr-mode never writes state.json.
+    if not args.dry_run and args.mode == MODE_PUSH:
         save_state(state)
 
     # Summary
@@ -1400,15 +1501,42 @@ def main() -> int:
     log("=== SUMMARY ===")
     exit_code = 0
     for r in results:
-        line = f"  {r.source.name:40s}  {r.status:12s}  {r.message}"
+        branch_suffix = f"  [branch={r.dest_branch}]" if r.dest_branch else ""
+        line = f"  {r.source.name:40s}  {r.status:12s}  {r.message}{branch_suffix}"
         log(line)
         if r.status == "failed":
             exit_code = 1
 
+    # Structured results dump for downstream workflow steps (pr-mode uses
+    # this to iterate sources and open/update one PR per synced branch).
+    # Written unconditionally when --results-json is set so dry-run and
+    # push-mode consumers can also introspect outcomes.
+    if args.results_json is not None:
+        payload = [
+            {
+                "name": r.source.name,
+                "status": r.status,
+                "commits_imported": r.commits_imported,
+                "new_head": r.new_head,
+                "dest_branch": r.dest_branch,
+                "message": r.message,
+                "src_path": r.source.src_path,
+                "dest_path": r.source.dest_path,
+                "url": r.source.url,
+            }
+            for r in results
+        ]
+        args.results_json.parent.mkdir(parents=True, exist_ok=True)
+        args.results_json.write_text(json.dumps(payload, indent=2, sort_keys=True))
+        log(f"wrote {len(payload)} result(s) to {args.results_json}")
+
     # Open/update/close GitHub issues based on results. Best-effort:
     # never affects exit code, silently skips in non-GitHub contexts.
     # Disabled under --dry-run so local rehearsals don't touch the tracker.
-    if not args.dry_run:
+    # Also disabled in pr-mode: the proposing repo shouldn't spam the target
+    # repo's issue tracker with sync-failure issues — the workflow surfaces
+    # failures via job status instead.
+    if not args.dry_run and args.mode == MODE_PUSH:
         # Signal to the reporter that this run processed every configured
         # source, so it's safe to close issues for sources no longer in
         # the config. Under --only we processed a subset, so skip that sweep.

--- a/sync-bot/src/skills_sync/main.py
+++ b/sync-bot/src/skills_sync/main.py
@@ -1,0 +1,1426 @@
+#!/usr/bin/env python3
+"""
+Skill sync — import skill subdirectories from upstream repos into this one.
+
+How it works
+------------
+For each source file in sync/sources/*.yaml:
+
+  1. Shallow-ish fetch of the upstream repo into a cache dir under
+     .sync-cache/<name> (persistent across runs for speed).
+  2. Read the last-synced upstream commit SHA from sync/state.json for
+     the (name, src_path, dest_path) tuple.
+  3. Enumerate new upstream commits that touched `src_path`:
+         git log --reverse <last>..<upstream_head> -- <src_path>
+     First-ever run imports upstream history from the repo-root commit.
+  4. For each such commit:
+         a. git format-patch -1 --relative=<src_path> <sha>
+            -> one patch with paths relative to src_path
+         b. git am --directory=<dest_path> --keep-cr --committer-date-is-author-date
+            -> applies under dest_path in this repo with ORIGINAL author preserved
+         c. git commit --amend to append provenance trailers:
+                 Source-Repo: <upstream url>
+                 Source-Commit: <upstream sha>
+                 Co-authored-by: <original author>      (already there via author field;
+                                                         added explicitly so squashes keep it)
+            and a Signed-off-by for the sync bot (committer).
+  5. Update state.json with the new head SHA and commit it.
+
+Push is handled by the caller (GitHub Actions workflow). This script only
+modifies the working tree + index of the CURRENT repo via commits on HEAD.
+
+Failure isolation
+-----------------
+Each source is wrapped in its own try/except. A failure during one source
+resets that source's working tree (git am --abort, hard reset to the
+pre-sync HEAD) and is recorded in the summary; other sources still run.
+Exit code is nonzero iff at least one source failed.
+
+Usage
+-----
+  uv run python sync/sync.py                          # sync all sources
+  uv run python sync/sync.py --only NAME              # sync a single source
+  uv run python sync/sync.py --dry-run                # show what would change
+  uv run python sync/sync.py --sources-dir path/      # custom sources dir
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import yaml  # type: ignore
+
+def _resolve_repo_root() -> Path:
+    """
+    Resolve the destination repo root.
+
+    Priority:
+      1. SYNC_REPO_ROOT env var (absolute path) — used by tests and for
+         out-of-tree invocations.
+      2. `git rev-parse --show-toplevel` from the current working directory —
+         matches how CI and local devs actually invoke the tool.
+      3. Fallback: the current working directory.
+
+    We intentionally do NOT derive the root from __file__ anymore: the sync
+    code lives in an installable package (sync-bot/) that may be installed
+    system-wide, while the data it manages (sync/state.json, sync/sources/)
+    still lives at the checkout root.
+    """
+    env_root = os.environ.get("SYNC_REPO_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if out:
+            return Path(out).resolve()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    return Path.cwd().resolve()
+
+
+REPO_ROOT = _resolve_repo_root()
+CACHE_DIR = REPO_ROOT / ".sync-cache"
+STATE_FILE = REPO_ROOT / "sync" / "state.json"
+DEFAULT_SOURCES_DIR = REPO_ROOT / "sync" / "sources"
+
+# Default identity: opensearch-ci-bot (GitHub user id 83309141, display name
+# "opensearch-ci"). The noreply `<id>+<login>@users.noreply.github.com` form
+# makes GitHub auto-resolve the commit author to that profile, so every sync
+# commit renders with the opensearch-ci-bot avatar + clickable profile link
+# on github.com — without needing to register a GitHub App or hold a PAT for
+# that account. Override via SYNC_BOT_NAME / SYNC_BOT_EMAIL env for local runs.
+SYNC_BOT_NAME = os.environ.get("SYNC_BOT_NAME", "opensearch-ci")
+SYNC_BOT_EMAIL = os.environ.get(
+    "SYNC_BOT_EMAIL", "83309141+opensearch-ci-bot@users.noreply.github.com"
+)
+
+
+# ---------- helpers ----------
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    capture: bool = True,
+    env: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command, streaming or capturing output."""
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        check=check,
+        text=True,
+        capture_output=capture,
+        env=full_env,
+        input=input_text,
+    )
+
+
+def run_ok(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> bool:
+    """Run a command; return True on exit 0."""
+    r = run(cmd, cwd=cwd, check=False, env=env)
+    return r.returncode == 0
+
+
+def log(msg: str) -> None:
+    print(f"[sync] {msg}", flush=True)
+
+
+def ensure_git_identity(repo: Path) -> None:
+    """Set the committer identity for the destination repo."""
+    run(["git", "config", "user.name", SYNC_BOT_NAME], cwd=repo)
+    run(["git", "config", "user.email", SYNC_BOT_EMAIL], cwd=repo)
+
+
+def prefix_subject(message: str, source_name: str) -> str:
+    """
+    Return `message` with an LLVM-style `[source_name] ` prefix on the
+    subject line, unless it already starts with that exact prefix
+    (making re-runs idempotent).
+
+    Only the subject (first line) is rewritten; body + trailers are left
+    intact. An empty message is returned as-is — `git am` already rejects
+    those upstream.
+    """
+    if not message:
+        return message
+    prefix = f"[{source_name}] "
+    newline, _, rest = message.partition("\n")
+    subject = newline
+    if subject.startswith(prefix):
+        return message
+    new_subject = prefix + subject
+    if rest == "" and "\n" not in message:
+        return new_subject
+    return new_subject + "\n" + rest
+
+
+# ---------- data model ----------
+
+@dataclass
+class Source:
+    name: str
+    url: str
+    branch: str = "main"
+    src_path: str = ""
+    dest_path: str = ""
+    # When True (default), collapse all imported commits for THIS source in
+    # a single sync run into one squashed commit on dest. Per-source: other
+    # sources in the same run are squashed independently. All original
+    # authors are retained as Co-authored-by trailers on the squashed commit
+    # so attribution survives on GitHub. Set to False to preserve one-to-one
+    # per-commit history (previous behaviour).
+    squash: bool = True
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Source":
+        missing = [k for k in ("name", "url", "src_path", "dest_path") if not d.get(k)]
+        if missing:
+            raise ValueError(f"source entry missing fields: {missing}: {d}")
+        squash_raw = d.get("squash", True)
+        # Accept bools and common string forms; anything else is a config error.
+        if isinstance(squash_raw, bool):
+            squash = squash_raw
+        elif isinstance(squash_raw, str) and squash_raw.lower() in (
+            "true", "false", "yes", "no", "1", "0",
+        ):
+            squash = squash_raw.lower() in ("true", "yes", "1")
+        else:
+            raise ValueError(
+                f"source {d.get('name')!r} has invalid `squash` value: {squash_raw!r}"
+            )
+        return cls(
+            name=d["name"],
+            url=d["url"],
+            branch=d.get("branch", "main"),
+            src_path=d["src_path"].strip("/"),
+            dest_path=d["dest_path"].strip("/"),
+            squash=squash,
+        )
+
+    @property
+    def state_key(self) -> str:
+        return f"{self.name}::{self.src_path}->{self.dest_path}"
+
+
+@dataclass
+class SourceResult:
+    source: Source
+    status: str  # "synced" | "up-to-date" | "failed" | "skipped"
+    commits_imported: int = 0
+    new_head: str = ""
+    message: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------- state ----------
+
+def load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {"version": 1, "sources": {}}
+    with STATE_FILE.open() as f:
+        return json.load(f)
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with STATE_FILE.open("w") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+# ---------- upstream cache ----------
+
+def upstream_cache(source: Source) -> Path:
+    # Use a name that's filesystem-safe
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", source.name)
+    return CACHE_DIR / safe
+
+
+def fetch_upstream(source: Source) -> tuple[Path, str]:
+    """
+    Clone or update the upstream repo in the cache.
+
+    Returns (path-to-cache, head-SHA-of-branch).
+    """
+    cache = upstream_cache(source)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+
+    if not (cache / ".git").exists():
+        log(f"{source.name}: initial clone from {source.url} (branch {source.branch})")
+        # Full clone (not --depth 1) because we may need history beyond the
+        # last-synced SHA on a first run. filter=blob:none keeps it light.
+        run(
+            [
+                "git",
+                "clone",
+                "--filter=blob:none",
+                "--no-checkout",
+                "--branch",
+                source.branch,
+                source.url,
+                str(cache),
+            ]
+        )
+    else:
+        log(f"{source.name}: fetching updates")
+        # Ensure the origin URL is up to date in case config changed
+        run(["git", "remote", "set-url", "origin", source.url], cwd=cache)
+        run(
+            [
+                "git",
+                "fetch",
+                "--filter=blob:none",
+                "origin",
+                f"{source.branch}:refs/remotes/origin/{source.branch}",
+            ],
+            cwd=cache,
+        )
+
+    head = run(
+        ["git", "rev-parse", f"refs/remotes/origin/{source.branch}"], cwd=cache
+    ).stdout.strip()
+    return cache, head
+
+
+# ---------- core sync ----------
+
+def commits_touching_path(
+    cache: Path, src_path: str, since_sha: str | None, head_sha: str
+) -> list[str]:
+    """Return the list of commit SHAs (oldest first) that touched src_path."""
+    rng = f"{since_sha}..{head_sha}" if since_sha else head_sha
+    args = [
+        "git",
+        "log",
+        "--reverse",
+        "--no-merges",
+        "--format=%H",
+        rng,
+        "--",
+        src_path,
+    ]
+    r = run(args, cwd=cache)
+    return [line.strip() for line in r.stdout.splitlines() if line.strip()]
+
+
+def import_commit(
+    cache: Path,
+    dest_repo: Path,
+    source: Source,
+    sha: str,
+) -> str | None:
+    """
+    Import a single upstream commit into dest_repo under dest_path.
+
+    Returns the new destination-commit SHA, or None if the patch produced
+    no changes (e.g. a commit that only renamed files OUT of src_path).
+    """
+    # Get original metadata
+    show = run(
+        [
+            "git",
+            "show",
+            "--no-patch",
+            "--format=%H%x00%an%x00%ae%x00%aI%x00%cn%x00%ce%x00%cI%x00%B",
+            sha,
+        ],
+        cwd=cache,
+    ).stdout
+    parts = show.split("\x00", 7)
+    if len(parts) < 8:
+        raise RuntimeError(f"unexpected git show output for {sha}: {show!r}")
+    _h, an, ae, adate, _cn, _ce, _cdate, body = parts
+    orig_message = body.rstrip("\n")
+    short = sha[:12]
+
+    # Produce a patch rooted at src_path, then feed to `git am --directory=dest_path`.
+    with tempfile.TemporaryDirectory(prefix=f"sync-patch-{short}-") as tmp:
+        tmp_dir = Path(tmp)
+        patch_args = [
+            "git",
+            "format-patch",
+            "-1",
+            "--stdout",
+            # Keep binary patches working
+            "--binary",
+            # Paths in the patch become relative to src_path; empty src_path
+            # means "repo root", handled naturally by not passing --relative.
+        ]
+        if source.src_path:
+            patch_args.append(f"--relative={source.src_path}")
+        patch_args.append(sha)
+
+        patch = run(patch_args, cwd=cache).stdout
+        if not patch.strip():
+            return None
+
+        patch_file = tmp_dir / f"{short}.patch"
+        patch_file.write_text(patch)
+
+        # Apply. Use --keep-non-patch and --keep-cr for robustness.
+        am_env = {
+            "GIT_COMMITTER_NAME": SYNC_BOT_NAME,
+            "GIT_COMMITTER_EMAIL": SYNC_BOT_EMAIL,
+        }
+        am_args = [
+            "git",
+            "am",
+            "--keep-cr",
+            "--keep-non-patch",
+            "--committer-date-is-author-date",
+            f"--directory={source.dest_path}" if source.dest_path else "",
+            str(patch_file),
+        ]
+        am_args = [a for a in am_args if a]
+        r = run(am_args, cwd=dest_repo, check=False, env=am_env)
+
+        if r.returncode != 0:
+            # Detect "empty patch" failures (commit touched src_path only via
+            # mode changes, or the whole patch cancels under relative path).
+            combined = (r.stdout or "") + (r.stderr or "")
+            if "Patch is empty" in combined or "patch does not apply" in combined:
+                run(["git", "am", "--abort"], cwd=dest_repo, check=False)
+                return None
+            run(["git", "am", "--abort"], cwd=dest_repo, check=False)
+            raise RuntimeError(
+                f"git am failed for {source.name} commit {sha}:\n{combined}"
+            )
+
+    # Amend to append provenance trailers without touching tree.
+    new_sha = run(["git", "rev-parse", "HEAD"], cwd=dest_repo).stdout.strip()
+    trailers = [
+        f"Source-Repo: {source.url}",
+        f"Source-Commit: {sha}",
+        # Author is already preserved by `git am`, but a Co-authored-by
+        # trailer makes the attribution survive squash-merges and shows
+        # the original author on the GitHub contributor graph for this repo.
+        f"Co-authored-by: {an} <{ae}>",
+        f"Signed-off-by: {SYNC_BOT_NAME} <{SYNC_BOT_EMAIL}>",
+    ]
+    # Use `git interpret-trailers --if-exists addIfDifferent` so re-runs are idempotent.
+    new_message_proc = run(
+        [
+            "git",
+            "interpret-trailers",
+            "--if-exists",
+            "addIfDifferent",
+            "--trailer",
+            trailers[0],
+            "--trailer",
+            trailers[1],
+            "--trailer",
+            trailers[2],
+            "--trailer",
+            trailers[3],
+        ],
+        cwd=dest_repo,
+        input_text=prefix_subject(orig_message, source.name) + "\n",
+    )
+    new_message = new_message_proc.stdout
+
+    run(
+        ["git", "commit", "--amend", "-m", new_message, "--no-edit",
+         # keep author as set by `git am`
+         ],
+        cwd=dest_repo,
+        env={
+            "GIT_COMMITTER_NAME": SYNC_BOT_NAME,
+            "GIT_COMMITTER_EMAIL": SYNC_BOT_EMAIL,
+        },
+    )
+    return run(["git", "rev-parse", "HEAD"], cwd=dest_repo).stdout.strip()
+
+
+# ---------- skill spec validation ----------
+#
+# After a source's commits have been imported, we run the Agent Skills Spec
+# validator (github.com/agentskills/agentskills, Apache-2.0) against every
+# SKILL.md under the source's dest_path. Any spec violation -- wrong YAML
+# shape, illegal top-level field, name mismatch, missing required field --
+# aborts the whole source import. The existing sync_one except block then
+# hard-resets to pre_head and the issue reporter files a failure issue,
+# so callers see the same visibility as any other sync failure.
+#
+# We validate the WHOLE dest tree, not just the individual files each
+# commit touched. A commit that didn't touch SKILL.md can still invalidate
+# an existing skill (e.g. renaming the directory without updating `name`),
+# and re-validating the whole tree on every successful import gives us a
+# cheap invariant: "if sync succeeded, every skill under dest_path is
+# spec-valid at HEAD." That's what downstream consumers actually care about.
+
+def validate_skill_tree(tree_root: Path) -> dict[Path, list[str]]:
+    """Validate every skill under `tree_root` against the Agent Skills Spec.
+
+    Returns a mapping of skill_dir -> list[error_msg] for skills that failed
+    validation. Empty dict means everything under this tree is spec-valid.
+
+    A "skill" is any directory that contains a SKILL.md file. The parent
+    of each SKILL.md is passed to skills_ref.validator.validate(), which
+    checks frontmatter fields, name<->directory match, YAML block style,
+    allowed fields, length limits, etc.
+    """
+    # Import lazily: keeps the top-of-file import block lean and means a
+    # missing skills-ref install (e.g. someone running an old checkout
+    # without `uv sync`) surfaces a clear error only if we actually try
+    # to validate, not at module load time.
+    from skills_ref.validator import validate as sr_validate
+
+    failures: dict[Path, list[str]] = {}
+    if not tree_root.exists():
+        # No skills imported yet (e.g. first run against an empty upstream).
+        # Nothing to validate -- that's not an error.
+        return failures
+    for skill_md in sorted(tree_root.rglob("SKILL.md")):
+        skill_dir = skill_md.parent
+        errors = sr_validate(skill_dir)
+        if errors:
+            failures[skill_dir] = errors
+    return failures
+
+
+def format_validation_failures(
+    tree_root: Path, failures: dict[Path, list[str]]
+) -> str:
+    """Render validation failures as a human-readable block for issue bodies."""
+    lines = [
+        f"Agent Skills Spec validation failed for {len(failures)} skill(s) "
+        f"under `{tree_root}`:",
+        "",
+    ]
+    for skill_dir, errors in sorted(failures.items()):
+        rel = skill_dir.relative_to(REPO_ROOT) if skill_dir.is_absolute() else skill_dir
+        lines.append(f"- `{rel}/SKILL.md`")
+        for err in errors:
+            lines.append(f"    - {err}")
+    lines += [
+        "",
+        "Fix the SKILL.md files in the upstream repo so they comply with the "
+        "spec at https://agentskills.io. Imports for this source are rolled "
+        "back; the next sync run after the upstream is fixed will retry.",
+    ]
+    return "\n".join(lines)
+
+
+def squash_imported_commits(
+    dest_repo: Path, source: Source, pre_head: str, imported_shas: list[str]
+) -> str:
+    """
+    Collapse the per-commit imports on top of `pre_head` into a single
+    commit for THIS source. Called only when `source.squash` is True and
+    at least one commit was imported.
+
+    Design:
+      - `git reset --soft pre_head` rewinds HEAD, keeping the aggregate
+        tree + index from all imports. Equivalent to an all-at-once
+        `git am` of the combined diff.
+      - The new commit's message lists every imported upstream commit,
+        accumulates all original authors as de-duplicated Co-authored-by
+        trailers, and records provenance for the newest upstream commit.
+      - Author of the squashed commit is the sync bot (there is no single
+        upstream author for a multi-commit squash). Individual authors
+        remain visible via Co-authored-by, which is exactly how GitHub
+        attributes squash-merges on the contributor graph.
+      - Only commits between `pre_head..HEAD` are squashed. Other sources
+        that ran earlier in the same workflow are untouched (their commits
+        are older than this source's `pre_head`).
+
+    Returns the new HEAD sha after squashing.
+    """
+    # Enumerate the imported commits on dest (not the upstream shas) so we
+    # can read the finalised trailers/authors that import_commit produced.
+    dest_shas = run(
+        ["git", "rev-list", "--reverse", f"{pre_head}..HEAD"],
+        cwd=dest_repo,
+    ).stdout.split()
+    if not dest_shas:
+        # Nothing to squash — caller guarded against this but be safe.
+        return pre_head
+
+    # Collect authors + subjects per imported commit for the message body.
+    entries: list[tuple[str, str, str, str]] = []  # (short, subject, an, ae)
+    for dsha in dest_shas:
+        meta = run(
+            ["git", "show", "--no-patch", "--format=%h%x00%s%x00%an%x00%ae", dsha],
+            cwd=dest_repo,
+        ).stdout.rstrip("\n")
+        parts = meta.split("\x00", 3)
+        if len(parts) < 4:
+            raise RuntimeError(f"unexpected git show output during squash: {meta!r}")
+        entries.append((parts[0], parts[1], parts[2], parts[3]))
+
+    # Soft-reset to collapse all imports into a single staged change.
+    run(["git", "reset", "--soft", pre_head], cwd=dest_repo)
+
+    # Compose the squashed message.
+    newest_upstream = imported_shas[-1]
+    oldest_upstream = imported_shas[0]
+    n = len(imported_shas)
+    if n == 1:
+        subject = f"[{source.name}] sync: import upstream {newest_upstream[:12]}"
+    else:
+        subject = (
+            f"[{source.name}] sync: import {n} upstream commits "
+            f"({oldest_upstream[:12]}..{newest_upstream[:12]})"
+        )
+
+    body_lines: list[str] = [""]
+    body_lines.append(f"Squashed {n} upstream commit(s) touching {source.src_path!r}:")
+    body_lines.append("")
+    for _dsh, subj, _an, _ae in entries:
+        body_lines.append(f"  - {subj}")
+    body_lines.append("")
+
+    # De-dupe authors preserving order-of-first-appearance.
+    seen: set[tuple[str, str]] = set()
+    co_authors: list[tuple[str, str]] = []
+    for _dsh, _subj, an, ae in entries:
+        key = (an, ae.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        co_authors.append((an, ae))
+
+    # Build trailers: provenance (newest commit pins state) + per-author
+    # Co-authored-by + bot sign-off. `git interpret-trailers` handles the
+    # canonical trailer-block formatting.
+    trailer_args: list[str] = []
+    trailer_args += ["--trailer", f"Source-Repo: {source.url}"]
+    trailer_args += ["--trailer", f"Source-Branch: {source.branch}"]
+    trailer_args += ["--trailer", f"Source-Commit: {newest_upstream}"]
+    for an, ae in co_authors:
+        trailer_args += ["--trailer", f"Co-authored-by: {an} <{ae}>"]
+    trailer_args += [
+        "--trailer",
+        f"Signed-off-by: {SYNC_BOT_NAME} <{SYNC_BOT_EMAIL}>",
+    ]
+
+    message_pre = subject + "\n" + "\n".join(body_lines)
+    message_proc = run(
+        ["git", "interpret-trailers", "--if-exists", "addIfDifferent", *trailer_args],
+        cwd=dest_repo,
+        input_text=message_pre if message_pre.endswith("\n") else message_pre + "\n",
+    )
+    message = message_proc.stdout
+
+    # Commit the squashed tree. Author = sync bot; per-author attribution
+    # lives in Co-authored-by trailers.
+    run(
+        ["git", "commit", "-m", message, "--allow-empty"],
+        cwd=dest_repo,
+        env={
+            "GIT_COMMITTER_NAME": SYNC_BOT_NAME,
+            "GIT_COMMITTER_EMAIL": SYNC_BOT_EMAIL,
+            "GIT_AUTHOR_NAME": SYNC_BOT_NAME,
+            "GIT_AUTHOR_EMAIL": SYNC_BOT_EMAIL,
+        },
+    )
+    return run(["git", "rev-parse", "HEAD"], cwd=dest_repo).stdout.strip()
+
+
+def sync_one(source: Source, state: dict, dest_repo: Path, dry_run: bool) -> SourceResult:
+    result = SourceResult(source=source, status="up-to-date")
+    try:
+        cache, head_sha = fetch_upstream(source)
+        last = state["sources"].get(source.state_key, {}).get("last_sha")
+
+        # `last_sha` semantics: the newest upstream commit that actually
+        # touched `src_path` and has been imported into this repo. It is
+        # NOT the upstream branch tip — we deliberately ignore upstream
+        # commits that don't touch the tracked path so state.json stays
+        # idempotent across unrelated upstream churn (no state-only
+        # commits every time an unrelated file changes upstream).
+        #
+        # `head_sha` is only used as the end-anchor of the path-filtered
+        # log range; we never persist it.
+        shas = commits_touching_path(cache, source.src_path, last, head_sha)
+        if not shas:
+            # No commits in `last..head` touched our src_path. Nothing to
+            # import, nothing to persist. Next run will re-scan the same
+            # (cheap, path-filtered) range and also no-op until upstream
+            # actually modifies src_path again.
+            result.status = "up-to-date"
+            result.message = (
+                f"no commits touched {source.src_path} since "
+                f"{(last or 'INIT')[:12]} (upstream tip {head_sha[:12]})"
+            )
+            return result
+
+        # New last_sha = newest commit that touched src_path. That's the
+        # tail of the --reverse log (== shas[-1]).
+        new_last_sha = shas[-1]
+
+        log(
+            f"{source.name}: {len(shas)} upstream commit(s) to import "
+            f"(from {(last or 'INIT')[:12]} to {new_last_sha[:12]}; "
+            f"upstream tip {head_sha[:12]})"
+        )
+        if dry_run:
+            for sha in shas:
+                subj = run(
+                    ["git", "log", "-1", "--format=%s", sha], cwd=cache
+                ).stdout.strip()
+                log(f"  would import {sha[:12]}  {subj}")
+            result.status = "synced"
+            result.commits_imported = len(shas)
+            result.new_head = new_last_sha
+            return result
+
+        ensure_git_identity(dest_repo)
+        pre_head = run(["git", "rev-parse", "HEAD"], cwd=dest_repo).stdout.strip()
+
+        imported = 0
+        imported_upstream_shas: list[str] = []
+        for sha in shas:
+            new_sha = import_commit(cache, dest_repo, source, sha)
+            if new_sha is None:
+                log(f"  skipped (empty under relative path): {sha[:12]}")
+                continue
+            imported += 1
+            imported_upstream_shas.append(sha)
+            log(f"  imported {sha[:12]} -> {new_sha[:12]}")
+
+        # Validate the post-import dest tree against the Agent Skills Spec.
+        # Any spec violation raises, which the outer `except` turns into a
+        # hard reset to pre_head + a failure result -> issue opened.
+        # We do this BEFORE bumping state.json so a failed validation also
+        # leaves last_sha unchanged, so the next run retries the same range
+        # rather than silently skipping past a broken commit.
+        dest_tree = dest_repo / source.dest_path
+        validation_failures = validate_skill_tree(dest_tree)
+        if validation_failures:
+            raise RuntimeError(
+                format_validation_failures(dest_tree, validation_failures)
+            )
+
+        # Optional per-source squash. Runs AFTER validation so a failed
+        # validation still triggers the outer reset-to-pre_head and leaves
+        # state.last_sha pinned — behaviour is unchanged from the
+        # non-squash path on failure. On success, we collapse only THIS
+        # source's imports (pre_head..HEAD) into a single commit; other
+        # sources processed earlier in the same run are untouched because
+        # their commits sit below pre_head.
+        if source.squash and imported > 0:
+            squash_imported_commits(
+                dest_repo, source, pre_head, imported_upstream_shas
+            )
+            log(
+                f"  squashed {imported} import commit(s) into one "
+                f"[{source.name}] commit"
+            )
+
+        # Advance state to the newest path-touching commit. If every
+        # imported commit came out empty under the relative path (e.g. a
+        # pure rename OUT of src_path — tracked by log but producing no
+        # patch for `git am`), we still bump `last_sha` so we don't
+        # rescan the same range next run.
+        state["sources"].setdefault(source.state_key, {}).update(
+            {
+                "last_sha": new_last_sha,
+                "url": source.url,
+                "branch": source.branch,
+                "src_path": source.src_path,
+                "dest_path": source.dest_path,
+            }
+        )
+        save_state(state)
+        # Commit the state bump (on top of the imported commits, or as its
+        # own commit if nothing was imported). Use a simple identity-signed
+        # sync commit.
+        run(["git", "add", str(STATE_FILE.relative_to(REPO_ROOT))], cwd=dest_repo)
+        if run_ok(["git", "diff", "--cached", "--quiet"], cwd=dest_repo):
+            # no state change (first-run identical) -- nothing to commit
+            pass
+        else:
+            msg = (
+                f"[{source.name}] chore(sync): advance state to {new_last_sha[:12]}\n\n"
+                f"Source-Repo: {source.url}\n"
+                f"Source-Branch: {source.branch}\n"
+                f"Source-Commit: {new_last_sha}\n"
+                f"Signed-off-by: {SYNC_BOT_NAME} <{SYNC_BOT_EMAIL}>\n"
+            )
+            run(
+                ["git", "commit", "-m", msg],
+                cwd=dest_repo,
+                env={
+                    "GIT_COMMITTER_NAME": SYNC_BOT_NAME,
+                    "GIT_COMMITTER_EMAIL": SYNC_BOT_EMAIL,
+                    "GIT_AUTHOR_NAME": SYNC_BOT_NAME,
+                    "GIT_AUTHOR_EMAIL": SYNC_BOT_EMAIL,
+                },
+            )
+
+        result.status = "synced" if imported > 0 else "up-to-date"
+        result.commits_imported = imported
+        result.new_head = new_last_sha
+        result.message = (
+            f"imported {imported}/{len(shas)} commits "
+            f"(tracked-path tip now {new_last_sha[:12]}, "
+            f"upstream tip {head_sha[:12]})"
+        )
+        return result
+    except Exception as e:  # noqa: BLE001
+        # Abort any in-progress am, hard reset to pre-sync HEAD to keep
+        # other sources unaffected.
+        run(["git", "am", "--abort"], cwd=dest_repo, check=False)
+        if "pre_head" in locals():
+            run(["git", "reset", "--hard", pre_head], cwd=dest_repo, check=False)
+        result.status = "failed"
+        result.message = str(e)
+        result.errors.append(str(e))
+        log(f"{source.name}: FAILED -> {e}")
+        return result
+
+
+# ---------- github failure reporter ----------
+#
+# On failure we surface the failure somewhere a human will see it, but we
+# pick the reporting channel based on where the run happened:
+#
+#   * Default branch (scheduled / dispatch on main): open/update a GitHub
+#     issue in the destination repo. Issues are persistent, labelled, and
+#     de-duped — perfect for cron failures nobody is watching.
+#
+#   * Non-default branch (dispatch on a feature branch): if an open PR
+#     exists for that branch, post a comment on the PR. Otherwise stay
+#     silent and rely on the failed workflow run itself as the signal.
+#     We explicitly avoid opening issues for PR-branch runs because they
+#     would clutter the tracker with transient failures that belong to an
+#     in-flight change.
+#
+# Issue-flow design (default branch):
+#
+#   - Primary dedupe key is the pair of labels (sync-failure, sync-source:<name>).
+#     A single open issue per failing source. Multiple source failures ->
+#     multiple issues. An issue is auto-created the first time a source
+#     fails and stays open across subsequent failures of the same source.
+#
+#   - The current error hash is stored in the issue body as an HTML comment
+#     marker. On re-failure with the SAME error, we stay quiet (no new
+#     comment) — the open issue itself is the signal. On re-failure with a
+#     DIFFERENT error, we post a comment with the new error details and
+#     update the marker. Prevents spam when a source is stuck in the same
+#     mode, still surfaces meaningfully changed failures.
+#
+#   - When a previously-failing source comes back up-to-date or syncs
+#     successfully, we close all matching open issues with a comment.
+#
+# PR-comment flow (non-default branch):
+#
+#   - Find the open PR whose HEAD ref matches the current branch. If none,
+#     no-op (the failed action status is the signal).
+#   - Dedupe by the same <!-- sync-error-hash: ... --> marker embedded in
+#     bot comments on the PR. If the most recent sync-failure comment has
+#     the same hash as the current error, stay silent — the existing
+#     comment already describes this failure. Otherwise post a new comment.
+#   - On success/recovery we do NOT delete or resolve prior PR comments.
+#     They remain as a record of prior attempts; the green run is the
+#     recovery signal for PR authors.
+#
+#   - All network + gh calls are wrapped so issue-tracker failures never
+#     affect the sync exit code. If gh is unavailable or unauthenticated
+#     (e.g. local dev), the reporter logs a skip line and returns.
+#
+# We shell out to `gh` rather than hitting the REST API directly because
+# it's already on GitHub-hosted runners and handles auth from GITHUB_TOKEN
+# automatically via the GH_TOKEN env var set in the workflow.
+
+SYNC_FAILURE_LABEL = "sync-failure"
+SOURCE_LABEL_PREFIX = "sync-source:"
+ERROR_HASH_MARKER_RE = re.compile(r"<!-- sync-error-hash: ([0-9a-f]{12}) -->")
+
+
+def _gh_available(repo: str) -> bool:
+    """Check gh CLI is installed and authed for the target repo."""
+    if not shutil.which("gh"):
+        return False
+    # `gh auth status` exits 0 if authed. We pass --hostname to be explicit.
+    r = run(["gh", "auth", "status"], check=False)
+    if r.returncode != 0:
+        return False
+    # Verify we can talk to the repo (catches missing scope / wrong token).
+    r = run(["gh", "repo", "view", repo, "--json", "name"], check=False)
+    return r.returncode == 0
+
+
+def _error_hash(source_name: str, err: str) -> str:
+    """
+    Hash a normalized form of the error so that "same class of failure"
+    produces the same hash across runs. We strip volatile bits:
+      - absolute paths under /home, /tmp, /runner, /github (CI artifacts)
+      - 7-40 hex SHAs
+      - ISO-ish timestamps and epoch seconds
+      - line/column numbers in tracebacks
+    """
+    norm = err
+    norm = re.sub(r"/(home|tmp|runner|github|Users|var)/[^\s'\"]+", "<path>", norm)
+    norm = re.sub(r"\b[0-9a-f]{7,40}\b", "<sha>", norm)
+    norm = re.sub(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}[^ ]*", "<ts>", norm)
+    norm = re.sub(r'line \d+', "line <n>", norm)
+    h = hashlib.sha256(f"{source_name}\0{norm}".encode()).hexdigest()
+    return h[:12]
+
+
+def _find_open_issue(repo: str, source_name: str) -> dict | None:
+    """
+    Return the single open issue for this source, or None. If multiple are
+    open (shouldn't happen, but be defensive), return the newest.
+    """
+    label_args = [
+        "--label", SYNC_FAILURE_LABEL,
+        "--label", f"{SOURCE_LABEL_PREFIX}{source_name}",
+    ]
+    r = run(
+        ["gh", "issue", "list", "--repo", repo, "--state", "open",
+         *label_args, "--json", "number,title,body,updatedAt", "--limit", "10"],
+        check=False,
+    )
+    if r.returncode != 0:
+        log(f"issue-reporter: gh issue list failed: {r.stderr.strip()}")
+        return None
+    try:
+        issues = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not issues:
+        return None
+    # Newest first by updatedAt
+    issues.sort(key=lambda i: i.get("updatedAt", ""), reverse=True)
+    return issues[0]
+
+
+def _ensure_labels(repo: str, names: Iterable[str]) -> None:
+    """
+    Create any missing labels. `gh label create` is idempotent-ish — it
+    errors if the label exists, so we suppress that. Safe to call every run.
+    """
+    for name in names:
+        color = "B60205" if name == SYNC_FAILURE_LABEL else "D4C5F9"
+        run(
+            ["gh", "label", "create", name, "--repo", repo,
+             "--color", color, "--description", f"Auto-managed by sync/sync.py"],
+            check=False,
+        )
+
+
+def _format_issue_body(source: Source, err: str, err_hash: str, run_url: str | None) -> str:
+    # Keep the error payload bounded — very long tracebacks get truncated
+    # (still recorded in full in the Actions log).
+    MAX_ERR = 6000
+    err_trimmed = err if len(err) <= MAX_ERR else err[:MAX_ERR] + "\n…[truncated]"
+    lines = [
+        f"The skill-sync job failed while mirroring `{source.name}`.",
+        "",
+        f"- **Upstream:** {source.url} (branch `{source.branch}`)",
+        f"- **Upstream path:** `{source.src_path}`",
+        f"- **Destination:** `{source.dest_path}`",
+    ]
+    if run_url:
+        lines.append(f"- **Workflow run:** {run_url}")
+    lines += [
+        "",
+        "## Error",
+        "",
+        "```",
+        err_trimmed,
+        "```",
+        "",
+        "---",
+        "",
+        "This issue is auto-managed by `sync/sync.py`. It will be closed "
+        "automatically the next time this source syncs successfully. If the "
+        "error signature changes, a new comment will be posted here.",
+        "",
+        f"<!-- sync-error-hash: {err_hash} -->",
+    ]
+    return "\n".join(lines)
+
+
+def _open_or_update_failure_issue(
+    repo: str, source: Source, err: str, run_url: str | None
+) -> None:
+    err_hash = _error_hash(source.name, err)
+    existing = _find_open_issue(repo, source.name)
+
+    if existing is None:
+        # First failure for this source (or any prior issues were closed).
+        _ensure_labels(repo, [SYNC_FAILURE_LABEL, f"{SOURCE_LABEL_PREFIX}{source.name}"])
+        body = _format_issue_body(source, err, err_hash, run_url)
+        title = f"[sync] {source.name}: mirror failed"
+        r = run(
+            ["gh", "issue", "create", "--repo", repo,
+             "--title", title, "--body", body,
+             "--label", SYNC_FAILURE_LABEL,
+             "--label", f"{SOURCE_LABEL_PREFIX}{source.name}"],
+            check=False,
+        )
+        if r.returncode == 0:
+            log(f"issue-reporter: opened issue for {source.name}: {r.stdout.strip()}")
+        else:
+            log(f"issue-reporter: failed to open issue for {source.name}: {r.stderr.strip()}")
+        return
+
+    # An open issue exists. Decide whether to stay silent or post an update.
+    number = existing["number"]
+    prior_hash_match = ERROR_HASH_MARKER_RE.search(existing.get("body") or "")
+    prior_hash = prior_hash_match.group(1) if prior_hash_match else None
+
+    if prior_hash == err_hash:
+        log(f"issue-reporter: #{number} already tracks this failure mode for "
+            f"{source.name} (hash {err_hash}); no comment posted")
+        return
+
+    # Error changed — update the issue body's hash marker and post a
+    # comment summarizing the new failure signature.
+    old_body = existing.get("body") or ""
+    if prior_hash_match:
+        new_body = ERROR_HASH_MARKER_RE.sub(f"<!-- sync-error-hash: {err_hash} -->", old_body)
+    else:
+        new_body = old_body.rstrip() + f"\n\n<!-- sync-error-hash: {err_hash} -->\n"
+    run(
+        ["gh", "issue", "edit", str(number), "--repo", repo, "--body", new_body],
+        check=False,
+    )
+
+    MAX_ERR = 6000
+    err_trimmed = err if len(err) <= MAX_ERR else err[:MAX_ERR] + "\n…[truncated]"
+    comment_lines = ["The failure signature changed."]
+    if run_url:
+        comment_lines.append(f"Workflow run: {run_url}")
+    comment_lines += ["", "```", err_trimmed, "```"]
+    comment = "\n".join(comment_lines)
+    r = run(
+        ["gh", "issue", "comment", str(number), "--repo", repo, "--body", comment],
+        check=False,
+    )
+    if r.returncode == 0:
+        log(f"issue-reporter: updated #{number} for {source.name} (new hash {err_hash})")
+    else:
+        log(f"issue-reporter: failed to comment on #{number}: {r.stderr.strip()}")
+
+
+def _close_recovered_issue(repo: str, source: Source, run_url: str | None) -> None:
+    existing = _find_open_issue(repo, source.name)
+    if existing is None:
+        return
+    number = existing["number"]
+    body_lines = ["Sync recovered — closing automatically."]
+    if run_url:
+        body_lines.append(f"Workflow run: {run_url}")
+    r = run(
+        ["gh", "issue", "close", str(number), "--repo", repo,
+         "--comment", "\n".join(body_lines)],
+        check=False,
+    )
+    if r.returncode == 0:
+        log(f"issue-reporter: closed #{number} — {source.name} recovered")
+    else:
+        log(f"issue-reporter: failed to close #{number}: {r.stderr.strip()}")
+
+
+def _all_open_failure_issues(repo: str) -> list[dict]:
+    """Return every open sync-failure issue on the repo (all sources)."""
+    r = run(
+        ["gh", "issue", "list", "--repo", repo, "--state", "open",
+         "--label", SYNC_FAILURE_LABEL,
+         "--json", "number,title,labels,body,updatedAt", "--limit", "100"],
+        check=False,
+    )
+    if r.returncode != 0:
+        log(f"issue-reporter: gh issue list (all) failed: {r.stderr.strip()}")
+        return []
+    try:
+        return json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+
+
+def _source_name_from_issue(issue: dict) -> str | None:
+    for lbl in issue.get("labels") or []:
+        name = lbl.get("name", "")
+        if name.startswith(SOURCE_LABEL_PREFIX):
+            return name[len(SOURCE_LABEL_PREFIX):]
+    return None
+
+
+def _is_default_branch(repo: str) -> bool:
+    """
+    Return True iff the current GITHUB_REF_NAME matches the repo's default
+    branch. Conservative: if we can't determine either side, return False
+    (safer to post a PR comment or stay silent than to cut an issue).
+    """
+    ref_name = os.environ.get("GITHUB_REF_NAME")
+    if not ref_name:
+        return False
+    r = run(
+        ["gh", "repo", "view", repo, "--json", "defaultBranchRef"],
+        check=False,
+    )
+    if r.returncode != 0:
+        log(f"issue-reporter: gh repo view failed ({r.stderr.strip()}); "
+            "assuming non-default branch")
+        return False
+    try:
+        info = json.loads(r.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    default = (info.get("defaultBranchRef") or {}).get("name")
+    return bool(default) and ref_name == default
+
+
+def _find_pr_for_ref(repo: str, ref_name: str) -> int | None:
+    """
+    Return the number of the (single) open PR whose head branch matches
+    ref_name, or None. Multiple-PR case is rare; we return the newest.
+    """
+    r = run(
+        ["gh", "pr", "list", "--repo", repo, "--state", "open",
+         "--head", ref_name, "--json", "number,updatedAt", "--limit", "5"],
+        check=False,
+    )
+    if r.returncode != 0:
+        log(f"issue-reporter: gh pr list failed: {r.stderr.strip()}")
+        return None
+    try:
+        prs = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    if not prs:
+        return None
+    prs.sort(key=lambda p: p.get("updatedAt", ""), reverse=True)
+    return prs[0].get("number")
+
+
+# A signature line we embed in every PR failure comment so we can
+# distinguish our comments from anyone else's when de-duping.
+PR_COMMENT_SIGNATURE = "<!-- sync-failure-comment -->"
+
+
+def _post_or_update_pr_comment(
+    repo: str, pr_number: int, source: "Source", err: str, run_url: str | None,
+) -> None:
+    """
+    Post a failure comment on the given PR, de-duplicated by error-hash.
+
+    We scan existing comments on the PR for any that carry our signature
+    marker AND a source-label marker for this source. If the most-recent
+    such comment's error-hash matches the current error, stay silent. Any
+    other case posts a fresh comment — we never edit old comments so the
+    chronological history of failure signatures is preserved on the PR.
+    """
+    err_hash = _error_hash(source.name, err)
+
+    # List recent comments and look for prior sync-failure comments for
+    # this source. `gh pr view --json comments` gives us the bodies.
+    r = run(
+        ["gh", "pr", "view", str(pr_number), "--repo", repo,
+         "--json", "comments"],
+        check=False,
+    )
+    prior_hash: str | None = None
+    if r.returncode == 0:
+        try:
+            data = json.loads(r.stdout or "{}")
+        except json.JSONDecodeError:
+            data = {}
+        comments = data.get("comments") or []
+        source_marker = f"<!-- sync-source: {source.name} -->"
+        # Comments come back oldest-first; walk in reverse to find the
+        # most recent matching one.
+        for c in reversed(comments):
+            body = c.get("body") or ""
+            if PR_COMMENT_SIGNATURE in body and source_marker in body:
+                m = ERROR_HASH_MARKER_RE.search(body)
+                prior_hash = m.group(1) if m else None
+                break
+    else:
+        log(f"issue-reporter: gh pr view failed: {r.stderr.strip()}")
+
+    if prior_hash == err_hash:
+        log(f"issue-reporter: PR #{pr_number} already has a comment for "
+            f"{source.name} with the same failure signature (hash "
+            f"{err_hash}); no comment posted")
+        return
+
+    MAX_ERR = 6000
+    err_trimmed = err if len(err) <= MAX_ERR else err[:MAX_ERR] + "\n…[truncated]"
+    lines = [
+        PR_COMMENT_SIGNATURE,
+        f"<!-- sync-source: {source.name} -->",
+        f"Skill sync failed for **`{source.name}`** on this branch.",
+        "",
+        f"- **Upstream:** {source.url} (branch `{source.branch}`)",
+        f"- **Upstream path:** `{source.src_path}`",
+        f"- **Destination:** `{source.dest_path}`",
+    ]
+    if run_url:
+        lines.append(f"- **Workflow run:** {run_url}")
+    lines += [
+        "",
+        "<details><summary>Error</summary>",
+        "",
+        "```",
+        err_trimmed,
+        "```",
+        "",
+        "</details>",
+        "",
+        "_This comment is auto-posted by `sync/sync.py` when the sync job "
+        "runs on a non-default branch. No GitHub issue will be opened for "
+        "PR-branch failures._",
+        "",
+        f"<!-- sync-error-hash: {err_hash} -->",
+    ]
+    body = "\n".join(lines)
+    rc = run(
+        ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body", body],
+        check=False,
+    )
+    if rc.returncode == 0:
+        log(f"issue-reporter: commented on PR #{pr_number} for "
+            f"{source.name} (hash {err_hash})")
+    else:
+        log(f"issue-reporter: failed to comment on PR #{pr_number}: "
+            f"{rc.stderr.strip()}")
+
+
+def report_results_to_github(results: list[SourceResult]) -> None:
+    """
+    Surface sync outcomes in GitHub. The reporting channel depends on which
+    branch the workflow is running on:
+
+      * Default branch  -> open/update/close labelled failure issues.
+      * Non-default ref -> post (de-duplicated) comments on the PR whose
+                           HEAD matches the current ref, if one exists.
+                           No issues are opened from non-default branches.
+
+    Best-effort in every case: never affects the sync exit code, silently
+    skips in non-GitHub contexts, and swallows all gh errors.
+    """
+    repo = os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        log("issue-reporter: GITHUB_REPOSITORY not set; skipping")
+        return
+    try:
+        if not _gh_available(repo):
+            log(f"issue-reporter: gh unavailable or not authed for {repo}; skipping")
+            return
+    except Exception as e:  # pragma: no cover - defensive
+        log(f"issue-reporter: gh availability check errored: {e}; skipping")
+        return
+
+    # Build a link to the current workflow run if we're in CI.
+    run_url: str | None = None
+    server = os.environ.get("GITHUB_SERVER_URL")
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if server and run_id:
+        run_url = f"{server}/{repo}/actions/runs/{run_id}"
+
+    on_default = _is_default_branch(repo)
+    ref_name = os.environ.get("GITHUB_REF_NAME", "")
+    if not on_default:
+        log(
+            f"issue-reporter: running on non-default branch {ref_name!r}; "
+            "will route failures to PR comments instead of issues"
+        )
+        pr_number = _find_pr_for_ref(repo, ref_name) if ref_name else None
+        for r in results:
+            if r.status != "failed":
+                continue
+            if pr_number is None:
+                log(
+                    f"issue-reporter: {r.source.name} failed on {ref_name!r} "
+                    "but no open PR was found; relying on failed workflow "
+                    "status as the signal"
+                )
+                continue
+            err_text = "\n".join(r.errors) if r.errors else (r.message or "unknown error")
+            try:
+                _post_or_update_pr_comment(repo, pr_number, r.source, err_text, run_url)
+            except Exception as e:  # pragma: no cover
+                log(f"issue-reporter: unexpected error commenting on PR #{pr_number} for {r.source.name}: {e}")
+        return
+
+    # Default branch: full issue-tracker flow (open/update/close).
+    for r in results:
+        try:
+            if r.status == "failed":
+                err_text = "\n".join(r.errors) if r.errors else (r.message or "unknown error")
+                _open_or_update_failure_issue(repo, r.source, err_text, run_url)
+            elif r.status in ("synced", "up-to-date"):
+                _close_recovered_issue(repo, r.source, run_url)
+            # status == "skipped" -> do nothing
+        except Exception as e:  # pragma: no cover
+            log(f"issue-reporter: unexpected error handling {r.source.name}: {e}")
+
+    # Close issues for sources that no longer exist in the config. When a
+    # user removes a bad source, sync_one is never called for it — so we'd
+    # otherwise leave the issue open forever. Skip this sweep when only a
+    # subset of sources ran (e.g. workflow_dispatch with `--only`), since
+    # we can't distinguish "removed from config" from "not in this run".
+    if os.environ.get("SYNC_FULL_RUN") == "1":
+        seen_source_names = {r.source.name for r in results}
+        for issue in _all_open_failure_issues(repo):
+            src_name = _source_name_from_issue(issue)
+            if not src_name or src_name in seen_source_names:
+                continue
+            number = issue["number"]
+            comment = (
+                "Source was removed from the sync configuration — closing "
+                "automatically."
+            )
+            if run_url:
+                comment += f"\n\nWorkflow run: {run_url}"
+            rc = run(
+                ["gh", "issue", "close", str(number), "--repo", repo,
+                 "--comment", comment],
+                check=False,
+            )
+            if rc.returncode == 0:
+                log(f"issue-reporter: closed #{number} — source {src_name!r} removed from config")
+            else:
+                log(f"issue-reporter: failed to close #{number} for removed source {src_name!r}: {rc.stderr.strip()}")
+
+
+def load_sources_from_dir(sources_dir: Path) -> list["Source"]:
+    """
+    Load sources from `sources_dir` — one YAML file per source.
+
+    Each file must be a mapping with at least `name`, `url`, `src_path`,
+    `dest_path` at the top level. `sources:` list-of-entries files are
+    also accepted for back-compat and for the rare case where a file
+    defines multiple sources that share context.
+
+    Files are loaded in lexicographic order so sync order is deterministic
+    and reviewable. Hidden files and non-`.yaml` / non-`.yml` files are
+    ignored. Duplicate source names across files are a hard error.
+    """
+    if not sources_dir.exists() or not sources_dir.is_dir():
+        raise FileNotFoundError(f"sources directory not found: {sources_dir}")
+
+    files = sorted(
+        p for p in sources_dir.iterdir()
+        if p.is_file() and p.suffix in (".yaml", ".yml") and not p.name.startswith(".")
+    )
+
+    sources: list[Source] = []
+    seen: dict[str, Path] = {}
+    for path in files:
+        with path.open() as f:
+            doc = yaml.safe_load(f)
+        if doc is None:
+            continue
+        if isinstance(doc, dict) and "sources" in doc:
+            entries = doc.get("sources") or []
+        elif isinstance(doc, dict):
+            entries = [doc]
+        else:
+            raise ValueError(
+                f"{path}: top-level must be a mapping "
+                f"(single source) or {{sources: [...]}}"
+            )
+        for entry in entries:
+            src = Source.from_dict(entry)
+            if src.name in seen:
+                raise ValueError(
+                    f"duplicate source name {src.name!r}: "
+                    f"defined in both {seen[src.name]} and {path}"
+                )
+            seen[src.name] = path
+            sources.append(src)
+    return sources
+
+
+# ---------- main ----------
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--sources-dir",
+        type=Path,
+        default=DEFAULT_SOURCES_DIR,
+        help="directory containing one YAML file per source (default: sync/sources/)",
+    )
+    ap.add_argument("--only", type=str, default=None, help="sync only this source name")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    sources_dir: Path = args.sources_dir
+    try:
+        sources = load_sources_from_dir(sources_dir)
+    except FileNotFoundError as e:
+        log(str(e))
+        return 2
+    except ValueError as e:
+        log(f"config error: {e}")
+        return 2
+
+    if not sources:
+        log(f"no sources defined under {sources_dir}, nothing to do")
+        return 0
+
+    if args.only:
+        sources = [s for s in sources if s.name == args.only]
+        if not sources:
+            log(f"no source named {args.only!r}")
+            return 2
+
+    state = load_state()
+    results: list[SourceResult] = []
+    for s in sources:
+        log(f"--- syncing: {s.name} ({s.src_path} -> {s.dest_path}) ---")
+        results.append(sync_one(s, state, REPO_ROOT, args.dry_run))
+
+    # Persist state one more time at the end (covers the no-op branches).
+    if not args.dry_run:
+        save_state(state)
+
+    # Summary
+    print()
+    log("=== SUMMARY ===")
+    exit_code = 0
+    for r in results:
+        line = f"  {r.source.name:40s}  {r.status:12s}  {r.message}"
+        log(line)
+        if r.status == "failed":
+            exit_code = 1
+
+    # Open/update/close GitHub issues based on results. Best-effort:
+    # never affects exit code, silently skips in non-GitHub contexts.
+    # Disabled under --dry-run so local rehearsals don't touch the tracker.
+    if not args.dry_run:
+        # Signal to the reporter that this run processed every configured
+        # source, so it's safe to close issues for sources no longer in
+        # the config. Under --only we processed a subset, so skip that sweep.
+        if not args.only:
+            os.environ["SYNC_FULL_RUN"] = "1"
+        try:
+            report_results_to_github(results)
+        except Exception as e:  # pragma: no cover - absolute belt-and-suspenders
+            log(f"issue-reporter: top-level error swallowed: {e}")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sync-bot/src/skills_sync/main.py
+++ b/sync-bot/src/skills_sync/main.py
@@ -927,6 +927,16 @@ SYNC_FAILURE_LABEL = "sync-failure"
 SOURCE_LABEL_PREFIX = "sync-source:"
 ERROR_HASH_MARKER_RE = re.compile(r"<!-- sync-error-hash: ([0-9a-f]{12}) -->")
 
+# Bound the error payload embedded in issue bodies and PR comments.
+# The full traceback is still preserved in the Actions log.
+ERROR_TRUNCATE_MAX = 6000
+
+
+def _truncate_err(err: str) -> str:
+    if len(err) <= ERROR_TRUNCATE_MAX:
+        return err
+    return err[:ERROR_TRUNCATE_MAX] + "\n…[truncated]"
+
 
 def _gh_available(repo: str) -> bool:
     """Check gh CLI is installed and authed for the target repo."""
@@ -1004,8 +1014,7 @@ def _ensure_labels(repo: str, names: Iterable[str]) -> None:
 def _format_issue_body(source: Source, err: str, err_hash: str, run_url: str | None) -> str:
     # Keep the error payload bounded — very long tracebacks get truncated
     # (still recorded in full in the Actions log).
-    MAX_ERR = 6000
-    err_trimmed = err if len(err) <= MAX_ERR else err[:MAX_ERR] + "\n…[truncated]"
+    err_trimmed = _truncate_err(err)
     lines = [
         f"The skill-sync job failed while mirroring `{source.name}`.",
         "",
@@ -1080,8 +1089,7 @@ def _open_or_update_failure_issue(
         check=False,
     )
 
-    MAX_ERR = 6000
-    err_trimmed = err if len(err) <= MAX_ERR else err[:MAX_ERR] + "\n…[truncated]"
+    err_trimmed = _truncate_err(err)
     comment_lines = ["The failure signature changed."]
     if run_url:
         comment_lines.append(f"Workflow run: {run_url}")
@@ -1240,8 +1248,7 @@ def _post_or_update_pr_comment(
             f"{err_hash}); no comment posted")
         return
 
-    MAX_ERR = 6000
-    err_trimmed = err if len(err) <= MAX_ERR else err[:MAX_ERR] + "\n…[truncated]"
+    err_trimmed = _truncate_err(err)
     lines = [
         PR_COMMENT_SIGNATURE,
         f"<!-- sync-source: {source.name} -->",

--- a/sync-bot/tests/conftest.py
+++ b/sync-bot/tests/conftest.py
@@ -1,0 +1,193 @@
+"""Shared fixtures for sync tests.
+
+These tests exercise skills_sync.main end-to-end with real git commands
+against synthetic local repositories in tmp_path. No network, no GitHub
+API — the module-level path constants (REPO_ROOT, STATE_FILE, CACHE_DIR)
+are monkeypatched to point into tmp_path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Allow `import skills_sync` even when the package hasn't been installed
+# (e.g. raw `pytest` invocation from the sync-bot/ directory). Normally
+# `uv run pytest` handles this via the pyproject's `pythonpath = ["src"]`,
+# but keeping the fallback makes ad-hoc invocation robust.
+SYNC_BOT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = SYNC_BOT_ROOT / "src"
+if SRC_DIR.exists() and str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def _git(cwd: Path, *args: str, env: dict | None = None) -> str:
+    """Run a git command and return stdout (stripped). Raises on failure."""
+    full_env = os.environ.copy()
+    # Pin identity so test commits are deterministic and don't depend on
+    # the developer's git config.
+    full_env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test Author",
+            "GIT_AUTHOR_EMAIL": "test-author@example.invalid",
+            "GIT_COMMITTER_NAME": "Test Committer",
+            "GIT_COMMITTER_EMAIL": "test-committer@example.invalid",
+            # Force a stable default branch name across all git versions.
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        }
+    )
+    if env:
+        full_env.update(env)
+    r = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=full_env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return r.stdout.strip()
+
+
+@pytest.fixture
+def git_env():
+    """Expose the helper so tests can run ad-hoc git commands with a stable identity."""
+    return _git
+
+
+@pytest.fixture
+def make_upstream(tmp_path):
+    """
+    Factory that creates a bare-backed local "upstream" git repo under
+    tmp_path/upstreams/<name>, returning its on-disk path.
+
+    The returned repo is a normal (non-bare) working clone so the test
+    can commit into it directly; sync.py will clone from this path via
+    `file://` URL — the same fetch path used in production against
+    github.com — giving us real end-to-end coverage of fetch/log/
+    format-patch/am semantics without any network.
+    """
+    base = tmp_path / "upstreams"
+    base.mkdir(exist_ok=True)
+
+    def _factory(name: str) -> Path:
+        repo = base / name
+        repo.mkdir()
+        _git(repo, "init", "-b", "main", ".")
+        # First commit must exist so HEAD resolves; keep it empty of
+        # tracked content the sync cares about.
+        (repo / "README.md").write_text("# upstream\n")
+        _git(repo, "add", "README.md")
+        _git(repo, "commit", "-m", "initial")
+        return repo
+
+    return _factory
+
+
+@pytest.fixture
+def commit_file():
+    """
+    Helper: write `content` to `repo/rel_path` and commit it with
+    `message` under an optional custom author identity.
+    Returns the new commit SHA.
+    """
+
+    def _commit(
+        repo: Path,
+        rel_path: str,
+        content: str,
+        message: str,
+        *,
+        author_name: str = "Upstream Dev",
+        author_email: str = "upstream-dev@example.invalid",
+    ) -> str:
+        fp = repo / rel_path
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content)
+        _git(repo, "add", rel_path)
+        _git(
+            repo,
+            "commit",
+            "-m",
+            message,
+            env={
+                "GIT_AUTHOR_NAME": author_name,
+                "GIT_AUTHOR_EMAIL": author_email,
+            },
+        )
+        return _git(repo, "rev-parse", "HEAD")
+
+    return _commit
+
+
+@pytest.fixture
+def dest_repo(tmp_path):
+    """A fresh local destination repo (simulates this repo in a PR branch)."""
+    repo = tmp_path / "dest"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main", ".")
+    (repo / "README.md").write_text("# dest\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+@pytest.fixture
+def sync_mod(tmp_path, dest_repo, monkeypatch):
+    """
+    Import skills_sync.main with its module-level REPO_ROOT / STATE_FILE /
+    CACHE_DIR redirected into tmp_path. Any previously-imported copy is
+    evicted so the constants are re-computed from scratch. Yields the
+    module with an attached `.dest_repo` attribute for convenience.
+
+    We import the concrete submodule (skills_sync.main) rather than the
+    package so monkeypatches on constants like SYNC_BOT_NAME actually
+    affect the bindings that the sync functions read at runtime (the
+    package __init__ merely re-exports them, and patching the re-export
+    has no effect on the originals).
+    """
+    # Drop any cached copies so re-patching REPO_ROOT / constants takes
+    # effect when _resolve_repo_root() is re-evaluated on import.
+    for mod in ("skills_sync", "skills_sync.main"):
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    import skills_sync.main as sync_module  # type: ignore
+
+    # Redirect module-level paths into the test sandbox. We rebase to the
+    # dest repo so state.json and .sync-cache live inside it — mirrors
+    # production, where state.json is committed into this very repo.
+    monkeypatch.setattr(sync_module, "REPO_ROOT", dest_repo, raising=True)
+    monkeypatch.setattr(
+        sync_module, "CACHE_DIR", dest_repo / ".sync-cache", raising=True
+    )
+    state_dir = dest_repo / "sync"
+    state_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr(
+        sync_module, "STATE_FILE", state_dir / "state.json", raising=True
+    )
+    # Pin bot identity so signed-off-by trailers are deterministic.
+    monkeypatch.setattr(sync_module, "SYNC_BOT_NAME", "test-bot", raising=True)
+    monkeypatch.setattr(
+        sync_module,
+        "SYNC_BOT_EMAIL",
+        "test-bot@example.invalid",
+        raising=True,
+    )
+    sync_module.dest_repo = dest_repo  # type: ignore[attr-defined]
+    return sync_module
+
+
+def _as_file_url(path: Path) -> str:
+    """file://-URL form that works on both Linux and macOS runners."""
+    return path.resolve().as_uri()
+
+
+@pytest.fixture
+def file_url():
+    return _as_file_url

--- a/sync-bot/tests/test_sync_integration.py
+++ b/sync-bot/tests/test_sync_integration.py
@@ -649,3 +649,370 @@ def test_sync_one_squash_is_per_source_not_cross_source(
     # Both skill trees present on disk.
     assert (sync_mod.dest_repo / "imported-a" / "alpha" / "SKILL.md").exists()
     assert (sync_mod.dest_repo / "imported-b" / "beta" / "SKILL.md").exists()
+
+
+# ---------- mode=pr ----------
+#
+# pr-mode is used when the sync engine proposes imports into another repo
+# as a PR rather than mirroring into the hub. Key behavioural differences
+# from push-mode being locked in below:
+#
+#   * imports land on a per-source branch `skills-sync/<name>` forked from
+#     the pre-sync HEAD; original branch is restored on return,
+#   * state.json is NOT modified and NO `chore(sync): advance state` commit
+#     is created (the hub owns sync state, not the PR target),
+#   * SourceResult.dest_branch is populated with the per-source branch name
+#     (workflow reads this to force-push + open/update a PR),
+#   * on failure, dest_branch is cleared and the per-source branch is reset
+#     to the pre-sync base so no empty/half-applied PR is ever proposed.
+
+
+def _current_branch(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _branch_exists(repo: Path, name: str) -> bool:
+    r = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{name}"],
+        cwd=repo,
+    )
+    return r.returncode == 0
+
+
+def test_sync_one_pr_mode_creates_per_source_branch_and_leaves_state_untouched(
+    sync_mod, make_upstream, commit_file
+):
+    """pr-mode: imports land on skills-sync/<name>, state.json untouched,
+    no chore(sync) state-bump commit, original branch restored on return,
+    and SourceResult.dest_branch is set to the per-source branch."""
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+
+    src = _make_source(sync_mod, "alpha-src", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+
+    base_before = _current_branch(sync_mod.dest_repo)
+    base_head_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    result = sync_mod.sync_one(
+        src, state, sync_mod.dest_repo, dry_run=False, mode=sync_mod.MODE_PR
+    )
+
+    assert result.status == "synced", result.message
+    assert result.commits_imported == 1
+    assert result.dest_branch == "skills-sync/alpha-src"
+
+    # We're back on the original branch and its HEAD is unchanged: pr-mode
+    # must not mutate the branch we were called on.
+    assert _current_branch(sync_mod.dest_repo) == base_before
+    base_head_after = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    assert base_head_after == base_head_before
+
+    # The per-source branch exists and IS ahead of base — this is what the
+    # workflow would push + open a PR for.
+    assert _branch_exists(sync_mod.dest_repo, "skills-sync/alpha-src")
+    pr_head = subprocess.run(
+        ["git", "rev-parse", "skills-sync/alpha-src"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    assert pr_head != base_head_after, (
+        "pr branch must carry the imported commit on top of base"
+    )
+
+    # state.json was NOT touched: pr-mode leaves canonical state alone
+    # because the hub owns it, not this proposing run.
+    assert state["sources"] == {}
+
+    # And no chore(sync): advance state commit was made on the pr branch.
+    subjects = subprocess.run(
+        [
+            "git",
+            "log",
+            "--format=%s",
+            f"{base_head_after}..skills-sync/alpha-src",
+        ],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+    assert subjects, "expected at least one commit on pr branch"
+    assert not any(
+        s.startswith("[alpha-src] chore(sync):") for s in subjects
+    ), f"pr-mode must not emit state-bump commits, got: {subjects}"
+
+
+def test_sync_one_pr_mode_two_sources_fork_from_same_base(
+    sync_mod, make_upstream, commit_file
+):
+    """Two pr-mode sources in one run must each fork their own
+    skills-sync/<name> branch off the SAME base (not off each other).
+    Proves original_branch is restored between sources so cross-source
+    contamination can't happen."""
+    up_a = make_upstream("up-a")
+    commit_file(
+        up_a,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+    up_b = make_upstream("up-b")
+    commit_file(
+        up_b,
+        "skills/beta/SKILL.md",
+        SKILL_FRONTMATTER.format(name="beta"),
+        "add beta",
+    )
+
+    src_a = _make_source(sync_mod, "a", up_a, "skills", "imported-a")
+    src_b = _make_source(sync_mod, "b", up_b, "skills", "imported-b")
+    state = {"version": 1, "sources": {}}
+
+    base_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    r_a = sync_mod.sync_one(
+        src_a, state, sync_mod.dest_repo, dry_run=False, mode=sync_mod.MODE_PR
+    )
+    r_b = sync_mod.sync_one(
+        src_b, state, sync_mod.dest_repo, dry_run=False, mode=sync_mod.MODE_PR
+    )
+
+    assert r_a.dest_branch == "skills-sync/a"
+    assert r_b.dest_branch == "skills-sync/b"
+
+    # Each per-source branch forks from exactly `base_head` — i.e. the B
+    # branch must NOT contain A's imports.
+    a_parent = subprocess.run(
+        ["git", "rev-parse", "skills-sync/a^"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    b_parent = subprocess.run(
+        ["git", "rev-parse", "skills-sync/b^"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    assert a_parent == base_head, f"a forked from {a_parent}, not {base_head}"
+    assert b_parent == base_head, f"b forked from {b_parent}, not {base_head}"
+
+    # Trees are isolated: branch a has alpha only, branch b has beta only.
+    a_files = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "skills-sync/a"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    b_files = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "skills-sync/b"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    assert "imported-a/alpha/SKILL.md" in a_files
+    assert "imported-b/beta/SKILL.md" not in a_files
+    assert "imported-b/beta/SKILL.md" in b_files
+    assert "imported-a/alpha/SKILL.md" not in b_files
+
+
+def test_sync_one_pr_mode_validation_failure_clears_dest_branch(
+    sync_mod, make_upstream, commit_file
+):
+    """If the imported tree fails validation in pr-mode, the per-source
+    branch is reset to base (no partial commits survive) and
+    SourceResult.dest_branch is cleared so the workflow doesn't open an
+    empty/broken PR."""
+    up = make_upstream("up")
+    # Upstream SKILL.md is missing a 'description' field -> fails spec
+    # validation. This is the same trigger that test_sync_one_validation_*
+    # uses in push-mode.
+    bad = "---\nname: broken\n---\n# broken\n"
+    commit_file(up, "skills/broken/SKILL.md", bad, "add broken skill")
+
+    src = _make_source(sync_mod, "broken-src", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+
+    base_before = _current_branch(sync_mod.dest_repo)
+    base_head_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    result = sync_mod.sync_one(
+        src, state, sync_mod.dest_repo, dry_run=False, mode=sync_mod.MODE_PR
+    )
+
+    assert result.status == "failed", result.message
+    # dest_branch cleared: no PR should be opened for a failed import.
+    assert result.dest_branch == ""
+    # state untouched.
+    assert state["sources"] == {}
+    # Original branch restored, base HEAD untouched.
+    assert _current_branch(sync_mod.dest_repo) == base_before
+    base_head_after = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    assert base_head_after == base_head_before
+    # The pr branch, if it exists, points at base (no imports on it).
+    if _branch_exists(sync_mod.dest_repo, "skills-sync/broken-src"):
+        pr_head = subprocess.run(
+            ["git", "rev-parse", "skills-sync/broken-src"],
+            cwd=sync_mod.dest_repo,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+        assert pr_head == base_head_before, (
+            "failed pr-mode branch must be reset to base, got commits on it"
+        )
+
+
+# ---------- CLI entrypoint: --results-json + --mode pr ----------
+
+
+def test_cli_main_results_json_pr_mode(
+    sync_mod, make_upstream, commit_file, monkeypatch, tmp_path
+):
+    """End-to-end CLI invocation: `opensearch-skills-sync --mode pr
+    --results-json PATH` against a sources dir with two sources. Verifies
+    the JSON payload has the fields the workflow iterates (name, status,
+    dest_branch, commits_imported) and that pr-mode isolation holds (no
+    state.json write, per-source branches exist, original branch restored).
+    """
+    import json as _json
+
+    # Two upstream repos, each contributing a skill.
+    up_a = make_upstream("up_a")
+    commit_file(
+        up_a,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "seed alpha",
+    )
+    up_b = make_upstream("up_b")
+    commit_file(
+        up_b,
+        "skills/beta/SKILL.md",
+        SKILL_FRONTMATTER.format(name="beta"),
+        "seed beta",
+    )
+
+    # Two source YAML files in a sandboxed sources_dir.
+    sources_dir = tmp_path / "sources"
+    sources_dir.mkdir()
+    (sources_dir / "alpha-src.yaml").write_text(
+        f"name: alpha-src\n"
+        f"url: {up_a.resolve().as_uri()}\n"
+        "branch: main\n"
+        "src_path: skills\n"
+        "dest_path: imported-a\n"
+        "squash: false\n"
+    )
+    (sources_dir / "beta-src.yaml").write_text(
+        f"name: beta-src\n"
+        f"url: {up_b.resolve().as_uri()}\n"
+        "branch: main\n"
+        "src_path: skills\n"
+        "dest_path: imported-b\n"
+        "squash: false\n"
+    )
+
+    results_json = tmp_path / "results.json"
+    # Invoke main() by patching sys.argv. main() uses argparse so this is
+    # the most faithful reproduction of the workflow's CLI invocation.
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "opensearch-skills-sync",
+            "--sources-dir",
+            str(sources_dir),
+            "--mode",
+            "pr",
+            "--results-json",
+            str(results_json),
+        ],
+    )
+
+    # dest_repo fixture made this repo the cwd-independent REPO_ROOT;
+    # main() also shells `git` from REPO_ROOT so no chdir needed.
+    base_before = _current_branch(sync_mod.dest_repo)
+    exit_code = sync_mod.main()
+    assert exit_code == 0
+
+    # Results JSON: one entry per source, required keys present.
+    assert results_json.exists()
+    payload = _json.loads(results_json.read_text())
+    assert isinstance(payload, list) and len(payload) == 2
+    by_name = {r["name"]: r for r in payload}
+    for expected in ("alpha-src", "beta-src"):
+        assert expected in by_name, f"missing {expected}"
+        r = by_name[expected]
+        # Keys the workflow iterates on.
+        for key in (
+            "name",
+            "status",
+            "commits_imported",
+            "new_head",
+            "dest_branch",
+            "message",
+            "src_path",
+            "dest_path",
+            "url",
+        ):
+            assert key in r, f"{expected}: missing {key}"
+        assert r["status"] == "synced", r
+        assert r["commits_imported"] >= 1
+        assert r["dest_branch"] == f"skills-sync/{expected}"
+
+    # pr-mode invariants: state.json untouched, original branch restored,
+    # per-source branches exist with commits on them.
+    assert not (sync_mod.dest_repo / "sync" / "state.json").exists(), (
+        "pr-mode must not write state.json"
+    )
+    assert _current_branch(sync_mod.dest_repo) == base_before
+    for name in ("alpha-src", "beta-src"):
+        assert _branch_exists(sync_mod.dest_repo, f"skills-sync/{name}")

--- a/sync-bot/tests/test_sync_integration.py
+++ b/sync-bot/tests/test_sync_integration.py
@@ -1,0 +1,651 @@
+"""
+Integration tests for sync/sync.py against synthetic local git repos.
+
+Each test builds a miniature "upstream" repo in tmp_path, points a
+Source at it via a file:// URL, and runs `sync_one` against a fresh
+destination repo. This exercises the real fetch / git log /
+format-patch / git am pipeline — the same code path that runs against
+GitHub in production — but is offline, deterministic, and takes
+milliseconds per test.
+
+Key invariants we lock in:
+
+  - first-ever sync imports the full history of src_path,
+  - re-run with no upstream changes is a no-op (idempotent),
+  - upstream commits that do NOT touch src_path leave state.json
+    unchanged,   <-- this is the scenario that motivated PR #12
+  - author attribution is preserved,
+  - [source_name] subject prefix is applied,
+  - provenance trailers (Source-Repo / Source-Commit) and Signed-off-by
+    are appended,
+  - validation failure hard-resets and does not bump state.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SKILL_FRONTMATTER = """\
+---
+name: {name}
+description: A test skill used by the sync integration test suite to exercise git-am import, subject prefixing, and provenance trailers.
+---
+
+# {name}
+
+Body for the {name} skill.
+"""
+
+
+def _skill(repo: Path, rel_dir: str, name: str) -> None:
+    """Write a minimal spec-valid SKILL.md inside repo at rel_dir/<name>/."""
+    p = repo / rel_dir / name / "SKILL.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(SKILL_FRONTMATTER.format(name=name))
+
+
+def _last_commit(repo: Path, *fmt_args: str) -> str:
+    r = subprocess.run(
+        ["git", "log", "-1", *fmt_args],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return r.stdout
+
+
+def _make_source(
+    sync_mod,
+    name: str,
+    upstream: Path,
+    src_path: str,
+    dest_path: str,
+    squash: bool = False,
+):
+    # Default squash=False in tests so the pre-existing fine-grained
+    # assertions (per-commit author preservation, subject prefix on each
+    # import) keep working. Squash-mode tests opt in explicitly.
+    return sync_mod.Source.from_dict(
+        {
+            "name": name,
+            "url": upstream.resolve().as_uri(),
+            "branch": "main",
+            "src_path": src_path,
+            "dest_path": dest_path,
+            "squash": squash,
+        }
+    )
+
+
+# ---------- commits_touching_path ----------
+
+
+def test_commits_touching_path_filters_unrelated(
+    sync_mod, make_upstream, commit_file, file_url, tmp_path
+):
+    """A commit that only touches files OUTSIDE src_path must be omitted
+    from the import range — that's the whole premise of idempotent state."""
+    up = make_upstream("up")
+    _skill(up, "skills", "alpha")
+    subprocess.run(
+        ["git", "add", "-A"], cwd=up, check=True, capture_output=True
+    )
+    sha_init = commit_file(up, "skills/alpha/notes.md", "n1", "init alpha")
+    sha_outside = commit_file(up, "other/file.md", "x", "outside src_path")
+    sha_inside = commit_file(up, "skills/alpha/notes.md", "n2", "update alpha")
+
+    # Fetch into the cache and run the filter.
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    cache, head = sync_mod.fetch_upstream(src)
+    shas = sync_mod.commits_touching_path(cache, src.src_path, None, head)
+    # Only the two skills/ commits — the outside commit is excluded.
+    assert sha_outside not in shas
+    assert sha_init in shas
+    assert sha_inside in shas
+    # Reverse order: oldest first.
+    assert shas.index(sha_init) < shas.index(sha_inside)
+
+
+# ---------- sync_one end-to-end ----------
+
+
+def test_sync_one_first_run_imports_history(
+    sync_mod, make_upstream, commit_file
+):
+    """First-ever sync against a fresh dest repo imports every upstream
+    commit that touched src_path."""
+    up = make_upstream("up")
+    sha1 = commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha skill",
+        author_name="Alice",
+        author_email="alice@example.invalid",
+    )
+    sha2 = commit_file(
+        up,
+        "skills/beta/SKILL.md",
+        SKILL_FRONTMATTER.format(name="beta"),
+        "add beta skill",
+        author_name="Bob",
+        author_email="bob@example.invalid",
+    )
+
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+    result = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+
+    assert result.status == "synced", result.message
+    assert result.commits_imported == 2
+    # dest tree contains both skills, copied under dest_path.
+    assert (sync_mod.dest_repo / "imported" / "alpha" / "SKILL.md").exists()
+    assert (sync_mod.dest_repo / "imported" / "beta" / "SKILL.md").exists()
+    # State advanced to the newest touching commit (sha2).
+    assert state["sources"][src.state_key]["last_sha"] == sha2
+
+
+def test_sync_one_rerun_no_changes_is_up_to_date(
+    sync_mod, make_upstream, commit_file
+):
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    pre_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    # Run again with no upstream changes.
+    result2 = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    post_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    assert result2.status == "up-to-date"
+    assert result2.commits_imported == 0
+    assert pre_head == post_head, "HEAD must not advance on up-to-date rerun"
+
+
+def test_sync_one_upstream_changes_outside_src_path_are_idempotent(
+    sync_mod, make_upstream, commit_file
+):
+    """
+    Regression guard for PR #12 / the whole motivation of idempotent state:
+
+    If the upstream advances with commits that do NOT touch src_path, the
+    next sync run must be a no-op. state.json.last_sha stays pinned to the
+    newest commit that DID touch src_path — not to the upstream tip.
+    Without this, every unrelated upstream commit would produce an empty
+    state-bump PR.
+    """
+    up = make_upstream("up")
+    sha_touch = commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    assert state["sources"][src.state_key]["last_sha"] == sha_touch
+
+    # Upstream advances with an UNRELATED commit.
+    commit_file(up, "other/README.md", "hello", "change outside src_path")
+
+    pre_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    result = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    post_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    assert result.status == "up-to-date"
+    assert pre_head == post_head
+    # Critically: last_sha MUST still point at sha_touch, not the new tip.
+    assert state["sources"][src.state_key]["last_sha"] == sha_touch
+
+
+def test_sync_one_incremental_import_of_new_touching_commit(
+    sync_mod, make_upstream, commit_file
+):
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+
+    # Second-run commit that DOES touch src_path.
+    sha2 = commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha") + "\nMore body.\n",
+        "tweak alpha",
+    )
+
+    result = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    assert result.status == "synced", result.message
+    assert result.commits_imported == 1
+    assert state["sources"][src.state_key]["last_sha"] == sha2
+
+
+def test_sync_one_preserves_author_and_applies_subject_prefix(
+    sync_mod, make_upstream, commit_file
+):
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha skill",
+        author_name="Original Author",
+        author_email="orig@example.invalid",
+    )
+
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+
+    # Inspect the last commit on dest. The state-bump commit is on top
+    # of the import, so we need the commit just before HEAD.
+    log_out = subprocess.run(
+        [
+            "git",
+            "log",
+            "--format=%an%x00%ae%x00%s%x00%b%x01",
+            "-3",
+        ],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    entries = [e for e in log_out.split("\x01") if e.strip()]
+    # Multiple commits start with `[src-a] ` — the state-bump commit
+    # (authored by the bot) and the actual import. We want the import,
+    # which is the one that is NOT a `chore(sync):` state-bump.
+    import_entry = next(
+        e for e in entries
+        if "\x00[src-a] " in e and "chore(sync)" not in e
+    )
+    author_name, author_email, subject, body = (
+        x.strip("\n") for x in import_entry.split("\x00", 3)
+    )
+
+    assert author_name == "Original Author"
+    assert author_email == "orig@example.invalid"
+    assert subject == "[src-a] add alpha skill"
+    # Provenance trailers appended.
+    assert "Source-Repo:" in body
+    assert "Source-Commit:" in body
+    # Committer (i.e. the bot) sign-off.
+    assert "Signed-off-by: test-bot <test-bot@example.invalid>" in body
+
+
+def test_sync_one_rerun_does_not_double_prefix(
+    sync_mod, make_upstream, commit_file
+):
+    """Guard: regardless of run count, no imported commit's subject
+    ever starts with `[src-a] [src-a] ...`. Combined with the
+    idempotence test, this locks in both halves of prefix safety
+    (don't re-import AND don't re-prefix if anything ever does)."""
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+
+    subjects = subprocess.run(
+        ["git", "log", "--format=%s"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+    # No subject should start with `[src-a] [src-a] `.
+    assert not any(s.startswith("[src-a] [src-a] ") for s in subjects), subjects
+
+
+def test_sync_one_dry_run_does_not_mutate(
+    sync_mod, make_upstream, commit_file
+):
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+
+    pre_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    result = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=True)
+    post_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    assert result.status == "synced"
+    assert result.commits_imported == 1
+    assert pre_head == post_head, "dry-run must not alter dest repo"
+    # state.json must not have been bumped either.
+    assert src.state_key not in state["sources"]
+
+
+def test_sync_one_validation_failure_resets_dest_and_keeps_state(
+    sync_mod, make_upstream, commit_file
+):
+    """
+    Import a commit whose SKILL.md is spec-invalid. sync_one must:
+      - hard-reset dest to the pre-sync HEAD,
+      - leave state.json unchanged (so next run retries, doesn't skip),
+      - return a failure result.
+    """
+    up = make_upstream("up")
+    # Frontmatter missing `description` — the validator will reject it.
+    commit_file(
+        up,
+        "skills/bad/SKILL.md",
+        "---\nname: bad\n---\n# body\n",
+        "add bad skill",
+    )
+
+    src = _make_source(sync_mod, "src-a", up, "skills", "imported")
+    state = {"version": 1, "sources": {}}
+
+    pre_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    result = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    post_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    assert result.status == "failed"
+    assert pre_head == post_head, (
+        "dest HEAD must be reset to pre-sync on failure"
+    )
+    # state must not be bumped for this source.
+    assert src.state_key not in state["sources"]
+    # Dest tree must be clean (the partial import file is gone).
+    assert not (sync_mod.dest_repo / "imported" / "bad" / "SKILL.md").exists()
+
+
+# ---------- squash mode ----------
+
+
+def test_sync_one_squash_collapses_multiple_commits_into_one(
+    sync_mod, make_upstream, commit_file
+):
+    """
+    With squash=True, a single sync run that imports N upstream commits
+    must produce exactly ONE import commit on dest (plus the state-bump
+    chore commit on top). The squashed commit:
+      - has `[src-a] sync: import N upstream commits` subject,
+      - lists every upstream subject in its body,
+      - carries a Co-authored-by trailer for every distinct original
+        author,
+      - pins Source-Commit to the newest upstream sha.
+    """
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha skill",
+        author_name="Alice",
+        author_email="alice@example.invalid",
+    )
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha") + "\nExtra body\n",
+        "tweak alpha",
+        author_name="Bob",
+        author_email="bob@example.invalid",
+    )
+    sha3 = commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha") + "\nMore extra body\n",
+        "polish alpha",
+        author_name="Alice",  # duplicate author — must only appear once
+        author_email="alice@example.invalid",
+    )
+
+    src = _make_source(
+        sync_mod, "src-a", up, "skills", "imported", squash=True
+    )
+    state = {"version": 1, "sources": {}}
+    pre_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    result = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    assert result.status == "synced", result.message
+    assert result.commits_imported == 3
+
+    # Between pre_head and HEAD there must be EXACTLY two commits:
+    # the squashed import + the state-bump chore.
+    commits = subprocess.run(
+        ["git", "rev-list", "--reverse", f"{pre_head}..HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.split()
+    assert len(commits) == 2, (
+        f"expected 2 commits (squash + state-bump), got {len(commits)}"
+    )
+
+    # Inspect the squashed import commit (not the chore on top).
+    imported_sha = commits[0]
+    show = subprocess.run(
+        ["git", "show", "--no-patch", "--format=%s%x00%b", imported_sha],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+    subject, body = show.split("\x00", 1)
+    subject = subject.rstrip("\n")
+
+    assert subject.startswith("[src-a] sync: import 3 upstream commits ")
+    assert "add alpha skill" in body
+    assert "tweak alpha" in body
+    assert "polish alpha" in body
+    # Provenance pins to newest upstream.
+    assert f"Source-Commit: {sha3}" in body
+    assert "Source-Repo:" in body
+    # Both distinct authors are co-authors; Alice only once despite two commits.
+    assert "Co-authored-by: Alice <alice@example.invalid>" in body
+    assert "Co-authored-by: Bob <bob@example.invalid>" in body
+    assert body.count("Co-authored-by: Alice") == 1
+    # Bot sign-off present.
+    assert "Signed-off-by: test-bot <test-bot@example.invalid>" in body
+
+
+def test_sync_one_squash_rerun_with_no_changes_is_up_to_date(
+    sync_mod, make_upstream, commit_file
+):
+    """Squash mode must still be idempotent — a rerun with no upstream
+    changes is a no-op, HEAD does not advance."""
+    up = make_upstream("up")
+    commit_file(
+        up,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha",
+    )
+    src = _make_source(
+        sync_mod, "src-a", up, "skills", "imported", squash=True
+    )
+    state = {"version": 1, "sources": {}}
+
+    sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    head1 = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    result2 = sync_mod.sync_one(src, state, sync_mod.dest_repo, dry_run=False)
+    head2 = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    assert result2.status == "up-to-date"
+    assert head1 == head2, "rerun with no changes must not advance HEAD"
+
+
+def test_sync_one_squash_is_per_source_not_cross_source(
+    sync_mod, make_upstream, commit_file
+):
+    """
+    Squash is scoped to ONE source's imports. Running two sources in
+    sequence must produce one squashed commit per source (plus their
+    state-bumps) — the second source's squash must NOT eat the first
+    source's commits.
+    """
+    up_a = make_upstream("up-a")
+    commit_file(
+        up_a,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha"),
+        "add alpha v1",
+    )
+    commit_file(
+        up_a,
+        "skills/alpha/SKILL.md",
+        SKILL_FRONTMATTER.format(name="alpha") + "\nbody\n",
+        "add alpha v2",
+    )
+
+    up_b = make_upstream("up-b")
+    commit_file(
+        up_b,
+        "skills/beta/SKILL.md",
+        SKILL_FRONTMATTER.format(name="beta"),
+        "add beta v1",
+    )
+    commit_file(
+        up_b,
+        "skills/beta/SKILL.md",
+        SKILL_FRONTMATTER.format(name="beta") + "\nbody\n",
+        "add beta v2",
+    )
+
+    src_a = _make_source(
+        sync_mod, "src-a", up_a, "skills", "imported-a", squash=True
+    )
+    src_b = _make_source(
+        sync_mod, "src-b", up_b, "skills", "imported-b", squash=True
+    )
+    state = {"version": 1, "sources": {}}
+
+    pre_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+    r1 = sync_mod.sync_one(src_a, state, sync_mod.dest_repo, dry_run=False)
+    r2 = sync_mod.sync_one(src_b, state, sync_mod.dest_repo, dry_run=False)
+    assert r1.status == "synced" and r1.commits_imported == 2
+    assert r2.status == "synced" and r2.commits_imported == 2
+
+    # Collect all commit subjects between pre_head..HEAD.
+    subjects = subprocess.run(
+        ["git", "log", "--format=%s", f"{pre_head}..HEAD", "--reverse"],
+        cwd=sync_mod.dest_repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.splitlines()
+
+    # Expected 4 commits total: squash-a, chore-a, squash-b, chore-b.
+    assert len(subjects) == 4, subjects
+    assert subjects[0].startswith("[src-a] sync: import 2 upstream commits")
+    assert subjects[1].startswith("[src-a] chore(sync):")
+    assert subjects[2].startswith("[src-b] sync: import 2 upstream commits")
+    assert subjects[3].startswith("[src-b] chore(sync):")
+    # Both skill trees present on disk.
+    assert (sync_mod.dest_repo / "imported-a" / "alpha" / "SKILL.md").exists()
+    assert (sync_mod.dest_repo / "imported-b" / "beta" / "SKILL.md").exists()

--- a/sync-bot/tests/test_sync_unit.py
+++ b/sync-bot/tests/test_sync_unit.py
@@ -1,0 +1,306 @@
+"""
+Unit tests for pure helpers in sync/sync.py.
+
+These tests exercise logic with no git I/O and no network — they run in
+milliseconds and are the first line of defence against regressions in
+parsing, hashing, and state-key formatting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+# ---------- prefix_subject ----------
+
+
+def test_prefix_subject_adds_tag_to_subject_only(sync_mod):
+    msg = "fix: foo\n\nlong body here\n"
+    out = sync_mod.prefix_subject(msg, "src-a")
+    assert out.splitlines()[0] == "[src-a] fix: foo"
+    # Body is untouched.
+    assert "\n\nlong body here\n" in out
+
+
+def test_prefix_subject_is_idempotent(sync_mod):
+    """Re-prefixing an already-prefixed message is a no-op — this is what
+    keeps re-runs from stacking `[x] [x] [x] subject`."""
+    msg = "[src-a] fix: foo\n\nbody\n"
+    assert sync_mod.prefix_subject(msg, "src-a") == msg
+
+
+def test_prefix_subject_different_source_does_stack(sync_mod):
+    """Idempotence is scoped to THIS source name. A different source
+    legitimately layers its own prefix (we don't normally call this in
+    practice, but the guarantee should be explicit)."""
+    msg = "[src-a] fix: foo\n"
+    assert sync_mod.prefix_subject(msg, "src-b").startswith("[src-b] [src-a] fix:")
+
+
+def test_prefix_subject_empty_message_returned_asis(sync_mod):
+    assert sync_mod.prefix_subject("", "src") == ""
+
+
+def test_prefix_subject_single_line_no_body(sync_mod):
+    out = sync_mod.prefix_subject("single line", "x")
+    assert out == "[x] single line"
+
+
+# ---------- Source model ----------
+
+
+def test_source_from_dict_strips_slashes(sync_mod):
+    src = sync_mod.Source.from_dict(
+        {
+            "name": "n",
+            "url": "https://example.invalid/a.git",
+            "src_path": "/a/b/",
+            "dest_path": "/x/y/",
+        }
+    )
+    assert src.src_path == "a/b"
+    assert src.dest_path == "x/y"
+    assert src.branch == "main"
+
+
+def test_source_from_dict_missing_fields(sync_mod):
+    with pytest.raises(ValueError, match="missing fields"):
+        sync_mod.Source.from_dict({"name": "n"})
+
+
+def test_source_state_key_stable(sync_mod):
+    src = sync_mod.Source.from_dict(
+        {
+            "name": "n",
+            "url": "u",
+            "src_path": "a",
+            "dest_path": "b",
+        }
+    )
+    assert src.state_key == "n::a->b"
+
+
+# ---------- load_sources_from_dir ----------
+
+
+def test_load_sources_single_doc_per_file(tmp_path, sync_mod):
+    d = tmp_path / "sources"
+    d.mkdir()
+    (d / "a.yaml").write_text(
+        "name: a\nurl: https://e.invalid/a\nsrc_path: s\ndest_path: d\n"
+    )
+    (d / "b.yaml").write_text(
+        "name: b\nurl: https://e.invalid/b\nsrc_path: s2\ndest_path: d2\n"
+    )
+    srcs = sync_mod.load_sources_from_dir(d)
+    assert [s.name for s in srcs] == ["a", "b"]
+
+
+def test_load_sources_list_style(tmp_path, sync_mod):
+    d = tmp_path / "sources"
+    d.mkdir()
+    (d / "multi.yaml").write_text(
+        "sources:\n"
+        "  - name: one\n"
+        "    url: u1\n"
+        "    src_path: s\n"
+        "    dest_path: d\n"
+        "  - name: two\n"
+        "    url: u2\n"
+        "    src_path: s\n"
+        "    dest_path: d2\n"
+    )
+    srcs = sync_mod.load_sources_from_dir(d)
+    assert [s.name for s in srcs] == ["one", "two"]
+
+
+def test_load_sources_duplicate_names_rejected(tmp_path, sync_mod):
+    d = tmp_path / "sources"
+    d.mkdir()
+    (d / "a.yaml").write_text(
+        "name: dup\nurl: u\nsrc_path: s\ndest_path: d\n"
+    )
+    (d / "b.yaml").write_text(
+        "name: dup\nurl: u\nsrc_path: s\ndest_path: d2\n"
+    )
+    with pytest.raises(ValueError, match="duplicate source name"):
+        sync_mod.load_sources_from_dir(d)
+
+
+def test_load_sources_ignores_non_yaml_and_hidden(tmp_path, sync_mod):
+    d = tmp_path / "sources"
+    d.mkdir()
+    (d / "a.yaml").write_text(
+        "name: a\nurl: u\nsrc_path: s\ndest_path: d\n"
+    )
+    (d / "README.md").write_text("not a source")
+    (d / ".hidden.yaml").write_text("name: hidden\n")  # should be skipped
+    srcs = sync_mod.load_sources_from_dir(d)
+    assert [s.name for s in srcs] == ["a"]
+
+
+def test_load_sources_missing_dir_raises(tmp_path, sync_mod):
+    with pytest.raises(FileNotFoundError):
+        sync_mod.load_sources_from_dir(tmp_path / "does-not-exist")
+
+
+def test_load_sources_bad_top_level_raises(tmp_path, sync_mod):
+    d = tmp_path / "sources"
+    d.mkdir()
+    (d / "bad.yaml").write_text("- just\n- a\n- list\n")
+    with pytest.raises(ValueError, match="top-level must be a mapping"):
+        sync_mod.load_sources_from_dir(d)
+
+
+# ---------- _error_hash ----------
+
+
+def test_error_hash_stable_across_volatile_bits(sync_mod):
+    """Two errors differing only in path, SHA, timestamp, or line number
+    must hash to the same value so we don't open a new issue each run."""
+    a = (
+        "Traceback at /home/runner/work/foo/bar.py line 42: "
+        "error 2025-04-22T19:30:15Z commit abc1234"
+    )
+    b = (
+        "Traceback at /home/ubuntu/work/other/path.py line 999: "
+        "error 2024-01-02T03:04:05Z commit deadbeef"
+    )
+    assert sync_mod._error_hash("src", a) == sync_mod._error_hash("src", b)
+
+
+def test_error_hash_source_scoped(sync_mod):
+    """Same error under different source names must hash differently so
+    each source gets its own issue."""
+    msg = "boom"
+    assert sync_mod._error_hash("s1", msg) != sync_mod._error_hash("s2", msg)
+
+
+def test_error_hash_genuinely_different_errors_differ(sync_mod):
+    assert sync_mod._error_hash("s", "aaa") != sync_mod._error_hash("s", "bbb")
+
+
+def test_error_hash_is_12_hex(sync_mod):
+    h = sync_mod._error_hash("s", "x")
+    assert len(h) == 12
+    int(h, 16)  # raises if not hex
+
+
+# ---------- _source_name_from_issue ----------
+
+
+def test_source_name_from_issue_reads_label(sync_mod):
+    prefix = sync_mod.SOURCE_LABEL_PREFIX
+    issue = {"labels": [{"name": "other"}, {"name": f"{prefix}my-source"}]}
+    assert sync_mod._source_name_from_issue(issue) == "my-source"
+
+
+def test_source_name_from_issue_missing(sync_mod):
+    issue = {"labels": [{"name": "unrelated"}]}
+    assert sync_mod._source_name_from_issue(issue) is None
+
+
+# ---------- validate_skill_tree / format_validation_failures ----------
+
+
+def test_validate_skill_tree_missing_dir_is_empty(sync_mod, tmp_path):
+    """A first run that hasn't imported anything yet has no dest tree.
+    That's legitimate — not an error."""
+    assert sync_mod.validate_skill_tree(tmp_path / "nope") == {}
+
+
+def test_validate_skill_tree_no_skill_md_files(sync_mod, tmp_path):
+    (tmp_path / "empty").mkdir()
+    assert sync_mod.validate_skill_tree(tmp_path / "empty") == {}
+
+
+def test_validate_skill_tree_detects_broken_skill(sync_mod, tmp_path):
+    """A SKILL.md with missing frontmatter fields surfaces as a failure."""
+    sk = tmp_path / "tree" / "broken"
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text(
+        "---\nname: wrong_name\n---\n# body\n"
+    )
+    failures = sync_mod.validate_skill_tree(tmp_path / "tree")
+    assert len(failures) == 1
+    (skill_dir, errors) = next(iter(failures.items()))
+    assert skill_dir.name == "broken"
+    assert errors  # at least one error message
+
+
+def test_format_validation_failures_mentions_each_skill(sync_mod):
+    # The formatter renders skill paths relative to REPO_ROOT, so the
+    # failure paths must sit under it (in production they always do
+    # because dest_path lives inside the repo being synced into).
+    root = sync_mod.REPO_ROOT
+    failures = {
+        root / "tree" / "sk1": ["err a", "err b"],
+        root / "tree" / "sk2": ["err c"],
+    }
+    text = sync_mod.format_validation_failures(root / "tree", failures)
+    assert "sk1/SKILL.md" in text
+    assert "sk2/SKILL.md" in text
+    assert "err a" in text and "err b" in text and "err c" in text
+
+
+def test_source_from_dict_squash_defaults_true(sync_mod):
+    src = sync_mod.Source.from_dict(
+        {
+            "name": "n",
+            "url": "u",
+            "src_path": "a",
+            "dest_path": "b",
+        }
+    )
+    assert src.squash is True, "squash must default to True for new configs"
+
+
+def test_source_from_dict_squash_explicit_false(sync_mod):
+    src = sync_mod.Source.from_dict(
+        {
+            "name": "n",
+            "url": "u",
+            "src_path": "a",
+            "dest_path": "b",
+            "squash": False,
+        }
+    )
+    assert src.squash is False
+
+
+def test_source_from_dict_squash_string_variants(sync_mod):
+    for val, expected in [
+        ("true", True),
+        ("false", False),
+        ("yes", True),
+        ("no", False),
+        ("1", True),
+        ("0", False),
+    ]:
+        src = sync_mod.Source.from_dict(
+            {
+                "name": "n",
+                "url": "u",
+                "src_path": "a",
+                "dest_path": "b",
+                "squash": val,
+            }
+        )
+        assert src.squash is expected, f"squash={val!r} parsed wrong"
+
+
+def test_source_from_dict_squash_invalid_raises(sync_mod):
+    import pytest as _pytest  # local import; file has pytest imported globally
+    with _pytest.raises(ValueError, match="squash"):
+        sync_mod.Source.from_dict(
+            {
+                "name": "n",
+                "url": "u",
+                "src_path": "a",
+                "dest_path": "b",
+                "squash": 42,
+            }
+        )

--- a/sync-bot/uv.lock
+++ b/sync-bot/uv.lock
@@ -1,0 +1,200 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "opensearch-skills-sync"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "skills-ref" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "skills-ref", specifier = ">=0.1.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "skills-ref"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "strictyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/42/943d3ba8b097af7068b7178563a5062ad8a977982f4a7b4f67facfc575e9/skills_ref-0.1.1.tar.gz", hash = "sha256:6b400ca6e0049be62dca0167ff943ba2745fd67efb37fbba4d0ee341fccd2695", size = 93519, upload-time = "2026-01-10T13:23:41.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/25/36a43c3a61fb6cc3984e6ad5e556929b8ae71c95eba615dae4cf2f427964/skills_ref-0.1.1-py3-none-any.whl", hash = "sha256:d35db5bb8de71ae301daf5ca9cb71f8a555e8c6f83a6d40e46a5bc09f8f461b5", size = 12918, upload-time = "2026-01-10T13:23:40.106Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]

--- a/sync/README.md
+++ b/sync/README.md
@@ -1,0 +1,127 @@
+# Skill Sync
+
+This directory contains the machinery that mirrors skill subdirectories
+from upstream repos into this one.
+
+## Files
+
+- `sources/*.yaml` — one file per upstream source (repo URL, branch,
+  source path, destination path). One-file-per-source keeps merge
+  conflicts localized when multiple sources are added in parallel.
+- `state.json` — last-synced upstream commit SHA per source. Committed
+  to the repo so subsequent runs are incremental. Do not hand-edit
+  unless you also want to reset the import window.
+
+The sync **engine** lives in [`../sync-bot/`](../sync-bot/) as a
+dedicated uv-managed Python package (`opensearch-skills-sync`) with
+its own `pyproject.toml` / `uv.lock`. Invoke it via `uv run
+--project sync-bot opensearch-skills-sync …` — see
+`sync-bot/README.md` for details.
+
+## What the sync does
+
+On each run, for every source:
+
+1. Clone-or-fetch the upstream into `.sync-cache/<name>` (blob-filtered,
+   so it stays small even for large repos).
+2. Read `state.json` for the last-synced upstream SHA.
+3. Enumerate upstream commits that touched `src_path` since then:
+   `git log --reverse --no-merges <last>..<head> -- <src_path>`.
+4. For each such commit:
+   - `git format-patch -1 --relative=<src_path>` produces a patch whose
+     paths are relative to the source subdirectory.
+   - `git am --directory=<dest_path>` applies that patch under the
+     destination path in this repo. `git am` preserves the **original
+     author** and sets the **committer** to the sync bot.
+   - `git commit --amend` rewrites the subject to
+     `[<source-name>] <original subject>` (LLVM-monorepo style) and
+     appends provenance trailers:
+     ```
+     Source-Repo:   <upstream url>
+     Source-Commit: <upstream sha>
+     Co-authored-by: <original author>
+     Signed-off-by: <sync bot>
+     ```
+     Re-runs are idempotent — an already-prefixed subject is not
+     re-prefixed.
+5. Validate the resulting dest tree against the Agent Skills Spec. A
+   spec violation rolls back this source's imports and opens a tracking
+   issue.
+6. Update `state.json` and commit the advance as
+   `[<source-name>] chore(sync): advance state to <sha>`. Push is
+   handled by the workflow.
+
+Original commit messages (minus the one-line subject prefix), dates,
+and authorship are preserved. The GitHub contributor graph for this
+repo credits upstream authors.
+
+## Adding a new source
+
+The whole flow is: **drop one YAML file into `sources/`, push a PR,
+done.** No manual workflow dispatches, no local sync run required.
+
+1. Create `sync/sources/<short-name>.yaml` (~20 lines; copy any
+   existing file as a template):
+
+   ```yaml
+   # sync/sources/some-project.yaml
+   name: some-project                              # stable id; used in state key and commit prefix
+   url: https://github.com/org/some-project.git
+   branch: main
+   src_path: skills                                # subdir in upstream to mirror
+   dest_path: skills/some-project                  # where it lands here (sibling of authored skills)
+   ```
+
+2. Commit and push on a branch, open a PR.
+
+3. `Sync Skills` auto-fires on the PR (it watches `sync/sources/**`).
+   It clones the upstream, replays the history that touched `src_path`
+   into `dest_path`, pushes those commits onto your PR branch, and
+   re-dispatches CI + dry-run validation against the new HEAD.
+
+4. Review the bot's added commits, squash or leave as-is when merging.
+
+Files are loaded in lexicographic order, so the filename doubles as the
+sync-order knob if you ever need one. Duplicate `name:` across files is
+a hard error.
+
+PRs opened from forks skip the auto-push (GitHub won't let workflows
+write to forks) but still run dry-run validation, so config mistakes
+surface before merge.
+
+## Running locally
+
+```bash
+# Sync all sources
+uv run --project sync-bot opensearch-skills-sync
+
+# Sync just one source
+uv run --project sync-bot opensearch-skills-sync --only some-project
+
+# Dry-run (list what would be imported, don't commit)
+uv run --project sync-bot opensearch-skills-sync --dry-run
+
+# Custom sources directory (useful for tests)
+uv run --project sync-bot opensearch-skills-sync --sources-dir path/to/sources
+```
+
+## Failure handling
+
+Each source is processed independently. A failure (bad patch, upstream
+fetch error, conflict, spec-validation violation) aborts any in-progress
+`git am`, hard-resets that source's imports, and moves on. Successful
+sources still commit. The script exits nonzero if any source failed, so
+CI marks the run failed — but the good commits are already in HEAD and
+will be pushed.
+
+Failed sources open (or update) a GitHub issue labelled
+`sync-failure` + `sync-source:<name>`. The issue stays open while the
+source keeps failing with the same error (no comment spam); a new error
+posts a comment; a successful sync auto-closes the issue.
+
+## Resetting a source
+
+To force a full re-import of an upstream, delete its entry from
+`state.json.sources` and commit. The next run will treat it as a
+first-time sync and replay the upstream history (bounded by the
+blob-filtered clone).

--- a/sync/README.md
+++ b/sync/README.md
@@ -125,3 +125,45 @@ To force a full re-import of an upstream, delete its entry from
 `state.json.sources` and commit. The next run will treat it as a
 first-time sync and replay the upstream history (bounded by the
 blob-filtered clone).
+
+## pr-mode (per-source PRs)
+
+The default sync flow above is **push mode** — the bot lands commits
+directly on the target branch, one shared state file, one combined
+history. That's the right choice for the hub repo itself (mirror
+behaviour, immediate availability to agents).
+
+The workflow also supports **pr mode** (`workflow_dispatch` → `mode:
+pr`), which is what the sync-bot framework ships as its externally-
+facing product: for every source with new upstream commits, the bot
+force-pushes a `skills-sync/<source>` branch and opens (or updates) a
+PR from it into the target branch. Each source gets its own PR so
+reviewers see a focused diff and one failing source doesn't block the
+others.
+
+Invariants:
+
+- **No `state.json` writes.** pr-mode derives the last-synced SHA from
+  the `Source-Commit:` trailer on the tip of `skills-sync/<source>`,
+  falling back to the same trailer on the target branch, falling back
+  to "first run". The state is the git history itself, not a file.
+- **Branch reset on every run.** `skills-sync/<source>` is reset to
+  the target branch at the start of each run and then has the
+  upstream commits replayed on top. Manual commits on it are
+  discarded — see `SYNCED_SKILL_POLICY.md` for the "edit upstream
+  instead" flow.
+- **One PR per source.** Even if N upstreams moved in one run, the
+  workflow opens/updates N PRs. A failed source only fails its own
+  PR; the others still publish.
+
+To flip the hub itself to pr-mode, just invoke the workflow with
+`mode: pr`. To invoke it from an automation, `gh workflow run
+sync-skills.yml -f mode=pr`.
+
+## Editing a synced skill
+
+**Don't edit synced files in this repo** — fix the upstream instead,
+and the next sync tick will carry the fix here. See
+[`SYNCED_SKILL_POLICY.md`](./SYNCED_SKILL_POLICY.md) for the full
+rationale and the "break the sync" escape hatch for legitimate
+divergence cases.

--- a/sync/README.md
+++ b/sync/README.md
@@ -160,6 +160,16 @@ To flip the hub itself to pr-mode, just invoke the workflow with
 `mode: pr`. To invoke it from an automation, `gh workflow run
 sync-skills.yml -f mode=pr`.
 
+### Repo-level prereq for pr-mode
+
+pr-mode uses `GITHUB_TOKEN` to open PRs, which requires the repo to
+allow Actions to create pull requests. Enable it once at **Settings →
+Actions → General → Workflow permissions → "Allow GitHub Actions to
+create and approve pull requests"**. A user/org-level toggle with the
+same name does **not** override a repo-level OFF — GitHub evaluates
+the most restrictive. Symptom if missing: `gh pr create` fails with
+`GitHub Actions is not permitted to create or approve pull requests`.
+
 ## Editing a synced skill
 
 **Don't edit synced files in this repo** — fix the upstream instead,

--- a/sync/SYNCED_SKILL_POLICY.md
+++ b/sync/SYNCED_SKILL_POLICY.md
@@ -1,0 +1,95 @@
+# Synced Skill Policy
+
+If you landed here from a link in a pull-request body, this document
+explains **why editing a synced skill directly in this repo is almost
+never what you want** — and what to do instead.
+
+## TL;DR
+
+Skills under a `dest_path` declared in `sync/sources/*.yaml` are
+**mirrored from an upstream repo**. The sync bot reruns on a cron and
+**replays upstream history on top of the destination branch**, which
+overwrites any local edits on the next run.
+
+- **Bug / feature / wording change** → fix it **upstream**, in the
+  repo listed under `Source-Repo:` in the commit trailer. The fix will
+  land here automatically on the next sync tick.
+- **Policy exception** (must diverge from upstream) → see
+  [Breaking the sync](#breaking-the-sync) below.
+- **Deleting a skill** → delete the `sync/sources/<name>.yaml` entry
+  and remove `dest_path` in the same PR; the bot will stop mirroring.
+
+## Why not just edit here?
+
+The sync bot is append-only on the upstream → hub edge: it takes every
+upstream commit that touched `src_path` and replays it at `dest_path`.
+It does **not** detect, preserve, or merge hub-local edits inside
+`dest_path`. Two modes, same outcome for you:
+
+- **push mode** (default for most sources): the bot commits directly
+  onto `main`. A hub-local edit to a synced file will survive until
+  the next upstream commit on the same file, at which point
+  `git am` will hit a conflict and roll back that source's entire
+  incremental window. Your edit wins the short term but **blocks all
+  future upstream syncs** for that source until someone resolves it.
+- **pr mode**: the bot resets `skills-sync/<source>` to `main` on every
+  run and replays upstream on top. Any edit you push to that branch is
+  discarded on the next cron tick. Edits to `main` under a pr-mode
+  `dest_path` survive locally but diverge silently from upstream — the
+  sync bot will keep opening PRs that revert your change.
+
+Neither is good. Both produce the same message in code review: "this
+file is synced; fix it upstream."
+
+## How to tell if a skill is synced
+
+Check `sync/sources/*.yaml`. If your file path starts with any
+`dest_path` listed there, it's synced. Every commit the sync bot lands
+also carries trailers:
+
+```
+Source-Repo:   https://github.com/<org>/<repo>.git
+Source-Commit: <upstream sha>
+Co-authored-by: <original author> <...>
+```
+
+`git log --format=%B <path> | grep '^Source-'` tells you quickly.
+
+## Where to send the PR
+
+1. Open the upstream repo from `Source-Repo:`.
+2. Find the file at the path under the upstream's `src_path` that
+   mirrors to this `dest_path`. (Example: this repo's
+   `skills/opensearch-migrations/<x>` is the upstream's
+   `skills/<x>`.)
+3. PR the fix there. Once it merges, the next sync run (≤5 min for
+   cron, immediate for `workflow_dispatch`) will carry it over.
+
+## Breaking the sync
+
+If you genuinely need to diverge from upstream — upstream is
+unmaintained, the fix is blocked there, or the skill here needs a
+hub-specific tweak — the supported path is to **detach the skill from
+the sync**:
+
+1. In the same PR: remove or rename the affected `dest_path` entry
+   in `sync/sources/<source>.yaml` (or narrow `src_path` to exclude
+   this skill).
+2. Move the skill files out of the synced tree (e.g., rename the
+   directory). This turns them into hub-authored skills.
+3. Now edit freely.
+
+Detaching is cheap and reversible — you can re-attach later by
+restoring the mapping, at which point the next sync replays upstream
+on top of the hub copy. It is **strictly better** than fighting the
+bot in-place.
+
+## Why this policy exists
+
+Skills here get pulled by agents across many tasks. Silent divergence
+between the hub copy and the upstream copy means an agent reads
+different instructions in different contexts, which is worse than
+either version alone. The sync bot's job is to keep that divergence
+visible and auditable.
+
+See `sync/README.md` for the mechanical details of how the sync works.

--- a/sync/sources/README.md
+++ b/sync/sources/README.md
@@ -1,0 +1,63 @@
+# Sync sources
+
+One YAML file per upstream repo whose skills we mirror into this one.
+
+## Add a new source (PR-driven — fully automated)
+
+1. Copy any existing `*.yaml` in this directory as a template.
+2. Edit the five fields (`name`, `url`, `branch`, `src_path`,
+   `dest_path`). Keep `name` matching the filename for sanity.
+3. Commit on a branch, push, open a PR.
+
+That's it. The `Sync Skills` workflow auto-runs on every PR that
+touches `sync/sources/**`: it replays the upstream history that
+touched `src_path` into `dest_path`, pushes those commits onto your
+PR branch, and re-runs CI + dry-run validation against the post-sync
+HEAD. Review the result, then merge.
+
+## Minimal template (21 lines)
+
+```yaml
+# Sync source: <short-name>
+#
+# Mirrors <upstream thing> from <upstream repo>.
+#
+# Schema:
+#   name:      unique short id (filename, state key, commit prefix)
+#   url:       upstream git URL
+#   branch:    upstream branch to track
+#   src_path:  subdirectory in the upstream repo whose history we import
+#   dest_path: where that subdirectory lands in this repo
+#   squash:    optional (default: true). When true, all commits imported
+#              for THIS source in a single sync run are collapsed into
+#              one commit on main. Per-source: unrelated sources in the
+#              same run get their own squashed commits. Original authors
+#              are preserved as Co-authored-by trailers so GitHub
+#              attribution survives. Set to false to keep one-to-one
+#              per-commit history (noisier but exact).
+name: <short-name>
+url: https://github.com/<org>/<repo>.git
+branch: main
+src_path: skills/<upstream-skill-dir>
+# dest_path's leaf MUST match the upstream SKILL.md `name:` field —
+# the Agent Skills Spec validator enforces this.
+dest_path: skills/<upstream-skill-dir>
+```
+
+## Rules
+
+- `name` must be unique across all files in this directory (hard error otherwise).
+- `dest_path`'s leaf directory name must equal the upstream SKILL.md's
+  `name:` field — the spec validator in `sync.py` enforces this and
+  rolls back the import on mismatch.
+- Files are processed in lexicographic order.
+
+## Troubleshooting
+
+If the auto-sync fails on your PR, `Sync Skills` will open (or update)
+a tracking issue labelled `sync-failure` + `sync-source:<name>` with
+the error. Fix the YAML, push again, and the issue auto-closes on the
+next successful sync.
+
+For full details on the sync engine and commit-rewriting semantics see
+[../README.md](../README.md).

--- a/sync/state.json
+++ b/sync/state.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "sources": {}
+}


### PR DESCRIPTION
## Summary

Adds a framework for mirroring agent-skill subdirectories from upstream
repositories into `skills/` on a schedule, preserving per-commit
authorship and history. Lets skills live in the project they ship
alongside (e.g. an integration skill for tool X, authored in tool X's
repo) while still surfacing in this catalog without copy-paste rot.

**This PR lands the framework only — no sources are registered, so no
runtime behavior changes until a source YAML is added in a follow-up.**

## How it works (1-minute version)

- One YAML file per upstream source under `sync/sources/` declares
  `url`, `branch`, `src_path`, `dest_path`, and `mode: pr | push`.
- A scheduled workflow (`Sync Skills`) runs every 20 min (fast path
  via `workflow_dispatch` on source-YAML PRs).
- For each source, the engine:
  1. clones upstream (blob-filtered, cached between runs),
  2. enumerates commits touching `src_path` since the last-synced SHA
     (tracked per-source in `sync/state.json`),
  3. replays each as its own commit here via
     `git format-patch | git am --directory=<dest_path>`,
  4. prefixes the subject with `[<source-name>]` and appends
     `Source-Repo` / `Source-Commit` / `Co-authored-by` trailers. The
     original author + date survive, so the GitHub contributor graph
     credits the upstream author.
- `sync/state.json` advances atomically per-source so subsequent runs
  are incremental.
- **Per-source isolation:** a failure in one source (bad patch, spec
  violation, upstream outage) opens a tracking issue via `gh` and does
  not block the others.
- **Opt-in squash:** `squash: true` on a source collapses that source's
  imports into one `[<name>] …` commit per sync run, with every
  upstream author preserved as `Co-authored-by`. Off by default.

Full semantics in [`sync/README.md`](../blob/sync/propose-framework/sync/README.md).
Engine source + tests in [`sync-bot/`](../blob/sync/propose-framework/sync-bot/).

## Sync modes (per source)

Each source picks one of:

- **`mode: pr`** *(recommended for this repo)* — the bot opens /
  updates `skills-sync/<source>` and pushes a PR. Normal review +
  **existing CI checks run on the PR branch** (the sync workflow also
  re-dispatches `ci.yml` / `validate-skills.yml` / `sync-bot-ci.yml`
  against that branch because `GITHUB_TOKEN` pushes don't retrigger
  `pull_request`). Nothing reaches `main` without maintainer approval.
- **`mode: push`** — the bot commits directly to `main`. Intended for
  mirrors where CI has already approved the content upstream; this PR
  keeps it available for maintainers who want it, but it is **not**
  the recommended default for this repo.

No sources are registered in this PR; maintainers choose the mode
per source as they add them.

## What happens if someone PRs a synced skill here

Covered by [`sync/SYNCED_SKILL_POLICY.md`](../blob/sync/propose-framework/sync/SYNCED_SKILL_POLICY.md),
which is linked from every synced-skill PR body. TL;DR:

- The PR template and policy doc redirect bug / feature / wording
  changes to the upstream repo listed in the commit's `Source-Repo:`
  trailer. Once merged upstream, the next sync tick carries the fix
  over here automatically.
- If a hub-specific divergence is genuinely needed, the supported path
  is to **detach the skill from the sync** in the same PR (remove or
  narrow the `sync/sources/<name>.yaml` entry, optionally rename the
  directory). That turns it into a hub-authored skill and makes the
  divergence explicit in git history.
- Hand-editing a synced file without detaching is discouraged: in
  push-mode it blocks future syncs at the next upstream touch; in
  pr-mode the bot-opened PR will keep reverting it.

## What's in this PR

```
New:
  sync/README.md                  Framework overview + semantics
  sync/SYNCED_SKILL_POLICY.md     Policy for edits to synced skills
  sync/sources/README.md          How to add a new source
  sync/state.json                 {"version":1,"sources":{}}
  sync-bot/                       Standalone uv-managed package
                                    - opensearch-skills-sync CLI
                                    - 40 unit + integration tests
  .github/workflows/
    sync-skills.yml               */20 cron + workflow_dispatch
                                    + auto-run on sync-config PRs
    validate-skills.yml           Dry-run spec validation (fork-safe)
    sync-bot-ci.yml               Engine tests (Linux + macOS)

Modified (minimal, additive):
  .github/workflows/ci.yml        + workflow_dispatch trigger
                                    (so sync-skills can re-dispatch
                                     CI on post-sync HEAD / PR branch)
  .gitignore                      + .sync-cache/ (regenerable clones)
  AGENTS.md                       + one-line pointer under
                                    "Architecture Notes"
  DEVELOPER_GUIDE.md              + "Mirroring an Upstream Skill"
                                    section
```

No files under `skills/`, `tests/`, or `scripts/` are touched.

## Adding a source (for reviewers — not in this PR)

```yaml
# sync/sources/<short-name>.yaml
name: <short-name>
url: https://github.com/<org>/<repo>.git
branch: main
src_path: skills/<upstream-skill-dir>
dest_path: skills/<upstream-skill-dir>
mode: pr           # recommended; use `push` only when the mirror is
                   # considered authoritative and needs no review here
# squash: true     # optional, default false
```

Commit, open a PR — `Sync Skills` auto-fires, replays upstream history
onto the sync branch, CI re-runs against the post-sync tree. Review
the replayed commits, merge.

## Identity / secrets

- Sync commits use identity `opensearch-ci` /
  `83309141+opensearch-ci-bot@users.noreply.github.com` (the existing
  opensearch-project CI bot, GitHub user id 83309141). Configurable via
  `SYNC_BOT_NAME` / `SYNC_BOT_EMAIL` workflow env.
- Uses the default `GITHUB_TOKEN` only — no new secrets required.
- `contents: write` + `issues: write` + `pull-requests: write` scopes
  (issues/PRs only for the failure-reporter + pr-mode; reporter
  silently skips when auth is missing).

## Validation

- `uv run --project sync-bot pytest` → **40 passed** (3.7s)
- `uv run --project sync-bot opensearch-skills-sync --dry-run` on this
  branch's empty `sync/sources/` → clean exit:
  `[sync] no sources defined under .../sync/sources, nothing to do`
- Existing repo tests untouched.

## Prior art

This framework has been running on a fork
(`AndreKurait/opensearch-agent-skills`). The code being proposed here is
the same engine (repo URLs scrubbed to `opensearch-project/…`), minus
the fork's experimental sources.

## Not in scope / follow-ups

- No sources are registered in this PR — maintainers decide which
  upstreams (if any) to pull in, and at what mode.
- A tiny `scripts/` wrapper could hide the
  `uv run --project sync-bot …` invocation — deferred until there's
  demand.

### Checklist

- [x] DCO sign-off on the commit
- [x] Framework tests green (40/40)
- [x] No changes to existing skills/tests
- [x] Docs: `DEVELOPER_GUIDE.md`, `AGENTS.md`, `sync/README.md`,
      `sync/SYNCED_SKILL_POLICY.md`, `sync/sources/README.md`,
      `sync-bot/README.md` all updated
