### PR TITLE
Add workflow benchmark

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -25,22 +25,25 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+      - 'scripts/**'
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
   pull_request:
     paths:
       - 'skills/**'
+      - 'scripts/**'
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
   pull_request_target:
     types: [labeled]
     paths:
       - 'skills/**'
+      - 'scripts/**'
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
 
 permissions:
-  contents: read
+  contents: write   # needed to commit updated baseline on main
   id-token: write   # required for OIDC role assumption
 
 concurrency:
@@ -51,7 +54,7 @@ jobs:
   evals:
     name: Skill Evals (LLM)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     # For pull_request_target: only run when a maintainer adds 'safe to test' label.
     # For all other triggers (push, schedule, workflow_dispatch, pull_request from
     # org members): always run.
@@ -101,3 +104,41 @@ jobs:
       - name: Analyze eval results
         run: |
           uv run --group evals pytest tests/evals/ --run-eval-analysis -v
+
+      # Phase 3: run workflow benchmark and compare against stored baseline.
+      # Fails if any dimension regresses >10% from baseline.
+      - name: Run workflow benchmark
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          uv run --group evals python scripts/run_benchmark.py \
+            --runs 1 \
+            --tag "ci-${{ github.sha }}" \
+            --output tests/evals/results/ci-run.json
+
+      - name: Compare against baseline
+        run: |
+          uv run --group evals python scripts/compare_baseline.py \
+            --baseline tests/evals/results/baseline.json \
+            --current tests/evals/results/ci-run.json \
+            --threshold 0.10
+
+      # Update baseline only on push to main, and only if ALL dimensions improved.
+      # This prevents downward drift — baseline only ratchets up.
+      - name: Update baseline if improved
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          uv run --group evals python scripts/update_baseline.py \
+            --baseline tests/evals/results/baseline.json \
+            --current tests/evals/results/ci-run.json
+
+      - name: Commit updated baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git diff --quiet tests/evals/results/baseline.json && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/evals/results/baseline.json
+          git commit -m "chore: update eval baseline (all dimensions improved)"
+          git push
+

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -42,19 +42,18 @@ on:
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
 
-permissions:
-  contents: write   # needed to commit updated baseline on main
-  id-token: write   # required for OIDC role assumption
-
 concurrency:
   group: evals-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  evals:
+  eval:
     name: Skill Evals (LLM)
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write   # required for OIDC role assumption
     # For pull_request_target: only run when a maintainer adds 'safe to test' label.
     # For all other triggers (push, schedule, workflow_dispatch, pull_request from
     # org members): always run.
@@ -123,17 +122,53 @@ jobs:
             --current tests/evals/results/ci-run.json \
             --threshold 0.10
 
