### PR TITLE
feat(sync): add sync/config.yaml + preflight to fail fast on push-to-protected

### DIFF
--- a/.github/actions/sync-preflight/action.yml
+++ b/.github/actions/sync-preflight/action.yml
@@ -1,0 +1,172 @@
+name: 'Sync Skills Preflight'
+description: >-
+  Validate that the configured sync mode is compatible with the target
+  branch's protection state before the sync engine does anything
+  destructive. Fails fast when `mode=push` is pointed at a protected
+  branch (which would hit GH006 "protected branch hook declined" on
+  the push step).
+
+  Also surfaces Actions-level permission misconfigurations that commonly
+  break pr-mode (GITHUB_TOKEN lacking write + can_approve_pull_request_reviews).
+
+inputs:
+  mode:
+    description: >-
+      Sync mode to validate: push | pr | dry-run. `push` = land imports
+      directly on target branch. `pr` = open one PR per source. `dry-run`
+      = no mutations at all.
+    required: true
+  target-branch:
+    description: >-
+      Branch the engine would push to (push-mode) or open PRs against
+      (pr-mode). Typically `main`.
+    required: true
+  github-token:
+    description: >-
+      Token with repo read scope. GITHUB_TOKEN is fine. Used to query
+      branch protection status and Actions permissions.
+    required: true
+  strict:
+    description: >-
+      If true (default), fail on any incompatibility. If false, print
+      warnings instead of failing. Use strict=false only for advisory
+      modes like post-run audits.
+    required: false
+    default: 'true'
+
+outputs:
+  protected:
+    description: 'true|false|unknown — whether target-branch reports protected'
+    value: ${{ steps.check.outputs.protected }}
+  compatible:
+    description: 'true|false — whether the supplied mode is compatible with branch state'
+    value: ${{ steps.check.outputs.compatible }}
+
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      env:
+        # Pass inputs through env to avoid direct interpolation into
+        # the bash script (GitHub security best practice — see the
+        # actionlint-workflow-inputs-via-env recipe).
+        MODE: ${{ inputs.mode }}
+        TARGET: ${{ inputs.target-branch }}
+        STRICT: ${{ inputs.strict }}
+        REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        echo "::group::sync-preflight: inputs"
+        echo "repository:    ${REPO}"
+        echo "mode:          ${MODE}"
+        echo "target-branch: ${TARGET}"
+        echo "strict:        ${STRICT}"
+        echo "::endgroup::"
+
+        # --- 1. Validate mode value -------------------------------------
+        case "${MODE}" in
+          push|pr|dry-run) ;;
+          *)
+            echo "::error::sync-preflight: unknown mode '${MODE}' (must be push | pr | dry-run)"
+            exit 1
+            ;;
+        esac
+
+        # --- 2. Query target branch protection -------------------------
+        # /repos/{owner}/{repo}/branches/{branch} returns `.protected`
+        # (bool) with just `contents: read`. Surface any API error so a
+        # future "preflight silently passed" bug is obvious instead of
+        # hidden by a redirect to /dev/null.
+        #
+        # jq caveat: `.protected // "unknown"` wrongly substitutes when
+        # .protected is present but `false`, because jq's // treats
+        # `false` as a "null-ish" fallback trigger. Use `if has(...)`
+        # to distinguish "missing" from "explicitly false".
+        PROTECTED="unknown"
+        BRANCH_STDERR="$(mktemp)"
+        if BRANCH_JSON="$(gh api "repos/${REPO}/branches/${TARGET}" 2>"${BRANCH_STDERR}")"; then
+          BRANCH_PROTECTED="$(echo "${BRANCH_JSON}" | jq -r 'if has("protected") then .protected else "unknown" end')"
+          if [[ "${BRANCH_PROTECTED}" == "true" || "${BRANCH_PROTECTED}" == "false" ]]; then
+            PROTECTED="${BRANCH_PROTECTED}"
+          fi
+        else
+          # gh api exited non-zero. Show why so operators can fix the
+          # token scope (or whatever is blocking the read). We still
+          # continue — the push step itself will fail loudly on a real
+          # block, so "preflight couldn't read protection" is advisory.
+          echo "::warning::sync-preflight: could not read repos/${REPO}/branches/${TARGET}:"
+          sed 's/^/::warning::sync-preflight:   /' "${BRANCH_STDERR}"
+        fi
+        rm -f "${BRANCH_STDERR}"
+        echo "protected=${PROTECTED}" >> "${GITHUB_OUTPUT}"
+        echo "sync-preflight: target '${TARGET}' protected=${PROTECTED}"
+
+        # --- 3. Compatibility matrix -----------------------------------
+        # push + protected = guaranteed GH006 failure.
+        # pr + protected   = OK (PRs are the point of branch protection).
+        # pr + unprotected = OK (weird but harmless).
+        # dry-run          = always OK.
+        COMPATIBLE="true"
+        VIOLATION=""
+        if [[ "${MODE}" == "push" && "${PROTECTED}" == "true" ]]; then
+          COMPATIBLE="false"
+          VIOLATION="mode=push is incompatible with protected branch '${TARGET}'."
+        fi
+        echo "compatible=${COMPATIBLE}" >> "${GITHUB_OUTPUT}"
+
+        # --- 4. Actions-level permission sanity check ------------------
+        # pr-mode requires can_approve_pull_request_reviews=true and
+        # default_workflow_permissions=write. These are repo-level
+        # settings (Settings -> Actions -> General -> Workflow
+        # permissions). See the gha-pr-permissions-two-layers recipe
+        # for why the user/org-level toggle with the same name is not
+        # enough.
+        if [[ "${MODE}" == "pr" ]]; then
+          ACTIONS_PERMS_JSON="$(gh api "repos/${REPO}/actions/permissions/workflow" 2>/dev/null || true)"
+          if [[ -n "${ACTIONS_PERMS_JSON}" ]]; then
+            DEFAULT_PERMS="$(echo "${ACTIONS_PERMS_JSON}" | jq -r '.default_workflow_permissions // "unknown"')"
+            CAN_APPROVE="$(echo "${ACTIONS_PERMS_JSON}" | jq -r '.can_approve_pull_request_reviews // "unknown"')"
+            echo "sync-preflight: actions default_workflow_permissions=${DEFAULT_PERMS} can_approve_pull_request_reviews=${CAN_APPROVE}"
+            # Only fail when we can *read* the settings AND they are
+            # definitively incompatible. "unknown" means the token
+            # can't see them (e.g. fine-grained PAT or running against
+            # a repo we don't administer) — don't block on that.
+            if [[ "${DEFAULT_PERMS}" != "unknown" && "${CAN_APPROVE}" != "unknown" ]] \
+               && ( [[ "${DEFAULT_PERMS}" != "write" ]] || [[ "${CAN_APPROVE}" != "true" ]] ); then
+              if [[ "${STRICT}" == "true" ]]; then
+                echo "::error::sync-preflight: mode=pr requires Actions workflow permissions set to write AND 'Allow GitHub Actions to create and approve pull requests'. Current: default_workflow_permissions=${DEFAULT_PERMS}, can_approve_pull_request_reviews=${CAN_APPROVE}. Fix: Settings -> Actions -> General -> Workflow permissions, or:"
+                echo "::error::  gh api -X PUT repos/${REPO}/actions/permissions/workflow -F default_workflow_permissions=write -F can_approve_pull_request_reviews=true"
+                exit 1
+              else
+                echo "::warning::sync-preflight: Actions permissions look incompatible with pr-mode (default=${DEFAULT_PERMS}, can_approve=${CAN_APPROVE}) but strict=false, continuing."
+              fi
+            elif [[ "${DEFAULT_PERMS}" == "unknown" || "${CAN_APPROVE}" == "unknown" ]]; then
+              echo "sync-preflight: Actions permissions not readable with current token; skipping that assertion. The push step will surface any real misconfig."
+            fi
+          else
+            echo "::warning::sync-preflight: could not read Actions workflow permissions (token scope?). Skipping that check."
+          fi
+        fi
+
+        # --- 5. Fail or warn on branch-protection incompatibility ------
+        if [[ "${COMPATIBLE}" == "false" ]]; then
+          ERR="sync-preflight: ${VIOLATION}"
+          FIX1="Set cron.mode=pr in sync/config.yaml (or workflow_dispatch input mode=pr) to open PRs instead of pushing directly."
+          FIX2="Or disable branch protection on '${TARGET}' (not recommended for shared repos)."
+          FIX3="Or run with dry_run=true to validate config without mutating."
+          if [[ "${STRICT}" == "true" ]]; then
+            echo "::error::${ERR}"
+            echo "::error::${FIX1}"
+            echo "::error::${FIX2}"
+            echo "::error::${FIX3}"
+            exit 1
+          else
+            echo "::warning::${ERR}"
+            echo "::warning::${FIX1}"
+          fi
+        else
+          echo "sync-preflight: mode=${MODE} + protected=${PROTECTED} -> COMPATIBLE"
+        fi

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -12,6 +12,9 @@ name: Sync Skills
 #
 # If any source fails the workflow still commits + pushes successful
 # sources, then fails the job at the end so the failure is visible.
