### PR TITLE
ci: Support fork PRs in evals via pull_request_target + safe-to-test label

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -5,22 +5,35 @@ name: Skill Evals
 # Triggers:
 #   - Manual dispatch (workflow_dispatch) — run on demand
 #   - Weekly schedule — Monday 06:00 UTC
-#   - Push/PR touching skill content or eval fixtures/tests
+#   - Push to main touching skill content or eval fixtures/tests
+#   - pull_request_target with 'safe to test' label — allows fork PRs to run
+#     evals after a maintainer reviews and labels the PR. Uses the base repo
+#     context so BEDROCK_ACCESS_ROLE secret is available.
+#
+# Security note: pull_request_target runs in the base repo context (has secrets)
+# but checks out the PR head. This is safe here because the eval tests only read
+# skill markdown files — they do not build or execute untrusted code from the PR.
 #
 # Requires BEDROCK_ACCESS_ROLE repository secret (IAM role ARN).
 # The role is assumed via GitHub OIDC — no static AWS keys stored.
-# Tests are automatically skipped if credentials are unavailable.
 
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
   push:
+    branches: [main]
     paths:
       - 'skills/**'
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
   pull_request:
+    paths:
+      - 'skills/**'
+      - 'tests/evals/**'
+      - '.github/workflows/evals.yml'
+  pull_request_target:
+    types: [labeled]
     paths:
       - 'skills/**'
       - 'tests/evals/**'
@@ -39,10 +52,20 @@ jobs:
     name: Skill Evals (LLM)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # For pull_request_target: only run when a maintainer adds 'safe to test' label.
+    # For all other triggers (push, schedule, workflow_dispatch, pull_request from
+    # org members): always run.
+    if: |
+      github.event_name != 'pull_request_target' ||
+      contains(github.event.pull_request.labels.*.name, 'safe to test')
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # For pull_request_target, check out the PR head so evals run against
+          # the contributor's skill changes, not the base branch.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Description

Replace pull_request trigger with pull_request_target (labeled) so that fork PRs can run eval tests after a maintainer adds the 'safe to test' label. The pull_request_target trigger runs in the base repo context, giving access to the BEDROCK_ACCESS_ROLE secret.

Security: the eval tests only read skill markdown files — they do not build or execute untrusted code from the PR, making pull_request_target safe to use here.

Also adds a new eval case (launchpad-pdf-reads-docling-guide) that checks the skill correctly references document_processing_guide.md when a user asks about PDF ingestion.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