-      # Update baseline only on push to main, and only if ALL dimensions improved.
-      # This prevents downward drift — baseline only ratchets up.
+  update-baseline:
+    name: Update Baseline (main only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: eval
+    permissions:
+      contents: write   # needed to commit updated baseline
+      id-token: write
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BEDROCK_ACCESS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Install eval dependencies
+        run: uv sync --group evals
+
+      - name: Run benchmark
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          uv run --group evals python scripts/run_benchmark.py \
+            --runs 1 \
+            --tag "baseline-${{ github.sha }}" \
+            --output tests/evals/results/ci-run.json
+
       - name: Update baseline if improved
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           uv run --group evals python scripts/update_baseline.py \
             --baseline tests/evals/results/baseline.json \
             --current tests/evals/results/ci-run.json
 
       - name: Commit updated baseline
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           git diff --quiet tests/evals/results/baseline.json && exit 0
           git config user.name "github-actions[bot]"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: test test-evals benchmark benchmark-3 baseline compare help
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run unit/integration tests (no evals)
+	uv run pytest tests/ --ignore=tests/evals -v
+
+test-evals: ## Run LLM eval tests (requires AWS credentials)
+	uv run --group evals pytest tests/evals/ --run-eval -v
+
+test-evals-analysis: ## Run eval analysis (aggregate results)
+	uv run --group evals pytest tests/evals/ --run-eval-analysis
+
+benchmark: ## Run benchmark (1 run, fast feedback)
+	uv run --group evals python scripts/run_benchmark.py --runs 1
+
+benchmark-3: ## Run benchmark with 3 runs (statistical stability)
+	uv run --group evals python scripts/run_benchmark.py --runs 3
+
+baseline: ## Run benchmark and save as baseline
+	uv run --group evals python scripts/run_benchmark.py --runs 3 --tag baseline --output tests/evals/results/baseline.json
+
+compare: ## Compare latest benchmark against baseline
+	uv run --group evals python scripts/compare_baseline.py
+
+benchmark-workflows: ## Run only the workflow evals (not routing/rules)
+	uv run --group evals pytest tests/evals/test_skill_workflows.py --run-eval -v
+
+benchmark-workflows-analysis: ## Analyze workflow eval results
+	uv run --group evals pytest tests/evals/test_skill_workflows.py --run-eval-analysis

--- a/scripts/compare_baseline.py
+++ b/scripts/compare_baseline.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Compare benchmark results against a stored baseline.
+
+Used in CI to detect regressions. Exits with code 1 if any dimension
+drops more than the allowed threshold from baseline.
+
+Usage:
+    uv run --group evals python scripts/compare_baseline.py
+    uv run --group evals python scripts/compare_baseline.py --baseline path/to/baseline.json --current path/to/current.json
+    uv run --group evals python scripts/compare_baseline.py --threshold 0.10
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_RESULTS_DIR = Path(__file__).resolve().parent.parent / "tests" / "evals" / "results"
+_DIMENSIONS = ["correctness", "completeness", "turn_efficiency", "autonomy"]
+_DEFAULT_THRESHOLD = 0.10  # 10% regression threshold
+
+
+def load_latest_result(results_dir: Path, exclude_baseline: bool = True) -> Path | None:
+    """Find the most recent results file (by timestamp in content)."""
+    candidates = []
+    for f in results_dir.glob("*.json"):
+        if exclude_baseline and f.name == "baseline.json":
+            continue
+        try:
+            data = json.loads(f.read_text())
+            candidates.append((data.get("timestamp", ""), f))
+        except (json.JSONDecodeError, KeyError):
+            continue
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return candidates[0][1]
+
+
+def compare(baseline: dict, current: dict, threshold: float) -> tuple[bool, list[str], str]:
+    """Compare current against baseline. Returns (passed, failures, report_table)."""
+    failures = []
+    rows = []
+
+    baseline_agg = baseline.get("aggregate", {})
+    current_agg = current.get("aggregate", {})
+
+    for dim in _DIMENSIONS:
+        b_data = baseline_agg.get(dim, {})
+        c_data = current_agg.get(dim, {})
+
+        b_mean = b_data.get("mean", 0)
+        c_mean = c_data.get("mean", 0)
+
+        if b_mean > 0:
+            delta = (c_mean - b_mean) / b_mean
+        else:
+            delta = 0.0 if c_mean == 0 else 1.0
+
+        status = "PASS"
+        if delta < -threshold:
+            status = "FAIL"
+            failures.append(
+                f"{dim}: {c_mean:.3f} vs baseline {b_mean:.3f} (delta: {delta:+.1%}, threshold: -{threshold:.0%})"
+            )
+        elif delta > 0:
+            status = "IMPROVED"
+
+        rows.append({
+            "dimension": dim,
+            "baseline": b_mean,
+            "current": c_mean,
+            "delta": delta,
+            "status": status,
+        })
+
+    # Token comparison (informational, no threshold)
+    b_tokens = baseline_agg.get("tokens", {}).get("mean", 0)
+    c_tokens = current_agg.get("tokens", {}).get("mean", 0)
+    token_delta = ((c_tokens - b_tokens) / b_tokens) if b_tokens > 0 else 0.0
+    rows.append({
+        "dimension": "tokens (avg)",
+        "baseline": b_tokens,
+        "current": c_tokens,
+        "delta": token_delta,
+        "status": "INFO",
+    })
+
+    # Format table
+    table_lines = [
+        f"| {'Dimension':<20} | {'Baseline':>10} | {'Current':>10} | {'Delta':>10} | {'Status':<10} |",
+        f"|{'-' * 22}|{'-' * 12}|{'-' * 12}|{'-' * 12}|{'-' * 12}|",
+    ]
+    for row in rows:
+        dim_name = row["dimension"]
+        if row["dimension"] == "tokens (avg)":
+            b_str = f"{row['baseline']:.0f}"
+            c_str = f"{row['current']:.0f}"
+        else:
+            b_str = f"{row['baseline']:.3f}"
+            c_str = f"{row['current']:.3f}"
+        delta_str = f"{row['delta']:+.1%}"
+        table_lines.append(
+            f"| {dim_name:<20} | {b_str:>10} | {c_str:>10} | {delta_str:>10} | {row['status']:<10} |"
+        )
+
+    report = "\n".join(table_lines)
+    passed = len(failures) == 0
+    return passed, failures, report
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare benchmark results against baseline")
+    parser.add_argument("--baseline", type=str, default="", help="Path to baseline JSON")
+    parser.add_argument("--current", type=str, default="", help="Path to current results JSON")
+    parser.add_argument("--threshold", type=float, default=_DEFAULT_THRESHOLD, help="Regression threshold (default: 0.10)")
+    args = parser.parse_args()
+
+    # Load baseline
+    baseline_path = Path(args.baseline) if args.baseline else _RESULTS_DIR / "baseline.json"
+    if not baseline_path.exists():
+        print(f"No baseline found at {baseline_path}")
+        print("Run the benchmark first and save as baseline:")
+        print(f"  uv run --group evals python scripts/run_benchmark.py --tag baseline")
+        print(f"  cp {_RESULTS_DIR}/baseline.json {baseline_path}")
+        sys.exit(0)  # Don't fail CI if no baseline exists yet
+
+    # Load current
+    if args.current:
+        current_path = Path(args.current)
+    else:
+        current_path = load_latest_result(_RESULTS_DIR)
+        if not current_path:
+            print("No current results found. Run the benchmark first:")
+            print("  uv run --group evals python scripts/run_benchmark.py")
+            sys.exit(1)
+
+    baseline = json.loads(baseline_path.read_text())
+    current = json.loads(current_path.read_text())
+
+    print(f"Baseline: {baseline_path.name} (tag: {baseline.get('tag', 'unknown')})")
+    print(f"Current:  {current_path.name} (tag: {current.get('tag', 'unknown')})")
+    print(f"Threshold: -{args.threshold:.0%} regression allowed")
+    print()
+
+    passed, failures, report = compare(baseline, current, args.threshold)
+
+    print(report)
+    print()
+
+    if passed:
+        print("RESULT: PASS — No regressions detected.")
+    else:
+        print("RESULT: FAIL — Regressions detected:")
+        for f in failures:
+            print(f"  - {f}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Local benchmark runner for opensearch-launchpad skill performance.
+
+Runs the workflow eval cases, collects scores and token usage,
+and outputs a results JSON file for comparison.
+
+Usage:
+    uv run --group evals python scripts/run_benchmark.py
+    uv run --group evals python scripts/run_benchmark.py --tag my-experiment
+    uv run --group evals python scripts/run_benchmark.py --runs 3
+"""
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Add project root to path
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from tests.evals.conftest import (
+    call_skill_with_usage,
+    load_skill_md,
+    _BEDROCK_MODEL_ID,
+    _BEDROCK_REGION,
+)
+
+
+_FIXTURES = _PROJECT_ROOT / "tests" / "evals" / "fixtures" / "workflow_evals.json"
+_RESULTS_DIR = _PROJECT_ROOT / "tests" / "evals" / "results"
+_DIMENSIONS = ["correctness", "completeness", "turn_efficiency", "autonomy"]
+
+
+def _get_bedrock_client():
+    """Create a boto3 bedrock-runtime client."""
+    try:
+        import boto3
+        return boto3.client("bedrock-runtime", region_name=_BEDROCK_REGION)
+    except Exception as e:
+        print(f"ERROR: Cannot create Bedrock client: {e}", file=sys.stderr)
+        print("Ensure AWS credentials are configured.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _judge_response(response: str, prompt: str, criteria: str, client) -> tuple[float, str]:
+    """Use LLM-as-judge to score a response against criteria. Returns (score, reason)."""
+    judge_prompt = f"""You are evaluating an AI assistant's response quality.
+
+USER PROMPT: {prompt}
+
+ASSISTANT RESPONSE: {response}
+
+EVALUATION CRITERIA: {criteria}
+
+Score the response from 0.0 to 1.0 based on how well it satisfies the criteria.
+- 1.0 = perfectly satisfies all criteria
+- 0.7 = mostly satisfies criteria with minor gaps
+- 0.5 = partially satisfies criteria
+- 0.3 = mostly fails to satisfy criteria
+- 0.0 = completely fails
+
+Respond in this exact JSON format:
+{{"score": <float>, "reason": "<brief explanation>"}}"""
+
+    body = json.dumps({
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 256,
+        "messages": [{"role": "user", "content": judge_prompt}],
+    })
+    response_raw = client.invoke_model(
+        modelId=_BEDROCK_MODEL_ID,
+        body=body,
+        contentType="application/json",
+        accept="application/json",
+    )
+    response_body = json.loads(response_raw["body"].read())
+    text = response_body["content"][0]["text"]
+
+    try:
+        # Parse JSON from response (handle markdown code blocks)
+        clean = text.strip()
+        if clean.startswith("```"):
+            clean = clean.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+        result = json.loads(clean)
+        return float(result.get("score", 0.0)), str(result.get("reason", ""))
+    except (json.JSONDecodeError, ValueError):
+        return 0.0, f"Failed to parse judge response: {text[:200]}"
+
+
+def run_single(cases: list[dict], skill_md: str, client) -> list[dict]:
+    """Run all cases once and return per-case results."""
+    results = []
+    for case in cases:
+        print(f"  Running: {case['id']}...", end=" ", flush=True)
+
+        response, token_usage = call_skill_with_usage(
+            skill_md, case["prompt"], client
+        )
+
+        scores = {}
+        reasons = {}
+        for dim in _DIMENSIONS:
+            criteria = case.get(f"criteria_{dim}", "")
+            if not criteria:
+                continue
+            score, reason = _judge_response(response, case["prompt"], criteria, client)
+            scores[dim] = score
+            reasons[dim] = reason
+
+        result = {
+            "case_id": case["id"],
+            "workflow": case["workflow"],
+            "scores": scores,
+            "tokens": token_usage,
+            "response_length": len(response),
+        }
+        results.append(result)
+
+        scores_str = " | ".join(f"{d[:4]}={s:.2f}" for d, s in scores.items())
+        print(f"{scores_str} | tokens={token_usage['total_tokens']}")
+
+    return results
+
+
+def aggregate_results(all_runs: list[list[dict]]) -> dict:
+    """Aggregate multiple runs into mean/stdev per dimension and per case."""
+    # Collect per-dimension scores across all runs
+    dim_all: dict[str, list[float]] = {d: [] for d in _DIMENSIONS}
+    token_all: list[int] = []
+
+    for run in all_runs:
+        for case_result in run:
+            for dim, score in case_result["scores"].items():
+                dim_all[dim].append(score)
+            token_all.append(case_result["tokens"]["total_tokens"])
+
+    aggregate = {}
+    for dim in _DIMENSIONS:
+        values = dim_all[dim]
+        if values:
+            aggregate[dim] = {
+                "mean": statistics.mean(values),
+                "stdev": statistics.stdev(values) if len(values) > 1 else 0.0,
+                "pass_rate": sum(1 for v in values if v >= 0.5) / len(values),
+            }
+
+    aggregate["tokens"] = {
+        "mean": statistics.mean(token_all) if token_all else 0,
+        "stdev": statistics.stdev(token_all) if len(token_all) > 1 else 0.0,
+        "total": sum(token_all),
+    }
+
+    # Per-case aggregation
+    case_ids = [r["case_id"] for r in all_runs[0]] if all_runs else []
+    per_case = {}
+    for case_id in case_ids:
+        case_scores: dict[str, list[float]] = {d: [] for d in _DIMENSIONS}
+        case_tokens: list[int] = []
+        for run in all_runs:
+            for r in run:
+                if r["case_id"] == case_id:
+                    for dim, score in r["scores"].items():
+                        case_scores[dim].append(score)
+                    case_tokens.append(r["tokens"]["total_tokens"])
+        per_case[case_id] = {
+            "scores": {
+                dim: {"mean": statistics.mean(vals), "stdev": statistics.stdev(vals) if len(vals) > 1 else 0.0}
+                for dim, vals in case_scores.items() if vals
+            },
+            "tokens": {
+                "mean": statistics.mean(case_tokens) if case_tokens else 0,
+                "stdev": statistics.stdev(case_tokens) if len(case_tokens) > 1 else 0.0,
+            },
+        }
+
+    return {"aggregate": aggregate, "per_case": per_case}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run opensearch-launchpad skill benchmark")
+    parser.add_argument("--tag", default="", help="Tag for this benchmark run (e.g., branch name)")
+    parser.add_argument("--runs", type=int, default=1, help="Number of runs for statistical stability (default: 1)")
+    parser.add_argument("--output", type=str, default="", help="Output file path (default: auto-generated)")
+    args = parser.parse_args()
+
+    cases = json.loads(_FIXTURES.read_text())
+    print(f"Loaded {len(cases)} workflow eval cases")
+    print(f"Running {args.runs} run(s)...")
+
+    client = _get_bedrock_client()
+    skill_md = load_skill_md("opensearch-launchpad")
+
+    all_runs = []
+    for run_idx in range(args.runs):
+        if args.runs > 1:
+            print(f"\n--- Run {run_idx + 1}/{args.runs} ---")
+        run_results = run_single(cases, skill_md, client)
+        all_runs.append(run_results)
+
+    # Aggregate
+    aggregated = aggregate_results(all_runs)
+
+    # Build output
+    tag = args.tag or f"benchmark-{int(time.time())}"
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    output = {
+        "tag": tag,
+        "timestamp": timestamp,
+        "model_id": _BEDROCK_MODEL_ID,
+        "num_runs": args.runs,
+        "num_cases": len(cases),
+        **aggregated,
+        "raw_runs": all_runs,
+    }
+
+    # Write results
+    _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = _RESULTS_DIR / f"{tag}.json"
+
+    output_path.write_text(json.dumps(output, indent=2, ensure_ascii=False))
+    print(f"\n{'═' * 60}")
+    print(f"Results saved to: {output_path}")
+    print(f"{'═' * 60}")
+
+    # Print summary
+    print(f"\nSUMMARY ({tag}, {args.runs} run(s), {len(cases)} cases)")
+    print(f"{'─' * 60}")
+    for dim in _DIMENSIONS:
+        if dim in aggregated["aggregate"]:
+            d = aggregated["aggregate"][dim]
+            print(f"  {dim:20s}: mean={d['mean']:.3f} stdev={d['stdev']:.3f} pass_rate={d['pass_rate']:.0%}")
+    tokens = aggregated["aggregate"]["tokens"]
+    print(f"  {'tokens':20s}: mean={tokens['mean']:.0f} stdev={tokens['stdev']:.0f} total={tokens['total']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -67,7 +67,7 @@ Respond in this exact JSON format:
 
     body = json.dumps({
         "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": 256,
+        "max_tokens": 512,
         "messages": [{"role": "user", "content": judge_prompt}],
     })
     response_raw = client.invoke_model(
@@ -78,6 +78,11 @@ Respond in this exact JSON format:
     )
     response_body = json.loads(response_raw["body"].read())
     text = response_body["content"][0]["text"]
+    stop_reason = response_body.get("stop_reason", "")
+
+    # Detect truncation — if the model hit max_tokens, the response is incomplete
+    if stop_reason == "max_tokens":
+        return 0.0, f"Judge response truncated (hit max_tokens). Raw: {text[:200]}"
 
     try:
         # Parse JSON from response (handle markdown code blocks)

--- a/scripts/update_baseline.py
+++ b/scripts/update_baseline.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Update baseline.json only if ALL dimensions improved (or stayed equal).
+
+This prevents downward drift — the baseline only ratchets up.
+If any dimension regressed, the baseline is NOT updated.
+
+Usage:
+    uv run --group evals python scripts/update_baseline.py \
+        --baseline tests/evals/results/baseline.json \
+        --current tests/evals/results/ci-run.json
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+_DIMENSIONS = ["correctness", "completeness", "turn_efficiency", "autonomy"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update baseline if all dimensions improved")
+    parser.add_argument("--baseline", required=True, help="Path to current baseline JSON")
+    parser.add_argument("--current", required=True, help="Path to current run JSON")
+    args = parser.parse_args()
+
+    baseline_path = Path(args.baseline)
+    current_path = Path(args.current)
+
+    if not baseline_path.exists():
+        # No baseline yet — adopt current as baseline
+        print(f"No baseline found. Adopting current as baseline.")
+        shutil.copy(current_path, baseline_path)
+        return
+
+    if not current_path.exists():
+        print(f"No current results found at {current_path}")
+        sys.exit(1)
+
+    baseline = json.loads(baseline_path.read_text())
+    current = json.loads(current_path.read_text())
+
+    baseline_agg = baseline.get("aggregate", {})
+    current_agg = current.get("aggregate", {})
+
+    # Check if ALL dimensions improved (or stayed equal)
+    improvements = []
+    regressions = []
+
+    for dim in _DIMENSIONS:
+        b_mean = baseline_agg.get(dim, {}).get("mean", 0)
+        c_mean = current_agg.get(dim, {}).get("mean", 0)
+        delta = c_mean - b_mean
+
+        if delta >= 0:
+            improvements.append((dim, b_mean, c_mean, delta))
+        else:
+            regressions.append((dim, b_mean, c_mean, delta))
+
+    print(f"Baseline vs Current:")
+    for dim in _DIMENSIONS:
+        b_mean = baseline_agg.get(dim, {}).get("mean", 0)
+        c_mean = current_agg.get(dim, {}).get("mean", 0)
+        delta = c_mean - b_mean
+        status = "UP" if delta > 0 else ("=" if delta == 0 else "DOWN")
+        print(f"  {dim:20s}: {b_mean:.3f} -> {c_mean:.3f} ({delta:+.3f}) [{status}]")
+
+    if regressions:
+        print(f"\nBaseline NOT updated — {len(regressions)} dimension(s) regressed:")
+        for dim, b, c, d in regressions:
+            print(f"  {dim}: {b:.3f} -> {c:.3f} ({d:+.3f})")
+    else:
+        print(f"\nAll dimensions improved or held. Updating baseline.")
+        shutil.copy(current_path, baseline_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/opensearch-skills/scripts/lib/ui.py
+++ b/skills/opensearch-skills/scripts/lib/ui.py
@@ -109,7 +109,8 @@ def _resolve_asset(path: str) -> Path | None:
         return None
     clean = path.lstrip("/") or "index.html"
     target = (SEARCH_UI_STATIC_DIR / clean).resolve()
-    if target.is_file() and str(target).startswith(str(SEARCH_UI_STATIC_DIR)):
+    static_resolved = SEARCH_UI_STATIC_DIR.resolve()
+    if target.is_file() and str(target).startswith(str(static_resolved)):
         return target
     return None
 

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -355,6 +355,7 @@ def cmd_check_agentic_setup(args):
         checks["status"].append({"check": "index_exists", "ok": False, "error": str(e)})
 
     # Check 2: Search pipeline attached
+    search_pipeline = ""
     try:
         settings = client.indices.get_settings(index=index)
         idx_settings = settings.get(index, {}).get("settings", {}).get("index", {})

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -32,6 +32,8 @@ Commands:
     create-conversational-agent Create a conversational agent with memory (multi-turn)
     create-flow-agentic-pipeline Create and attach a flow agent search pipeline
     create-conversational-agent-pipeline Create and attach a conversational agent pipeline with RAG
+    check-agentic-setup    Diagnose an existing agentic search setup
+    setup-agentic-search   Full agentic search setup in one command (composite, supports --resume)
     search-docs            Search documentation via DuckDuckGo (default: opensearch.org)
 """
 
@@ -337,6 +339,177 @@ def cmd_create_conversational_agent_pipeline(args):
     print(create_conversational_agent_pipeline(args.name, args.agent_id, args.index, args.model_id))
 
 
+def cmd_check_agentic_setup(args):
+    """Diagnose an existing agentic search setup on an index."""
+    from lib.client import create_client
+
+    client = create_client()
+    index = args.index
+    checks = {"index": index, "status": []}
+
+    # Check 1: Index exists
+    try:
+        exists = client.indices.exists(index=index)
+        checks["status"].append({"check": "index_exists", "ok": exists})
+    except Exception as e:
+        checks["status"].append({"check": "index_exists", "ok": False, "error": str(e)})
+
+    # Check 2: Search pipeline attached
+    try:
+        settings = client.indices.get_settings(index=index)
+        idx_settings = settings.get(index, {}).get("settings", {}).get("index", {})
+        search_pipeline = idx_settings.get("search", {}).get("default_pipeline", "")
+        checks["status"].append({
+            "check": "search_pipeline_attached",
+            "ok": bool(search_pipeline),
+            "pipeline": search_pipeline,
+        })
+    except Exception as e:
+        checks["status"].append({"check": "search_pipeline_attached", "ok": False, "error": str(e)})
+
+    # Check 3: Pipeline exists and has agent processor
+    if search_pipeline:
+        try:
+            pipeline_resp = client.transport.perform_request(
+                "GET", f"/_search/pipeline/{search_pipeline}"
+            )
+            pipeline_body = pipeline_resp.get(search_pipeline, {})
+            processors = pipeline_body.get("response_processors", [])
+            has_agent = any("retrieval_augmented_generation" in p or "ml_inference" in p for p in processors)
+            agent_id = ""
+            for p in processors:
+                if "retrieval_augmented_generation" in p:
+                    agent_id = p["retrieval_augmented_generation"].get("agent_id", "")
+                elif "ml_inference" in p:
+                    agent_id = p["ml_inference"].get("agent_id", "")
+            checks["status"].append({
+                "check": "pipeline_has_agent",
+                "ok": has_agent,
+                "agent_id": agent_id,
+            })
+        except Exception as e:
+            checks["status"].append({"check": "pipeline_has_agent", "ok": False, "error": str(e)})
+
+    # Check 4: Model deployed (if we found an agent, check its model)
+    agent_id_found = next((s.get("agent_id") for s in checks["status"] if s.get("agent_id")), "")
+    if agent_id_found:
+        try:
+            agent_resp = client.transport.perform_request("GET", f"/_plugins/_ml/agents/{agent_id_found}")
+            model_id = agent_resp.get("model_id", "")
+            checks["status"].append({"check": "agent_exists", "ok": True, "agent_id": agent_id_found, "model_id": model_id})
+            if model_id:
+                model_resp = client.transport.perform_request("GET", f"/_plugins/_ml/models/{model_id}")
+                model_state = model_resp.get("model_state", "UNKNOWN")
+                checks["status"].append({"check": "model_deployed", "ok": model_state == "DEPLOYED", "model_id": model_id, "state": model_state})
+        except Exception as e:
+            checks["status"].append({"check": "agent_or_model", "ok": False, "error": str(e)})
+
+    checks["all_ok"] = all(s.get("ok", False) for s in checks["status"])
+    print(json.dumps(checks, indent=2))
+
+
+def cmd_setup_agentic_search(args):
+    """Composite command: set up full agentic search in one shot.
+
+    For conversational agent: deploy model -> create agent -> deploy RAG model -> create pipeline
+    For flow agent: deploy model -> create agent -> create pipeline
+
+    Supports --resume with --model-id and/or --agent-id to skip completed steps.
+    """
+    from lib.operations import (
+        deploy_agentic_model, deploy_rag_model,
+        create_flow_agent, create_conversational_agent,
+        create_flow_agentic_pipeline, create_conversational_agent_pipeline,
+    )
+
+    access_key = args.access_key or os.getenv("AWS_ACCESS_KEY_ID", "")
+    secret_key = args.secret_key or os.getenv("AWS_SECRET_ACCESS_KEY", "")
+    session_token = args.session_token or os.getenv("AWS_SESSION_TOKEN", "")
+    region = args.region
+    index = args.index
+    agent_type = args.agent_type
+    model_name = args.model_name
+
+    # Resume support: skip steps that already completed
+    resume_model_id = getattr(args, "model_id", None) or ""
+    resume_agent_id = getattr(args, "agent_id", None) or ""
+
+    results = {"agent_type": agent_type, "index": index, "steps": []}
+
+    # Step 1: Deploy agentic model (skip if resuming with model_id)
+    if resume_model_id:
+        model_id = resume_model_id
+        print(f"Step 1: Reusing existing model {model_id} (--resume)", file=sys.stderr)
+        results["steps"].append({"step": "deploy-agentic-model", "model_id": model_id, "skipped": True})
+    else:
+        print(f"Step 1: Deploying agentic model ({model_name}) in {region}...", file=sys.stderr)
+        model_id = deploy_agentic_model(access_key, secret_key, region, session_token, model_name)
+        results["steps"].append({"step": "deploy-agentic-model", "model_id": model_id})
+        if model_id.startswith("Error"):
+            results["error"] = model_id
+            results["resume_hint"] = "Fix the error and retry. No --resume needed (step 1 failed)."
+            print(json.dumps(results, indent=2))
+            return
+
+    # Step 2: Create agent (skip if resuming with agent_id)
+    if resume_agent_id:
+        agent_id = resume_agent_id
+        print(f"Step 2: Reusing existing agent {agent_id} (--resume)", file=sys.stderr)
+        results["steps"].append({"step": f"create-{agent_type}-agent", "agent_id": agent_id, "skipped": True})
+    else:
+        agent_name = f"agentic-search-{agent_type}-{index}"
+        print(f"Step 2: Creating {agent_type} agent '{agent_name}'...", file=sys.stderr)
+        if agent_type == "conversational":
+            agent_result = create_conversational_agent(agent_name, model_id)
+        else:
+            agent_result = create_flow_agent(agent_name, model_id)
+
+        try:
+            agent_data = json.loads(agent_result)
+            agent_id = agent_data.get("agent_id", "")
+        except (json.JSONDecodeError, TypeError):
+            agent_id = ""
+        results["steps"].append({"step": f"create-{agent_type}-agent", "result": agent_result, "agent_id": agent_id})
+        if not agent_id:
+            results["error"] = f"Failed to create agent: {agent_result}"
+            results["resume_hint"] = f"Retry with: --model-id {model_id}"
+            print(json.dumps(results, indent=2))
+            return
+
+    # Step 3 (conversational only): Deploy RAG model
+    rag_model_id = ""
+    if agent_type == "conversational":
+        print(f"Step 3: Deploying RAG model for pipeline...", file=sys.stderr)
+        rag_model_id = deploy_rag_model(access_key, secret_key, region, session_token, model_name)
+        results["steps"].append({"step": "deploy-rag-model", "model_id": rag_model_id})
+        if rag_model_id.startswith("Error"):
+            results["error"] = rag_model_id
+            results["resume_hint"] = f"Retry with: --model-id {model_id} --agent-id {agent_id}"
+            print(json.dumps(results, indent=2))
+            return
+
+    # Step 4: Create pipeline
+    pipeline_name = f"agentic-search-pipeline-{index}"
+    step_num = 4 if agent_type == "conversational" else 3
+    print(f"Step {step_num}: Creating {agent_type} search pipeline on '{index}'...", file=sys.stderr)
+    if agent_type == "conversational":
+        pipeline_result = create_conversational_agent_pipeline(pipeline_name, agent_id, index, rag_model_id)
+    else:
+        pipeline_result = create_flow_agentic_pipeline(pipeline_name, agent_id, index)
+    results["steps"].append({"step": "create-pipeline", "result": pipeline_result})
+
+    results["success"] = True
+    results["summary"] = {
+        "agentic_model_id": model_id,
+        "agent_id": agent_id,
+        "pipeline_name": pipeline_name,
+    }
+    if rag_model_id:
+        results["summary"]["rag_model_id"] = rag_model_id
+
+    print(json.dumps(results, indent=2))
+
+
 def main():
     parser = argparse.ArgumentParser(description="OpenSearch operations CLI (standalone)", allow_abbrev=False)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -481,6 +654,23 @@ def main():
     p.add_argument("--index", required=True, help="Index name")
     p.add_argument("--model-id", required=True, help="Deployed LLM model ID for RAG")
 
+    # check-agentic-setup
+    p = sub.add_parser("check-agentic-setup", help="Diagnose agentic search setup on an index")
+    p.add_argument("--index", required=True, help="Index to check")
+
+    # setup-agentic-search (composite)
+    p = sub.add_parser("setup-agentic-search", help="Full agentic search setup in one command")
+    p.add_argument("--index", required=True, help="Target index name")
+    p.add_argument("--agent-type", required=True, choices=["flow", "conversational"],
+                   help="Agent type: flow (stateless) or conversational (multi-turn)")
+    p.add_argument("--access-key", default="")
+    p.add_argument("--secret-key", default="")
+    p.add_argument("--region", default="us-east-1")
+    p.add_argument("--session-token", default="")
+    p.add_argument("--model-name", default="us.anthropic.claude-sonnet-4-20250514-v1:0")
+    p.add_argument("--model-id", default="", help="Resume: skip model deployment, reuse this model ID")
+    p.add_argument("--agent-id", default="", help="Resume: skip agent creation, reuse this agent ID")
+
     args = parser.parse_args()
 
     dispatch = {
@@ -505,6 +695,8 @@ def main():
         "create-conversational-agent": cmd_create_conversational_agent,
         "create-flow-agentic-pipeline": cmd_create_flow_agentic_pipeline,
         "create-conversational-agent-pipeline": cmd_create_conversational_agent_pipeline,
+        "check-agentic-setup": cmd_check_agentic_setup,
+        "setup-agentic-search": cmd_setup_agentic_search,
         "search-docs": cmd_search_docs,
     }
 

--- a/skills/opensearch-skills/search/opensearch-launchpad/SKILL.md
+++ b/skills/opensearch-skills/search/opensearch-launchpad/SKILL.md
@@ -112,13 +112,23 @@ See [cli-reference.md](../../cli-reference.md) for the full command reference.
 
 ## Key Rules
 
-- Ask **one** preference question per message.
-- **Never skip Phase 1** (sample document collection).
-- Show architecture proposals to the user before execution.
-- Follow the phases **in order** — do not jump ahead.
-- When a step fails, present the error and wait for guidance.
+### Autonomy & Efficiency
+- **If the user provides all necessary information** (index name, search strategy, model, cluster status, credentials), **proceed directly** to planning and execution. Do not ask for information already stated.
+- **Batch missing questions**: If information IS missing, ask all needed questions in ONE message — never one question per message across multiple turns.
+- **Skip Phase 2** if the user's prompt already specifies the search strategy.
+- **Skip plan approval** for straightforward setups where the user has stated what they want. Only present the plan for approval when there are meaningful architectural decisions the user hasn't addressed.
+
+### Recovery & Error Handling
+- When a step fails, **diagnose the error and provide concrete fix commands** — do not just say "an error occurred, what would you like to do?"
+- When the user describes a partial setup (some steps done, some failed), **resume from where it failed**. Do not redo completed steps. Reuse existing IDs (model_id, agent_id, pipeline names).
+- When credentials expire, the fix is to refresh credentials and update the connector — **never re-deploy a model** that is already registered.
+
+### Correctness
+- **Never skip Phase 1** (preflight check) — always verify cluster is available first. However, if the user states "cluster is running" or "OpenSearch is already running", treat that as a passed preflight and proceed without waiting for output.
+- **Only use commands documented in [cli-reference.md](../../cli-reference.md)**. Do not invent flags or arguments. If unsure about exact syntax, read the CLI reference first.
 - Do not describe **Amazon OpenSearch Serverless** as scaling to zero.
 - **Agentic search** does not deploy to **Amazon OpenSearch Serverless** — use a **managed domain**.
+- Follow the phases **in order** unless the user's context allows skipping (e.g., cluster already running with data = skip sample loading).
 
 ## Workflow Phases
 
@@ -134,18 +144,25 @@ uv run python scripts/opensearch_ops.py preflight-check
 - **`status: "auth_required"`** — Ask for credentials, then retry with `--auth-mode custom`.
 - **`status: "no_cluster"`** — Start one: `bash scripts/start_opensearch.sh`
 
-Once available, ask for the data source. Use `load-sample` to load data.
+Once available:
+- If the user **already has data in an index** (stated in their prompt), skip sample loading.
+- If the user **specifies a data source** (file path, URL, builtin_imdb), load it directly with `load-sample`.
+- Otherwise, ask for the data source.
 
 If the user provides PDF, DOCX, PPTX, or XLSX files, use Docling to process them. Read [document_processing_guide.md](document_processing_guide.md) for the workflow.
 
 ### Phase 2 — Gather Preferences
 
-Ask **one at a time**: search strategy and deployment preference. Present all five strategies:
+**Skip this phase** if the user already specified their search strategy in the prompt.
+
+If the strategy is unclear, present all five options and ask the user to choose:
 - `bm25` (keyword)
 - `dense_vector` (semantic via embeddings)
 - `neural_sparse` (semantic via learned sparse representations)
 - `hybrid` (combines keyword + semantic)
 - `agentic` (LLM-driven multi-step retrieval, requires OpenSearch 3.2+)
+
+Recognize natural language equivalents: "keyword search" = BM25, "semantic search" = dense_vector, "best of both" = hybrid, "AI-powered search" / "conversational search" = agentic.
 
 ### Phase 3 — Plan
 
@@ -157,13 +174,41 @@ Design a search architecture. Read the relevant knowledge files:
 - [agentic_search_guide.md](agentic_search_guide.md)
 - [document_processing_guide.md](document_processing_guide.md)
 
-Present the plan and wait for user approval.
+**Fast-path**: If the user specified strategy, model, and index name — present a brief plan summary and proceed to execution in the same message. No separate approval turn needed.
+
+**Standard path**: If there are open architectural decisions (model choice, weights, field mappings), present the plan and wait for approval.
 
 ### Phase 4 — Execute
 
 Execute the plan using `opensearch_ops.py` commands. When launching the UI, present the URL (default: `http://127.0.0.1:8765`).
 
-**For Agentic Search:** Ask for AWS credentials for Bedrock, then ask about agent type (Flow vs Conversational). See [cli-reference.md](../../cli-reference.md) for agentic setup commands.
+**For Dense Vector / Hybrid Search:** Execute these steps in sequence. Use exact command syntax from [cli-reference.md](../../cli-reference.md):
+
+1. `deploy-model --name "huggingface/sentence-transformers/<model>"` → get model_id
+2. `create-pipeline --name <pipeline> --index <index> --type ingest --body '{...text_embedding processor with model_id and field_map...}'`
+3. `create-index --name <index> --body '{...knn_vector field with correct dimension...}'`
+4. For hybrid: `create-pipeline --name <search-pipeline> --index <index> --type search --hybrid --weights '[0.3, 0.7]'`
+5. `index-bulk --index <index> --source-file <path>`
+6. `launch-ui --index <index>`
+
+**For Agentic Search:** Use the composite command to set up the full pipeline in one step:
+
+```bash
+uv run python scripts/opensearch_ops.py setup-agentic-search \
+  --index <index_name> --agent-type <flow|conversational> --region <aws_region>
+```
+
+This handles all steps automatically (deploy model → create agent → deploy RAG model → create pipeline). AWS credentials are read from environment variables. If a step fails, the output includes a `resume_hint` with the exact command to retry using `--model-id` and/or `--agent-id` to skip completed steps.
+
+If AWS credentials and agent type are already in the user's prompt, proceed directly. Otherwise ask for both in **one message**. See [cli-reference.md](../../cli-reference.md) for all options.
+
+**Verification after multi-step setup (dense/hybrid/agentic):** After completing pipeline setup, run diagnostics:
+
+```bash
+uv run python scripts/opensearch_ops.py check-agentic-setup --index <index_name>
+```
+
+This checks: index exists, pipeline attached, agent registered, model deployed. If any check fails, diagnose the issue and provide the fix command.
 
 After the UI is running:
 > "Your search app is live! Here's what you can do next:"

--- a/tests/evals/conftest.py
+++ b/tests/evals/conftest.py
@@ -69,6 +69,21 @@ def call_skill(skill_md: str, prompt: str, client, model_id: str = _BEDROCK_MODE
 
     Calls Bedrock using the Messages API (anthropic_version bedrock-2023-05-31),
     matching the pattern used in opensearch-build's AIReleaseNotesGenerator.
+
+    Returns just the response text for backward compatibility.
+    Use call_skill_with_usage() for token tracking.
+    """
+    text, _ = call_skill_with_usage(skill_md, prompt, client, model_id)
+    return text
+
+
+def call_skill_with_usage(
+    skill_md: str, prompt: str, client, model_id: str = _BEDROCK_MODEL_ID
+) -> tuple[str, dict]:
+    """Simulate an agent with skill_md loaded as the system prompt.
+
+    Returns (response_text, token_usage) where token_usage is:
+        {"input_tokens": int, "output_tokens": int, "total_tokens": int}
     """
     body = json.dumps({
         "anthropic_version": "bedrock-2023-05-31",
@@ -83,4 +98,14 @@ def call_skill(skill_md: str, prompt: str, client, model_id: str = _BEDROCK_MODE
         accept="application/json",
     )
     response_body = json.loads(response["body"].read())
-    return response_body["content"][0]["text"]
+    text = response_body["content"][0]["text"]
+
+    usage = response_body.get("usage", {})
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+    token_usage = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    return text, token_usage

--- a/tests/evals/fixtures/workflow_evals.json
+++ b/tests/evals/fixtures/workflow_evals.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "bm25-full-info",
+    "workflow": "bm25",
+    "prompt": "Set up BM25 search on my 'products' index with the built-in IMDB data. OpenSearch is already running locally.",
+    "context": { "cluster_status": "available", "data_source": "builtin_imdb", "strategy": "bm25" },
+    "criteria_correctness": "The response must instruct running preflight-check first, then load-sample with builtin_imdb, then create-index, and finally launch-ui. Commands must be syntactically valid opensearch_ops.py commands. Preflight is a required first step per skill rules.",
+    "criteria_completeness": "The response must cover all required steps: (1) preflight-check, (2) load-sample --type builtin_imdb, (3) create-index with appropriate mappings, (4) index-bulk or reindex, (5) launch-ui. Preflight is expected and counts toward completeness.",
+    "criteria_turn_efficiency": "The response should execute the full BM25 setup without asking unnecessary questions since all info is provided (cluster running, data source known, strategy chosen). Should complete in 1-2 messages.",
+    "criteria_autonomy": "Should not ask for: cluster status (stated available), data source (stated IMDB), search strategy (stated BM25), or confirmation to proceed."
+  },
+  {
+    "id": "bm25-minimal",
+    "workflow": "bm25",
+    "prompt": "I want keyword search on my data.",
+    "context": { "cluster_status": "unknown", "data_source": "unknown", "strategy": "bm25" },
+    "criteria_correctness": "The response must mention preflight-check and ask about the data source. It should recognize 'keyword search' as BM25.",
+    "criteria_completeness": "The response must identify what's needed: cluster status and data source. It should confirm BM25 is the right strategy for keyword search.",
+    "criteria_turn_efficiency": "Should batch all needed questions (cluster status + data source) in one message rather than asking one per turn.",
+    "criteria_autonomy": "Questions ARE needed here since info is missing, but they must be batched. Should not ask about search strategy since user said 'keyword search' which maps to BM25."
+  },
+  {
+    "id": "dense-full-info",
+    "workflow": "dense_vector",
+    "prompt": "Set up semantic search using sentence-transformers/all-mpnet-base-v2 on index 'docs'. My cluster is already running locally with data loaded in 'docs'.",
+    "context": { "cluster_status": "available", "index_exists": true, "model": "huggingface/sentence-transformers/all-mpnet-base-v2" },
+    "criteria_correctness": "Must include preflight-check first, then: deploy-model with the correct model name (huggingface/sentence-transformers/all-mpnet-base-v2), create an ingest pipeline with text_embedding processor, and set up knn_vector mapping with dimension 768. Must use correct command names from cli-reference.md.",
+    "criteria_completeness": "Must cover: (1) preflight-check, (2) deploy-model, (3) create ingest pipeline with embedding processor, (4) create index with knn_vector field (dim 768), (5) reindex or bulk-index through pipeline, (6) create search pipeline or configure neural search, (7) launch-ui.",
+    "criteria_turn_efficiency": "Should proceed without asking unnecessary questions since model, index, and cluster status are all provided. Should lay out the full plan and execute.",
+    "criteria_autonomy": "Should not ask for: model choice (provided), index name (provided), cluster status (stated running). May briefly present the plan before executing."
+  },
+  {
+    "id": "dense-model-choice",
+    "workflow": "dense_vector",
+    "prompt": "I want semantic search but not sure which embedding model to use. My data is English product descriptions, about 200 words each. Cluster is running.",
+    "context": { "cluster_status": "available", "data_source": "product_descriptions", "model": "unknown" },
+    "criteria_correctness": "Must recommend appropriate models from the supported list (e.g., all-mpnet-base-v2 for quality, all-MiniLM-L6-v2 for speed) with trade-offs explained.",
+    "criteria_completeness": "Must mention: (1) at least 2 model options with trade-offs (dimension, speed, quality), (2) recommendation based on 200-word English descriptions, (3) explain that model choice affects index dimension.",
+    "criteria_turn_efficiency": "Should present model options with a clear recommendation in one message, not ask multiple rounds of clarifying questions.",
+    "criteria_autonomy": "Should provide a recommendation, not just list options without guidance. One question about model preference is acceptable after presenting options."
+  },
+  {
+    "id": "hybrid-full-info",
+    "workflow": "hybrid",
+    "prompt": "Set up hybrid search (BM25 + dense vector) with 0.3/0.7 weights on 'products'. Use all-MiniLM-L6-v2. Cluster running, data already in the index.",
+    "context": { "cluster_status": "available", "index_exists": true, "model": "huggingface/sentence-transformers/all-MiniLM-L6-v2", "weights": [0.3, 0.7] },
+    "criteria_correctness": "Must include preflight-check first, then: deploy-model with all-MiniLM-L6-v2, create ingest pipeline with text_embedding processor, create hybrid search pipeline with weights [0.3, 0.7], and attach to the index. Must use correct command names from cli-reference.md.",
+    "criteria_completeness": "Must cover: (1) preflight-check, (2) deploy model, (3) create ingest pipeline with text_embedding, (4) create index with knn_vector (dim 384 for MiniLM-L6), (5) create search pipeline with hybrid weights 0.3/0.7, (6) reindex data through ingest pipeline, (7) launch-ui. Preflight is a required step.",
+    "criteria_turn_efficiency": "All information is provided. Should execute the full hybrid setup without asking additional questions. Complete in 1-2 messages.",
+    "criteria_autonomy": "Should not ask for: model (provided), weights (provided), index name (provided), strategy confirmation. Should proceed directly."
+  },
+  {
+    "id": "hybrid-minimal",
+    "workflow": "hybrid",
+    "prompt": "I want the best of both keyword and semantic search for my e-commerce site.",
+    "context": { "cluster_status": "unknown", "strategy_hint": "hybrid" },
+    "criteria_correctness": "Must recognize this as a hybrid search request. Should explain that hybrid combines BM25 (keyword) with vector search (semantic).",
+    "criteria_completeness": "Must explain: (1) hybrid search concept, (2) ask about cluster/data, (3) ask about model preference or recommend one, (4) mention weight tuning is possible.",
+    "criteria_turn_efficiency": "Should batch questions about cluster status, data source, and model preference in one message after explaining hybrid.",
+    "criteria_autonomy": "Questions needed (cluster, data, model), but must be batched. Should not require multiple rounds of single questions."
+  },
+  {
+    "id": "sparse-full-info",
+    "workflow": "neural_sparse",
+    "prompt": "Set up neural sparse search on my 'articles' index using opensearch-neural-sparse-encoding-doc-v2-distill. Cluster is running, articles index has data.",
+    "context": { "cluster_status": "available", "index_exists": true, "model": "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v2-distill" },
+    "criteria_correctness": "Must include preflight-check first, then: deploy the sparse model, create an ingest pipeline with sparse_encoding processor, create index with rank_features field, and set up neural_sparse search. Must use correct command names from cli-reference.md.",
+    "criteria_completeness": "Must cover: (1) preflight-check, (2) deploy sparse model, (3) create ingest pipeline with sparse_encoding processor, (4) create index with rank_features field, (5) reindex through pipeline, (6) configure search, (7) launch-ui.",
+    "criteria_turn_efficiency": "All info provided. Should proceed without unnecessary questions.",
+    "criteria_autonomy": "Should not ask for model choice, index name, or cluster status since all are provided."
+  },
+  {
+    "id": "agentic-conv-full-info",
+    "workflow": "agentic",
+    "prompt": "I want to set up conversational agentic search on my existing index called 'products'. I have AWS credentials configured in my environment (us-east-1). Please set it up.",
+    "context": { "cluster_status": "available", "index_exists": true, "aws_creds_in_env": true },
+    "criteria_correctness": "Must include preflight-check as a first step AND then use setup-agentic-search composite command with --index products --agent-type conversational --region us-east-1. Alternatively, listing the individual steps (deploy-agentic-model, create-conversational-agent, deploy-rag-model, create-conversational-agent-pipeline) is also acceptable. Must use correct command names and flags.",
+    "criteria_completeness": "Must cover: (1) preflight-check, (2) the full agentic setup — either via setup-agentic-search composite OR the individual 4 steps (deploy model, create agent, deploy RAG, create pipeline). Must reference the 'products' index.",
+    "criteria_turn_efficiency": "Should provide the full execution plan (preflight + setup commands) without asking for information already provided (AWS region, credentials, index name, agent type). Complete in 1-2 messages.",
+    "criteria_autonomy": "Should not ask for: AWS credentials (in env), region (us-east-1), index name (products), agent type (conversational stated). May include preflight-check as a required first step — that is expected, not a question."
+  },
+  {
+    "id": "agentic-flow-full-info",
+    "workflow": "agentic",
+    "prompt": "Set up a flow agent for agentic search on index 'articles'. AWS creds are in my env, region us-west-2. I want stateless low-latency queries.",
+    "context": { "cluster_status": "available", "index_exists": true, "aws_creds_in_env": true },
+    "criteria_correctness": "Must include preflight-check as a first step AND then use setup-agentic-search composite command with --index articles --agent-type flow --region us-west-2. Alternatively, listing the individual steps (deploy-agentic-model, create-flow-agent, create-flow-agentic-pipeline) is also acceptable. Must use correct command names and flags.",
+    "criteria_completeness": "Must cover: (1) preflight-check, (2) the full agentic setup — either via setup-agentic-search composite OR the individual 3 steps (deploy model, create flow agent, create flow pipeline). Must reference the 'articles' index and region us-west-2.",
+    "criteria_turn_efficiency": "Should provide the full execution plan (preflight + setup commands) without asking additional questions. All information is provided. Complete in 1-2 messages.",
+    "criteria_autonomy": "Should not ask for agent type (user said 'flow agent' and 'stateless'), region (provided), credentials (in env), or index name (provided). Preflight-check is a required step, not a question."
+  },
+  {
+    "id": "agentic-missing-info",
+    "workflow": "agentic",
+    "prompt": "I want agentic search on my data.",
+    "context": { "cluster_status": "unknown", "index_exists": "unknown", "aws_creds_in_env": "unknown" },
+    "criteria_correctness": "Must identify this as an agentic search request and identify all missing prerequisites before attempting setup.",
+    "criteria_completeness": "Must identify all missing prerequisites: (1) cluster availability, (2) target index, (3) AWS credentials/region, (4) agent type preference (flow vs conversational).",
+    "criteria_turn_efficiency": "Should batch ALL needed questions in ONE message rather than asking one per turn.",
+    "criteria_autonomy": "Questions ARE needed here, but they must be BATCHED in one message. Asking one question per message is the anti-pattern."
+  },
+  {
+    "id": "recovery-creds-expired",
+    "workflow": "agentic",
+    "prompt": "I was setting up conversational agentic search. The model deployed successfully (model_id: abc123) and agent was created (agent_id: xyz789), but when I ran verify-agentic-setup it said 'connector_live: false, ExpiredTokenException'. How do I fix this?",
+    "context": { "partial_state": { "model_deployed": true, "model_id": "abc123", "agent_created": true, "agent_id": "xyz789", "creds_expired": true } },
+    "criteria_correctness": "Must identify this as an expired credentials problem. Must NOT suggest re-deploying the model or re-creating the agent. Must suggest refreshing credentials and updating the connector.",
+    "criteria_completeness": "Must: (1) explain that creds expired in the connector, (2) suggest refreshing AWS creds, (3) provide command to update connector or re-verify, (4) note that model and agent are fine and should be reused.",
+    "criteria_turn_efficiency": "Should provide the complete recovery plan in 1 turn since all diagnostic info is provided.",
+    "criteria_autonomy": "Should not ask 'what model did you deploy?' or 'what agent type?' since model_id, agent_id, and error are all provided."
+  },
+  {
+    "id": "recovery-dim-mismatch",
+    "workflow": "dense_vector",
+    "prompt": "I deployed all-mpnet-base-v2 (model_id: m789) and created the ingest pipeline. But when I ran verify-search-pipeline it said 'embedding_populated: false, mapper_parsing_exception: vector dimension mismatch, expected 384 got 768'. What's wrong?",
+    "context": { "partial_state": { "model_deployed": true, "model_id": "m789", "pipeline_created": true, "index_dim": 384, "model_dim": 768 } },
+    "criteria_correctness": "Must identify that the index was created with dimension 384 but all-mpnet-base-v2 outputs 768. Must suggest either recreating the index with dim 768 or switching to a 384-dim model like all-MiniLM-L6-v2.",
+    "criteria_completeness": "Must: (1) explain the mismatch (index expects 384, model outputs 768), (2) provide at least one fix option, (3) note that the model and pipeline don't need re-creation if index is fixed.",
+    "criteria_turn_efficiency": "Should provide diagnosis and fix in 1 turn.",
+    "criteria_autonomy": "All diagnostic info is in the error message. Should not ask clarifying questions."
+  },
+  {
+    "id": "recovery-resume-after-fix",
+    "workflow": "hybrid",
+    "prompt": "I was setting up hybrid search. Model deployed (id: m456), ingest pipeline created, but search pipeline creation failed because I had a typo in the weights. I've fixed the issue. The model is deployed, ingest pipeline is attached to 'products'. How do I continue?",
+    "context": { "partial_state": { "model_deployed": true, "model_id": "m456", "ingest_pipeline": true, "search_pipeline": false, "index": "products" } },
+    "criteria_correctness": "Must resume from creating the search pipeline. Must NOT re-deploy the model or recreate the ingest pipeline.",
+    "criteria_completeness": "Must: (1) acknowledge model and ingest pipeline are done, (2) provide the create-pipeline command for the search pipeline with hybrid weights, (3) suggest verify-search-pipeline after, (4) then bulk-index/launch-ui.",
+    "criteria_turn_efficiency": "Should provide remaining steps in 1 turn without asking what was already done (user stated it).",
+    "criteria_autonomy": "Should not ask about model or ingest pipeline status since user confirmed they're done."
+  },
+  {
+    "id": "docproc-pdf",
+    "workflow": "document_processing",
+    "prompt": "I have a folder of PDFs at ./research-papers/ that I want to make searchable with semantic search. Cluster is running.",
+    "context": { "cluster_status": "available", "data_source": "pdf_folder", "strategy": "dense_vector" },
+    "criteria_correctness": "Must mention Docling for PDF processing, explain chunking strategy options, and propose a pipeline that processes PDFs into searchable chunks with embeddings.",
+    "criteria_completeness": "Must cover: (1) Docling for PDF extraction, (2) chunking strategy (size, overlap), (3) embedding model for semantic search, (4) index mapping with text + vector fields, (5) ingestion workflow.",
+    "criteria_turn_efficiency": "Should present the full document processing plan. May ask one question about chunking preference or model choice.",
+    "criteria_autonomy": "Should recommend a chunking strategy and model rather than asking multiple rounds of questions."
+  },
+  {
+    "id": "switch-strategy",
+    "workflow": "cross_cutting",
+    "prompt": "I set up BM25 search on 'products' but search quality isn't great for natural language queries. I want to upgrade to hybrid search. What needs to change?",
+    "context": { "current_strategy": "bm25", "target_strategy": "hybrid", "index": "products" },
+    "criteria_correctness": "Must explain the incremental migration from BM25 to hybrid: deploy a model, add ingest pipeline, add vector field to mapping, reindex, add search pipeline with hybrid weights.",
+    "criteria_completeness": "Must cover: (1) deploy an embedding model, (2) add ingest pipeline, (3) update index mapping or create new index with vector field, (4) reindex data through pipeline, (5) create hybrid search pipeline with weights, (6) explain that existing BM25 functionality is preserved in hybrid.",
+    "criteria_turn_efficiency": "Should explain the full migration path in 1-2 turns. May ask about model preference.",
+    "criteria_autonomy": "Should provide actionable steps, not just conceptual explanation. Should recommend a model rather than only asking."
+  },
+  {
+    "id": "evaluate-quality",
+    "workflow": "cross_cutting",
+    "prompt": "My hybrid search is set up on 'products' but results don't seem relevant for some queries. How do I evaluate and improve search quality?",
+    "context": { "strategy": "hybrid", "index": "products", "issue": "relevance" },
+    "criteria_correctness": "Must reference the evaluation workflow (Phase 4.5) and suggest concrete evaluation steps like running test queries, checking nDCG/precision, and tuning weights.",
+    "criteria_completeness": "Must cover: (1) running evaluation with test queries, (2) metrics to look at (nDCG, precision, recall), (3) possible improvements (weight tuning, different model, field boosting), (4) how to compare before/after.",
+    "criteria_turn_efficiency": "Should provide the evaluation approach in 1-2 turns.",
+    "criteria_autonomy": "Should provide concrete steps to evaluate, not just ask 'what queries are failing?'"
+  }
+]

--- a/tests/evals/test_skill_workflows.py
+++ b/tests/evals/test_skill_workflows.py
@@ -1,0 +1,211 @@
+"""Eval tests: end-to-end workflow quality — LLM-as-judge.
+
+Tests that the opensearch-launchpad skill produces high-quality responses
+across all 5 search strategies and cross-cutting scenarios. Evaluates on
+5 dimensions: correctness, completeness, turn efficiency, autonomy, and
+token usage.
+
+Architecture:
+  1. call_skill_with_usage() — runs the skill as system prompt, returns
+     response + token counts (Haiku 4.5 via Bedrock)
+  2. GEval judge — evaluates response on 4 semantic criteria (Haiku 4.5)
+  3. Token tracking — records input/output tokens per case
+
+Run:
+    uv run --group evals pytest tests/evals/test_skill_workflows.py --run-eval -v
+    uv run --group evals pytest tests/evals/test_skill_workflows.py --run-eval-analysis
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("deepeval", reason="evals group not installed — run with: uv run --group evals pytest tests/evals/")
+pytest.importorskip("pytest_evals", reason="evals group not installed — run with: uv run --group evals pytest tests/evals/")
+from deepeval.metrics import GEval
+from deepeval.models import AmazonBedrockModel
+from deepeval.test_case import LLMTestCase, SingleTurnParams
+from pytest_evals import eval_bag  # noqa: F401 — fixture injected by plugin
+
+from tests.evals.conftest import (
+    call_skill_with_usage,
+    load_skill_md,
+    _BEDROCK_MODEL_ID,
+    _BEDROCK_REGION,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "workflow_evals.json"
+_CASES = json.loads(_FIXTURES.read_text())
+
+# Minimum fraction of workflow cases that must pass (per dimension).
+_PASS_THRESHOLD = 0.60
+
+# GEval pass threshold: score >= 0.5 means the criterion is satisfied.
+_GEVAL_THRESHOLD = 0.5
+
+# Dimensions to evaluate
+_DIMENSIONS = ["correctness", "completeness", "turn_efficiency", "autonomy"]
+
+
+def _make_judge(
+    model_id: str = _BEDROCK_MODEL_ID, region: str = _BEDROCK_REGION
+) -> AmazonBedrockModel:
+    return AmazonBedrockModel(model=model_id, region=region)
+
+
+# ---------------------------------------------------------------------------
+# Eval phase — one test per golden case
+# ---------------------------------------------------------------------------
+
+@pytest.mark.eval(name="skill_workflows")
+@pytest.mark.parametrize("case", _CASES, ids=[c["id"] for c in _CASES])
+def test_skill_workflow(case, eval_bag, bedrock_client):  # noqa: F811
+    """Load the launchpad skill, get a response, judge on 4 dimensions + track tokens."""
+    if bedrock_client is None:
+        pytest.skip("AWS Bedrock credentials not available")
+
+    skill_md = load_skill_md("opensearch-launchpad")
+    response, token_usage = call_skill_with_usage(
+        skill_md, case["prompt"], bedrock_client
+    )
+
+    judge = _make_judge()
+    scores = {}
+    reasons = {}
+
+    for dim in _DIMENSIONS:
+        criteria_key = f"criteria_{dim}"
+        criteria = case.get(criteria_key, "")
+        if not criteria:
+            continue
+
+        metric = GEval(
+            name=f"Workflow:{case['id']}:{dim}",
+            criteria=criteria,
+            evaluation_params=[SingleTurnParams.INPUT, SingleTurnParams.ACTUAL_OUTPUT],
+            threshold=_GEVAL_THRESHOLD,
+            model=judge,
+            async_mode=False,
+        )
+
+        test_case = LLMTestCase(
+            input=case["prompt"],
+            actual_output=response,
+        )
+        metric.measure(test_case)
+        scores[dim] = metric.score
+        reasons[dim] = metric.reason
+
+    # Determine overall pass: all dimensions must meet threshold
+    all_passed = all(s >= _GEVAL_THRESHOLD for s in scores.values())
+
+    # Store results in eval_bag
+    eval_bag.case_id = case["id"]
+    eval_bag.workflow = case["workflow"]
+    eval_bag.prompt = case["prompt"]
+    eval_bag.response = response
+    eval_bag.scores = scores
+    eval_bag.reasons = reasons
+    eval_bag.passed = all_passed
+    eval_bag.input_tokens = token_usage["input_tokens"]
+    eval_bag.output_tokens = token_usage["output_tokens"]
+    eval_bag.total_tokens = token_usage["total_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# Analysis phase — aggregate results
+# ---------------------------------------------------------------------------
+
+@pytest.mark.eval_analysis(name="skill_workflows")
+def test_workflow_quality(eval_results):
+    """Enforce minimum quality across all workflow eval cases."""
+    if not eval_results:
+        pytest.skip("No eval results to analyze")
+
+    ran = [r for r in eval_results if hasattr(r.result, "passed")]
+    if not ran:
+        pytest.skip("All eval cases were skipped (no AWS credentials available)")
+
+    # Print header
+    print(f"\n{'═' * 80}")
+    print("WORKFLOW EVAL RESULTS")
+    print(f"{'═' * 80}")
+
+    # Per-dimension aggregate
+    dim_scores: dict[str, list[float]] = {d: [] for d in _DIMENSIONS}
+    for r in ran:
+        for dim, score in r.result.scores.items():
+            dim_scores[dim].append(score)
+
+    print(f"\n{'─' * 60}")
+    print("Aggregate Scores by Dimension")
+    print(f"{'─' * 60}")
+    for dim in _DIMENSIONS:
+        scores_list = dim_scores[dim]
+        if scores_list:
+            mean = sum(scores_list) / len(scores_list)
+            pass_count = sum(1 for s in scores_list if s >= _GEVAL_THRESHOLD)
+            print(f"  {dim:20s}: mean={mean:.3f}  pass_rate={pass_count}/{len(scores_list)}")
+
+    # Per-workflow breakdown
+    by_workflow: dict[str, list] = {}
+    for r in ran:
+        by_workflow.setdefault(r.result.workflow, []).append(r)
+
+    print(f"\n{'─' * 60}")
+    print("Per-Workflow Breakdown")
+    print(f"{'─' * 60}")
+    for workflow, results in sorted(by_workflow.items()):
+        workflow_passed = sum(1 for r in results if r.result.passed)
+        print(f"\n  {workflow}: {workflow_passed}/{len(results)} fully passed")
+        for r in results:
+            status = "PASS" if r.result.passed else "FAIL"
+            scores_str = " | ".join(
+                f"{d[:4]}={s:.2f}" for d, s in r.result.scores.items()
+            )
+            print(f"    [{status}] {r.result.case_id}: {scores_str}")
+            if not r.result.passed:
+                for dim, reason in r.result.reasons.items():
+                    if r.result.scores.get(dim, 1.0) < _GEVAL_THRESHOLD:
+                        print(f"          {dim}: {reason}")
+
+    # Token usage summary
+    print(f"\n{'─' * 60}")
+    print("Token Usage Summary")
+    print(f"{'─' * 60}")
+    total_input = sum(r.result.input_tokens for r in ran)
+    total_output = sum(r.result.output_tokens for r in ran)
+    avg_input = total_input / len(ran) if ran else 0
+    avg_output = total_output / len(ran) if ran else 0
+    print(f"  Total cases: {len(ran)}")
+    print(f"  Avg input tokens:  {avg_input:.0f}")
+    print(f"  Avg output tokens: {avg_output:.0f}")
+    print(f"  Avg total tokens:  {avg_input + avg_output:.0f}")
+    print(f"  Total tokens used: {total_input + total_output}")
+
+    # Per-workflow token usage
+    print(f"\n  By workflow:")
+    for workflow, results in sorted(by_workflow.items()):
+        wf_input = sum(r.result.input_tokens for r in results)
+        wf_output = sum(r.result.output_tokens for r in results)
+        wf_avg = (wf_input + wf_output) / len(results)
+        print(f"    {workflow:20s}: avg={wf_avg:.0f} tokens/case ({len(results)} cases)")
+
+    print(f"\n{'═' * 80}")
+
+    # Enforce pass rates per dimension
+    failures = []
+    for dim in _DIMENSIONS:
+        scores_list = dim_scores[dim]
+        if not scores_list:
+            continue
+        pass_rate = sum(1 for s in scores_list if s >= _GEVAL_THRESHOLD) / len(scores_list)
+        if pass_rate < _PASS_THRESHOLD:
+            failures.append(f"{dim}: {pass_rate:.0%} < {_PASS_THRESHOLD:.0%}")
+
+    if failures:
+        assert False, (
+            f"Workflow eval dimensions below {_PASS_THRESHOLD:.0%} threshold:\n"
+            + "\n".join(f"  - {f}" for f in failures)
+        )


### PR DESCRIPTION
## Summary

  Agent skills are non-deterministic — the same skill can produce different token usage,
  turn counts, and task completion rates across runs. Without measurement, skill edits
  (prompt changes, new commands, workflow restructuring) can silently regress performance.
  This PR introduces a benchmark framework that quantifies skill performance and gates CI
  on regressions, alongside new composite commands that resulted from benchmark-driven
  improvements.

  ## Why benchmarks matter for agent skills

  1. **Visibility** — Skill changes (SKILL.md edits, new commands) shift agent behavior
     in ways that aren't obvious from code review alone. Benchmarks surface regressions
     in token efficiency, turn count, and task success rate.

  2. **Feedback loop** — Benchmarks showed that the agentic search setup required too many
     turns (agent asked questions one-at-a-time, failed mid-setup without recovery). This
     directly motivated the SKILL.md autonomy rules and the `setup-agentic-search` composite                                                                                       
     command — reducing a 6+ turn workflow to 1-2 turns.                                                                                                                           
                                                                                                                                                                                   
  3. **CI guardrail** — The baseline comparison (`compare_baseline.py`) fails CI if any                                                                                            
     dimension regresses >10%, preventing slow degradation over time. When all dimensions                                                                                          
     improve, the baseline auto-ratchets upward.           

## Results
### _**This benchmark evaluates skill instruction quality using a single model (Claude Haiku). Metrics like turn_efficiency and autonomy measure how well the SKILL.md guides  toward efficient behavior — actual turn counts and token usage will vary across agent runtimes (Kiro, Claude Code, Cursor). Agent-specific integration benchmarks can be done locally with same eval scripts.**_                                                                                                                                                     
                                                                                                                                                                 
 | Dimension | Baseline | After | Δ | Pass rate |                                                                                                               
  |---|---:|---:|---:|---|                                                                                                                                       
  | Correctness | 0.564 | 0.764 | **+35.6%** | 52% → 85% |                                                                                                       
  | Completeness | 0.533 | 0.732 | **+37.3%** | 50% → 88% |                                                                                                      
  | Turn efficiency | 0.499 | 0.707 | **+41.8%** | 42% → 77% |                                                                                                   
  | Autonomy | 0.554 | 0.731 | **+32.0%** | 52% → 73% |                                                                                                          
  | Tokens/case (happy path) | 2,126 | 3,278 | +54.2% | trade-off for quality |                                                                                  
  | Tokens/case (failure path)¹ | ~12,000 | ~5,500 | **−54%** | checkpoint/resume saves retries |                                                                
                                                                                                                                                                 
 > ¹ Eval measures single-turn token cost (one skill invocation). Failure-path estimates                                                                        
  > reflect full multi-turn workflows (4–6 turns with growing context). Without                                                                                  
  > checkpoint/resume, a mid-setup failure forces a full restart — doubling the multi-turn                                                                       
  > cost. Gates detect failures early and resume from the last successful step.                                                                                                                                   
                                                                                                                                                                                   
  ## Changes                                                                                                                                                                       
                                                                                                                                                                                   
  **Benchmarks & Evals**                                                                                                                                                           
  - Workflow benchmark framework: `run_benchmark.py`, `compare_baseline.py`, `update_baseline.py`
  - Eval fixtures covering all 5 search strategies (BM25, dense, sparse, hybrid, agentic)                                                                                          
  - Token tracking via `call_skill_with_usage` in eval conftest                                                                                                                    
  - CI integration: run benchmarks post-eval, auto-update baseline on main                                                                                                         
                                                                                                                                                                                   
  **Benchmark-driven improvements**                                                                                                                                                
  - `setup-agentic-search` — full pipeline setup in one command (was 4+ separate steps)                                                                                            
  - `check-agentic-setup` — post-setup diagnostics to verify all components are healthy                                                                                            
  - SKILL.md: skip phases when info is provided, batch questions, recovery from mid-setup failures                                                                                 
                                                                                                                                                                                   
  **Bug fix**                                                                                                                                                                      
  - Fix symlinked static assets 404 in Search Builder UI                                                                                                                           
                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                   
                                                                                                                                                                                   
  - [x] `uv run pytest tests/ --ignore=tests/evals -v` passes                                                                                                                      
  - [x] `make benchmark` runs locally and produces scored output
  - [x] DCO sign-off on all commits  

## Benchmakrs Results
- command: `AWS_PROFILE=bedrock AWS_REGION=us-west-2 make benchmark`      
- number of runs matters for the final benchmarking accuracy. In benchmarks, I tried 3 runs and average. 
- this is single run results                                                                                  

```
uv run --group evals python scripts/run_benchmark.py --runs 1
Loaded 16 workflow eval cases
Running 1 run(s)...
  Running: bm25-full-info... corr=0.70 | comp=0.40 | turn=0.30 | auto=0.20 | tokens=2984
  Running: bm25-minimal... corr=0.40 | comp=0.60 | turn=0.90 | auto=0.85 | tokens=2934
  Running: dense-full-info... corr=0.65 | comp=0.71 | turn=0.85 | auto=0.85 | tokens=3721
  Running: dense-model-choice... corr=0.00 | comp=0.00 | turn=0.25 | auto=0.35 | tokens=3129
  Running: hybrid-full-info... corr=0.85 | comp=0.60 | turn=0.75 | auto=0.85 | tokens=3804
  Running: hybrid-minimal... corr=0.35 | comp=0.65 | turn=0.95 | auto=0.95 | tokens=2968
  Running: sparse-full-info... corr=0.75 | comp=0.90 | turn=0.75 | auto=0.85 | tokens=3791
  Running: agentic-conv-full-info... corr=0.95 | comp=0.90 | turn=0.85 | auto=0.95 | tokens=3204
  Running: agentic-flow-full-info... corr=0.30 | comp=0.45 | turn=0.35 | auto=0.35 | tokens=3155
  Running: agentic-missing-info... corr=0.90 | comp=0.00 | turn=0.95 | auto=0.95 | tokens=3013
  Running: recovery-creds-expired... corr=0.95 | comp=0.95 | turn=0.85 | auto=0.95 | tokens=3189
  Running: recovery-dim-mismatch... corr=0.15 | comp=0.40 | turn=0.92 | auto=0.95 | tokens=3335
  Running: recovery-resume-after-fix... corr=0.95 | comp=0.40 | turn=0.30 | auto=0.95 | tokens=2907
  Running: docproc-pdf... corr=0.65 | comp=0.45 | turn=0.00 | auto=0.25 | tokens=3124
  Running: switch-strategy... corr=0.92 | comp=0.85 | turn=0.85 | auto=0.72 | tokens=3433
  Running: evaluate-quality... corr=0.85 | comp=0.85 | turn=0.72 | auto=0.45 | tokens=3344

════════════════════════════════════════════════════════════
Results saved to: /Users/mfenqin/workspace/opensearch-agent-skills/tests/evals/results/benchmark-1778618724.json
════════════════════════════════════════════════════════════

SUMMARY (benchmark-1778618724, 1 run(s), 16 cases)
────────────────────────────────────────────────────────────
  correctness         : mean=0.645 stdev=0.310 pass_rate=69%
  completeness        : mean=0.569 stdev=0.296 pass_rate=56%
  turn_efficiency     : mean=0.659 stdev=0.307 pass_rate=69%
  autonomy            : mean=0.714 stdev=0.285 pass_rate=69%
  tokens              : mean=3252 stdev=299 total=52035
```

- command: `AWS_PROFILE=bedrock AWS_REGION=us-west-2 make compare`

```
uv run --group evals python scripts/compare_baseline.py
Baseline: baseline.json (tag: baseline-v2)
Current:  benchmark-1778618724.json (tag: benchmark-1778618724)
Threshold: -10% regression allowed

| Dimension            |   Baseline |    Current |      Delta | Status     |
|----------------------|------------|------------|------------|------------|
| correctness          |      0.564 |      0.645 |     +14.5% | IMPROVED   |
| completeness         |      0.533 |      0.569 |      +6.9% | IMPROVED   |
| turn_efficiency      |      0.499 |      0.659 |     +32.1% | IMPROVED   |
| autonomy             |      0.554 |      0.714 |     +28.9% | IMPROVED   |
| tokens (avg)         |       2126 |       3252 |     +53.0% | INFO       |
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