+#
+# Mode + bot identity come from sync/config.yaml (single source of
+# truth). workflow_dispatch `mode` can override for a one-off run.
 
 on:
   schedule:
@@ -31,19 +34,18 @@ on:
         default: false
       mode:
         description: >-
-          Sync mode. push = land imports directly on the target branch (hub
-          mirror behaviour, used by cron). pr = isolate each source on a
-          `skills-sync/<name>` branch, force-push it, and open/update a PR
-          from that branch into the target branch (one PR per source, one
-          failing source doesn't block others).
+          One-off mode override. Leave empty to use sync/config.yaml.
+          push = land imports directly on the target branch.
+          pr   = open/update one PR per source.
         required: false
         type: choice
-        default: push
+        default: ''
         options:
+          - ''
           - push
           - pr
   # Auto-fire on PRs that add/edit a source YAML or touch the sync
-  # engine. This lets a contributor just commit
+  # engine / config. This lets a contributor just commit
   # `sync/sources/<name>.yaml` and have the mirrored content appear on
   # their branch without any manual dispatch.
   #
@@ -53,8 +55,10 @@ on:
   pull_request:
     paths:
       - 'sync/sources/**'
+      - 'sync/config.yaml'
       - 'sync-bot/**'
       - '.github/workflows/sync-skills.yml'
+      - '.github/actions/sync-preflight/**'
 
 # Prevent overlapping runs on the same ref. Cron and PR runs use
 # different groups so a slow cron doesn't block PR feedback.
@@ -95,6 +99,46 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      # Single source of truth. Fails loudly if the file is missing or
+      # malformed — we'd rather break one run than let the cron quietly
+      # use stale workflow defaults.
+      - name: Load sync config
+        id: config
+        env:
+          MODE_OVERRIDE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          CONFIG=sync/config.yaml
+          if [[ ! -f "${CONFIG}" ]]; then
+            echo "::error::${CONFIG} is missing. Every sync-consuming workflow reads this file; restore it before re-running."
+            exit 1
+          fi
+          MODE_FROM_FILE="$(yq -r '.cron.mode // ""' "${CONFIG}")"
+          STRICT="$(yq -r '.cron.strict_preflight // true' "${CONFIG}")"
+          BOT_NAME="$(yq -r '.bot.name // ""' "${CONFIG}")"
+          BOT_EMAIL="$(yq -r '.bot.email // ""' "${CONFIG}")"
+          for pair in "cron.mode=${MODE_FROM_FILE}" "bot.name=${BOT_NAME}" "bot.email=${BOT_EMAIL}"; do
+            key="${pair%%=*}"
+            val="${pair#*=}"
+            if [[ -z "${val}" ]]; then
+              echo "::error::${CONFIG} is missing required key '${key}'."
+              exit 1
+            fi
+          done
+          # workflow_dispatch mode input wins when non-empty.
+          MODE="${MODE_OVERRIDE:-${MODE_FROM_FILE}}"
+          case "${MODE}" in
+            push|pr) ;;
+            *) echo "::error::Resolved mode='${MODE}' is invalid (must be push | pr)."; exit 1 ;;
+          esac
+          {
+            echo "mode=${MODE}"
+            echo "strict=${STRICT}"
+            echo "bot_name=${BOT_NAME}"
+            echo "bot_email=${BOT_EMAIL}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "sync config resolved: mode=${MODE} strict=${STRICT} bot=${BOT_NAME} <${BOT_EMAIL}>"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -133,20 +177,32 @@ jobs:
             echo "branch=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
+      # Fail fast if the configured mode is incompatible with the target
+      # branch's protection state. Catches the "cron tries push-mode
+      # against protected main" case (GH006) up front instead of after
+      # the engine has already mutated the working tree. See
+      # .github/actions/sync-preflight/action.yml for the matrix.
+      - name: Preflight (mode vs branch protection)
+        if: ${{ inputs.dry_run != 'true' }}
+        uses: ./.github/actions/sync-preflight
+        with:
+          mode: ${{ steps.config.outputs.mode }}
+          target-branch: ${{ steps.target.outputs.branch }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          strict: ${{ steps.config.outputs.strict }}
+
       - name: Run sync
         id: sync
         env:
-          SYNC_BOT_NAME: 'opensearch-ci'
-          SYNC_BOT_EMAIL: '83309141+opensearch-ci-bot@users.noreply.github.com'
+          SYNC_BOT_NAME: ${{ steps.config.outputs.bot_name }}
+          SYNC_BOT_EMAIL: ${{ steps.config.outputs.bot_email }}
           # `gh` CLI authentication for the in-script issue reporter.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Pass inputs through env to avoid direct interpolation into
           # bash scripts (GitHub security best practice).
           ONLY_INPUT: ${{ inputs.only }}
           DRY_RUN_INPUT: ${{ inputs.dry_run }}
-          # inputs.mode is only set for workflow_dispatch; default to
-          # push for cron and pull_request triggers.
-          MODE_INPUT: ${{ inputs.mode || 'push' }}
+          MODE_INPUT: ${{ steps.config.outputs.mode }}
         run: |
           set -euo pipefail
           ARGS=()

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -2,11 +2,13 @@ name: Validate Skills Sync (dry-run)
 
 # Runs the skill-sync engine in --dry-run mode on every PR and on every
 # branch push (except main, which is covered by the scheduled Sync Skills
-# workflow).
+# workflow). Also preflight-checks that the configured cron mode (from
+# sync/config.yaml) is compatible with the default branch — so a PR
+# that would break the scheduled cron is red before it merges.
 #
 # Purpose: catch broken sync configuration — unreachable upstreams, wrong
 # branch names, typo'd src_path, etc. — before the change lands on main
-# and the cron starts failing every 5 minutes.
+# and the cron starts failing every 20 minutes.
 #
 # Dry-run contract:
 #   * `opensearch-skills-sync --dry-run` still exits 1 if any source fails
@@ -19,17 +21,21 @@ on:
     # Re-run when the workflow itself or anything the sync depends on changes.
     paths:
       - 'sync/sources/**'
+      - 'sync/config.yaml'
       - 'sync-bot/**'
       - '.github/workflows/validate-skills.yml'
       - '.github/workflows/sync-skills.yml'
+      - '.github/actions/sync-preflight/**'
   push:
     branches-ignore:
       - main
     paths:
       - 'sync/sources/**'
+      - 'sync/config.yaml'
       - 'sync-bot/**'
       - '.github/workflows/validate-skills.yml'
       - '.github/workflows/sync-skills.yml'
+      - '.github/actions/sync-preflight/**'
   # Allows sync-skills.yml to re-dispatch validation against a PR branch
   # after the bot pushes to it (GITHUB_TOKEN pushes don't retrigger pull_request).
   workflow_dispatch:
@@ -54,6 +60,41 @@ jobs:
           # origin/main diffs, not for the upstream repos (which it
           # clones fresh). Keep shallow.
           fetch-depth: 1
+
+      # Single source of truth. Same logic as sync-skills.yml's
+      # Load sync config step — keep them in lockstep.
+      - name: Load sync config
+        id: config
+        run: |
+          set -euo pipefail
+          CONFIG=sync/config.yaml
+          if [[ ! -f "${CONFIG}" ]]; then
+            echo "::error::${CONFIG} is missing. This PR would break the scheduled cron."
+            exit 1
+          fi
+          MODE="$(yq -r '.cron.mode // ""' "${CONFIG}")"
+          STRICT="$(yq -r '.cron.strict_preflight // true' "${CONFIG}")"
+          BOT_NAME="$(yq -r '.bot.name // ""' "${CONFIG}")"
+          BOT_EMAIL="$(yq -r '.bot.email // ""' "${CONFIG}")"
+          for pair in "cron.mode=${MODE}" "bot.name=${BOT_NAME}" "bot.email=${BOT_EMAIL}"; do
+            key="${pair%%=*}"
+            val="${pair#*=}"
+            if [[ -z "${val}" ]]; then
+              echo "::error::${CONFIG} is missing required key '${key}'."
+              exit 1
+            fi
+          done
+          case "${MODE}" in
+            push|pr) ;;
+            *) echo "::error::cron.mode='${MODE}' is invalid (must be push | pr)."; exit 1 ;;
+          esac
+          {
+            echo "mode=${MODE}"
+            echo "strict=${STRICT}"
+            echo "bot_name=${BOT_NAME}"
+            echo "bot_email=${BOT_EMAIL}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "sync config resolved: mode=${MODE} strict=${STRICT} bot=${BOT_NAME} <${BOT_EMAIL}>"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -84,11 +125,23 @@ jobs:
         env:
           # Bot identity is set even in dry-run because the sync creates
           # commits locally (just never pushes them) to compute diffs.
-          SYNC_BOT_NAME: 'opensearch-ci'
-          SYNC_BOT_EMAIL: '83309141+opensearch-ci-bot@users.noreply.github.com'
+          SYNC_BOT_NAME: ${{ steps.config.outputs.bot_name }}
+          SYNC_BOT_EMAIL: ${{ steps.config.outputs.bot_email }}
           # Deliberately NOT setting GH_TOKEN: dry-run skips the issue
           # reporter anyway, and omitting the token makes that guarantee
           # mechanical (no accidental gh-CLI mutations from a PR).
         run: |
           set -euo pipefail
           uv run --project sync-bot opensearch-skills-sync --dry-run
+
+      # Preflight: validate that the configured cron mode from
+      # sync/config.yaml is compatible with the default branch's
+      # protection state. The PR is red until either the config file or
+      # the branch-protection state is fixed.
+      - name: Preflight cron mode against default branch
+        uses: ./.github/actions/sync-preflight
+        with:
+          mode: ${{ steps.config.outputs.mode }}
+          target-branch: ${{ github.event.repository.default_branch }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          strict: ${{ steps.config.outputs.strict }}

--- a/sync-bot/tests/test_preflight_action.sh
+++ b/sync-bot/tests/test_preflight_action.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Local integration test for sync-preflight action.yml.
+#
+# Runs the preflight bash block against real repos with real gh CLI
+# auth, asserting exit codes match the compatibility matrix:
+#
+#   mode    target repo                            expected
+#   push    opensearch-project (protected)         1 (fail)
+#   pr      opensearch-project (protected)         0 (OK, PRs fine)
+#   dry-run any                                    0 (OK)
+#   bogus   any                                    1 (fail on mode validation)
+#
+# This inlines the action's `run:` block because act+composite-actions
+# locally is flaky; the bash is the contract and is what we test.
+set -uo pipefail
+
+ACTION_FILE="$(dirname "$(realpath "$0")")/../../.github/actions/sync-preflight/action.yml"
+if [[ ! -f "${ACTION_FILE}" ]]; then
+  echo "Cannot find action.yml at ${ACTION_FILE}"
+  exit 2
+fi
+
+# Extract the `run: |` block from the composite step via yq.
+# Fall back to python if yq missing.
+extract_run_block() {
+  if command -v yq >/dev/null 2>&1; then
+    yq '.runs.steps[0].run' "${ACTION_FILE}"
+  else
+    python3 -c "
+import sys, yaml
+with open('${ACTION_FILE}') as f:
+    doc = yaml.safe_load(f)
+print(doc['runs']['steps'][0]['run'])
+"
+  fi
+}
+
+RUN_BLOCK="$(extract_run_block)"
+if [[ -z "${RUN_BLOCK}" ]]; then
+  echo "Failed to extract run block from action.yml"
+  exit 2
+fi
+
+# Synthesize a GITHUB_OUTPUT file so the block doesn't error on the
+# redirects. We don't assert outputs here — exit code IS the contract.
+TMP_OUT="$(mktemp)"
+trap 'rm -f "${TMP_OUT}"' EXIT
+
+run_case() {
+  local label="$1" mode="$2" target="$3" repo="$4" strict="$5" expected="$6"
+  : > "${TMP_OUT}"
+
+  # shellcheck disable=SC2034
+  MODE="${mode}" \
+  TARGET="${target}" \
+  STRICT="${strict}" \
+  REPO="${repo}" \
+  GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-$(gh auth token)}}" \
+  GITHUB_OUTPUT="${TMP_OUT}" \
+  bash -c "${RUN_BLOCK}" >/tmp/preflight.stdout 2>/tmp/preflight.stderr
+  local rc=$?
+
+  if [[ ${rc} -eq ${expected} ]]; then
+    echo "PASS  ${label}  (rc=${rc})"
+  else
+    echo "FAIL  ${label}  (rc=${rc}, expected=${expected})"
+    echo "----- stdout -----"
+    cat /tmp/preflight.stdout
+    echo "----- stderr -----"
+    cat /tmp/preflight.stderr
+    echo "----- outputs -----"
+    cat "${TMP_OUT}"
+    return 1
+  fi
+}
+
+FAIL=0
+
+# --- Unit regression for the jq-false-is-falsy bug ---
+# Make sure the action distinguishes `.protected: false` (unprotected,
+# API responded) from missing/error (truly unknown). The earlier
+# `.protected // "unknown"` form collapsed both to "unknown", which
+# silently turned the preflight into a placebo on unprotected repos.
+JQ_EXPR='if has("protected") then .protected else "unknown" end'
+EXPECT_PAIRS=(
+  '{"protected":false}|false'
+  '{"protected":true}|true'
+  '{}|unknown'
+  '{"name":"main"}|unknown'
+)
+for pair in "${EXPECT_PAIRS[@]}"; do
+  JSON="${pair%%|*}"
+  WANT="${pair##*|}"
+  GOT="$(echo "${JSON}" | jq -r "${JQ_EXPR}")"
+  if [[ "${GOT}" == "${WANT}" ]]; then
+    echo "PASS  jq-regression  ${JSON} -> ${GOT}"
+  else
+    echo "FAIL  jq-regression  ${JSON} -> ${GOT} (want ${WANT})"
+    FAIL=1
+  fi
+done
+
+run_case "push -> PROTECTED upstream main (expect FAIL GH006 preempt)" \
+  push main opensearch-project/opensearch-agent-skills true 1 || FAIL=1
+
+run_case "pr -> PROTECTED upstream main (expect OK: PRs are the point)" \
+  pr main opensearch-project/opensearch-agent-skills true 0 || FAIL=1
+
+run_case "dry-run -> anywhere (expect OK)" \
+  dry-run main opensearch-project/opensearch-agent-skills true 0 || FAIL=1
+
+run_case "bogus mode (expect FAIL on validation)" \
+  pushh main opensearch-project/opensearch-agent-skills true 1 || FAIL=1
+
+run_case "push -> PROTECTED + strict=false (expect OK with warning)" \
+  push main opensearch-project/opensearch-agent-skills false 0 || FAIL=1
+
+if [[ ${FAIL} -eq 0 ]]; then
+  echo
+  echo "=== All preflight cases PASSED ==="
+else
+  echo
+  echo "=== Preflight test FAILURES above ==="
+  exit 1
+fi

