### PR TITLE
Add Claude Code plugin manifest for marketplace discoverability

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "opensearch-agent-skills",
   "displayName": "OpenSearch Agent Skills",
   "version": "0.2.0",
-  "description": "Build and deploy search applications with semantic, hybrid, neural sparse, and agentic search strategies using OpenSearch. Analyze observability data including log analytics with PPL and Query DSL, and distributed trace analysis with OpenTelemetry. Deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG. Just ask your AI assistant to set up a search app, query logs, investigate traces, or deploy to AWS.",
+  "description": "OpenSearch skills to help set up and deploy OpenSearch for a variety of use cases: build search applications with semantic, hybrid, neural sparse, and agentic search strategies; analyze observability data with log analytics (PPL and Query DSL) and distributed traces (OpenTelemetry); deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG; migrate from other platforms like Solr to OpenSearch. Just ask your AI assistant to set up a search app, query logs, investigate traces, migrate from Solr, or deploy to AWS.",
   "author": {
     "name": "opensearch-project"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "opensearch-agent-skills",
+  "displayName": "OpenSearch Agent Skills",
+  "version": "0.2.0",
+  "description": "Build and deploy search applications with semantic, hybrid, neural sparse, and agentic search strategies using OpenSearch. Analyze observability data including log analytics with PPL and Query DSL, and distributed trace analysis with OpenTelemetry. Deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG. Just ask your AI assistant to set up a search app, query logs, investigate traces, or deploy to AWS.",
+  "author": {
+    "name": "opensearch-project"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/opensearch-project/opensearch-agent-skills",
+  "homepage": "https://github.com/opensearch-project/opensearch-agent-skills",
+  "keywords": ["search", "observability", "opensearch", "aws"],
+  "skills": [
+    "./skills/opensearch-skills",
+    "./skills/solr-opensearch-migration-advisor"
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "opensearch-agent-skills",
   "displayName": "OpenSearch Agent Skills",
   "version": "0.2.0",
-  "description": "Build and deploy search applications with semantic, hybrid, neural sparse, and agentic search strategies using OpenSearch. Analyze observability data including log analytics with PPL and Query DSL, and distributed trace analysis with OpenTelemetry. Deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG. Just ask your AI assistant to set up a search app, query logs, investigate traces, or deploy to AWS.",
+  "description": "OpenSearch skills to help set up and deploy OpenSearch for a variety of use cases: build search applications with semantic, hybrid, neural sparse, and agentic search strategies; analyze observability data with log analytics (PPL and Query DSL) and distributed traces (OpenTelemetry); deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG; migrate from other platforms like Solr to OpenSearch. Just ask your AI assistant to set up a search app, query logs, investigate traces, migrate from Solr, or deploy to AWS.",
   "author": {
     "name": "opensearch-project"
   },


### PR DESCRIPTION
## Why
Today this repo is not discoverable by Claude Code — users have to manually clone and copy folders into `~/.claude/skills/`. Adding a `.claude-plugin/plugin.json` manifest makes it installable via:

```
/plugin marketplace add opensearch-project/opensearch-agent-skills
```

and lets us submit a single entry to the official Anthropic marketplace at [`anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) so all Claude Code users can discover it by default.

## What
- Adds `.claude-plugin/plugin.json` mirroring the existing `.cursor-plugin/plugin.json` (same name, version, description, license, repository, keywords).
- Lists two top-level skills:
  - `./skills/opensearch-skills` — the meta-skill, which internally routes to `search/`, `observability/`, and `cloud/` sub-skills via its existing routing table.
  - `./skills/solr-opensearch-migration-advisor`
- No changes to existing skill files or directory layout.

## Reference
Other plugin authors follow this pattern — e.g. [`endorlabs/ai-plugins`](https://github.com/endorlabs/ai-plugins) (single-plugin repo) and [`adobe/skills`](https://github.com/adobe/skills) (multi-plugin repo). Schema: `https://anthropic.com/claude-code/plugin.schema.json`.

## Next step
Once merged, a follow-up PR to `anthropics/claude-plugins-official` will add a `marketplace.json` entry pinned to the merge commit, making the plugin discoverable to all Claude Code users by default.