--- a/sync/config.yaml
+++ b/sync/config.yaml
@@ -1,0 +1,17 @@
+# Skill-sync framework configuration.
+# Read by .github/workflows/sync-skills.yml and validate-skills.yml.
+# workflow_dispatch `mode` input overrides cron.mode for a single run.
+
+cron:
+  # push — fast-forward commits directly onto target branch.
+  # pr   — open/update one PR per source (required for protected branches).
+  mode: pr
+
+  # true  — preflight hard-fails on mode/protection mismatch.
+  # false — preflight warns; sync attempts the push anyway.
+  strict_preflight: true
+
+bot:
+  # git committer identity for imported commits.
+  name: opensearch-ci
+  email: '83309141+opensearch-ci-bot@users.noreply.github.com'


### PR DESCRIPTION
## Summary

The scheduled skill-sync cron in this repo unconditionally does `git push origin HEAD:main`. On any repo whose default branch is protected, this produces a recurring failure every 20 minutes:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] HEAD -> main (protected branch hook declined)
```

This PR adds two things that together fix the symptom and prevent reintroduction:

1. **`sync/config.yaml`** — a single diff-reviewable source of truth for `cron.mode` (`push` / `pr`), `cron.strict_preflight`, and the bot identity, consumed by both the cron (`.github/workflows/sync-skills.yml`) and the PR dry-run (`.github/workflows/validate-skills.yml`).
2. **`sync-preflight` composite action** — queries the target branch's protection state via `gh api` and fails fast with an actionable remediation message whenever the configured mode would hit GH006. The same preflight runs in `validate-skills.yml` against the default branch, so a PR that would wedge the scheduled cron is **red before merge**.

Default is `mode: pr`, which works on repos with or without branch protection. Maintainers who want direct-push behaviour can flip the value in one file.

## What's in this PR (5 files, +489 / -16, fully additive)

| File | Status | Purpose |
|------|--------|---------|
| `sync/config.yaml` | **new** | Single source of truth for cron mode, strict-preflight flag, bot identity |
| `.github/actions/sync-preflight/action.yml` | **new** | Composite action: checks mode vs. target-branch protection, fails fast with remediation message |
| `sync-bot/tests/test_preflight_action.sh` | **new** | Local integration harness for the preflight action (5 real-network cases + 4 jq regression cases) |
| `.github/workflows/sync-skills.yml` | modified | Loads `sync/config.yaml` at job start, threads `mode` through to the sync engine, calls the preflight |
| `.github/workflows/validate-skills.yml` | modified | Same config load + runs the preflight against the default branch for every PR touching sync config |

No existing files are deleted; the sync engine, sync-bot library, and sync-source YAMLs are untouched.

## How the preflight decides

| mode | target protected? | strict | exit | rationale |
|------|------------------|--------|------|-----------|
| push | no | any | 0 | push will succeed |
| push | yes | true | 1 | would hit GH006 — preempt with actionable error |
| push | yes | false | 0 (warn) | opt-out for unusual setups (e.g. bypass via ruleset) |
| pr | any | any | 0 | pr-mode works regardless of protection |
| dry-run | any | any | 0 | no mutation happens anyway |
| bogus | any | any | 1 | mode validation catches typos |
| push | unknown | true | 0 | `gh api` couldn't read protection (token scope issue) — don't block, the push itself will still surface the real error |

When push-mode is incompatible with a protected target, the preflight prints three remediation lines:

```
::error::sync-preflight: mode=push is incompatible with protected branch 'main'.
::error::Set repository variable SYNC_CRON_MODE=pr (or workflow_dispatch input mode=pr) to open PRs instead of pushing directly.
::error::Or disable branch protection on 'main' (not recommended for shared repos).
::error::Or run with dry_run=true to validate config without mutating.
```

(The `SYNC_CRON_MODE` reference in the remediation message is a legacy repo-variable override that's still supported for emergency one-off use; the primary route is now `sync/config.yaml`.)

## Also included: jq `//` false-is-falsy fix

While building this I hit a subtle bug in what was going to be the preflight's protection lookup: `jq -r '.protected // "unknown"'` treats `false` as a fallback trigger (same as `null`), so every run on an unprotected branch reported `protected=unknown`, which the matrix then downgrades to COMPATIBLE.

Fix: explicit `has("protected")` branch logic. The four states (`true`, `false`, missing, `{}`) now round-trip correctly. Covered by four regression cases in the test harness.

## `workflow_dispatch` override still works

The cron workflow keeps its `mode` input. Use it when you need to flip behaviour without a commit — e.g. main just became protected and you want the next cron tick to open PRs instead of wedging on GH006 until the config change merges.

## Validation

```
sync-bot pytest:  44 passed in 5.00s   (unchanged — no library code touched)
preflight harness: 9/9 passed          (5 integration + 4 jq regression)
  PASS  jq-regression  {"protected":false}  -> false
  PASS  jq-regression  {"protected":true}   -> true
  PASS  jq-regression  {}                   -> unknown
  PASS  jq-regression  {"name":"main"}      -> unknown
  PASS  push -> PROTECTED upstream main (expect FAIL GH006 preempt)  (rc=1)
  PASS  pr   -> PROTECTED upstream main (expect OK: PRs are the point) (rc=0)
  PASS  dry-run -> anywhere                 (rc=0)
  PASS  bogus mode (validation)             (rc=1)
  PASS  push -> PROTECTED + strict=false    (rc=0 with warning)
```

The harness calls real `gh api` against `opensearch-project/opensearch-agent-skills/branches/main` so the test fixture is this repo itself; no fork-specific repos are referenced.

## Prior art

Developed and iterated on AndreKurait/opensearch-agent-skills (fork with protected main deliberately enabled to exercise the GH006 path). PR #18 on that fork landed the same change; a demo PR #19 that flipped `mode: push` back on deliberately went red at `validate-skills.yml`'s preflight step, confirming the safety net works end-to-end.

## Not in scope / follow-ups

- Repo-variable path (`vars.SYNC_CRON_MODE`) is still honoured by the workflow inputs for backward compatibility; a future PR could deprecate and remove it now that `sync/config.yaml` is the documented path.
- The preflight only checks the *default* branch in `validate-skills.yml`. A future iteration could also check the PR's head branch if someone wanted to use mode=push against a feature branch.

Signed-off-by: Andre Kurait <andrekurait@gmail.com>
