### PR TITLE
docs(ppl): expand PPL reference coverage and require upstream + cluster verification

### DIFF
--- a/skills/opensearch-skills/observability/log-analytics/SKILL.md
+++ b/skills/opensearch-skills/observability/log-analytics/SKILL.md
@@ -103,6 +103,8 @@ For Amazon OpenSearch Serverless (AOSS) — [User Guide](https://github.com/open
 - Fall back to Query DSL for complex aggregations PPL doesn't support well.
 - Always backtick-quote dotted field names in PPL: `` `log.level` ``, `` `host.name` ``
 - Use `head N` before memory-intensive commands (`grok`, `streamstats`, `eventstats`)
+- **Unknown commands → upstream docs.** If a PPL command or function isn't in [ppl-reference.md](../ppl-reference.md), or an emitted query fails with a syntax error, fetch the raw upstream doc from `github.com/opensearch-project/sql` under `docs/user/ppl/` before answering. See [ppl-reference.md](../ppl-reference.md) "Looking Up PPL Documentation" for exact URL patterns.
+- **Verify queries when an endpoint is available — best-effort cascade.** If a cluster endpoint is reachable (user-provided, `OPENSEARCH_URL`, or via MCP), every emitted PPL query MUST be validated before being returned: (1) run it against `_plugins/_ppl`; (2) if it succeeds but returns 0 rows, fall back to `_plugins/_ppl/_explain` to confirm the plan and surface the empty-result observation; (3) if `_plugins/_ppl` errors, fix and re-validate. If no endpoint is available, state explicitly that the query is unverified.
 
 ## Workflow
 
@@ -155,4 +157,4 @@ Build PPL queries using the actual field names discovered. Common analytics:
 | File | Content |
 |---|---|
 | [log-analytics.md](log-analytics.md) | Full workflow with PPL examples, common schemas, curl commands |
-| [ppl-reference.md](../ppl-reference.md) | PPL syntax — 50+ commands, 14 function categories |
+| [ppl-reference.md](../ppl-reference.md) | PPL command + function reference, with upstream-fetch and cluster-validation rules |

--- a/skills/opensearch-skills/observability/ppl-reference.md
+++ b/skills/opensearch-skills/observability/ppl-reference.md
@@ -37,19 +37,28 @@ curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
   -d '{"query": "source=otel-v1-apm-span-* | where `status.code` = 2 | stats count() by serviceName"}'
 ```
 
+> `_explain` accepts an optional `mode` (`standard` / `simple` / `cost` / `extended`). `simple`, `cost`, and `extended` require the v3 engine (`plugins.calcite.enabled=true`); `standard` works on both v2 and v3.
+
 ## Core Commands
 
 | Command | Syntax | Description |
 |---|---|---|
 | `source` | `source=<index>` | Start query from index pattern |
+| `search` | `search source=<index> [<expr>]` | Alternative first command; supports search-expression syntax (`field=value`, `AND/OR/NOT`, time modifiers) |
 | `where` | `where <condition>` | Filter rows |
+| `regex` | `regex <field> = '<pattern>'` (or `!=`) | Filter rows by Java regex on a field |
 | `fields` | `fields [+\|-] <list>` | Select/exclude fields |
+| `table` | `table [+\|-] <list>` | Alias for `fields` (SPL ergonomics) |
 | `stats` | `stats <agg>... [by <field>]` | Aggregate data |
 | `sort` | `sort [+\|-] <field>` | Order results (+ asc, - desc) |
+| `reverse` | `reverse` | Reverse result order (⚠️ no-op without preceding `sort` or `@timestamp`; collation-destroying ops like `stats`/`join` make it a no-op) |
 | `head` | `head [N]` | Limit results (default 10) |
 | `eval` | `eval <new> = <expr>` | Compute new fields |
+| `fieldformat` | `fieldformat <field>=[(prefix).]<expr>[.(suffix)]` | `eval` alias with prefix/suffix string concat for display |
 | `dedup` | `dedup [N] <field>` | Remove duplicates |
 | `rename` | `rename <old> AS <new>` | Rename fields |
+| `replace` | `replace '<pat>' WITH '<repl>' IN <field>` | Literal/wildcard string replace in fields (supports `*`) |
+| `convert` | `convert <fn>(<field>) [AS <field>]` | Type-coerce fields (`auto()`, `num()`, `mktime()`, `ctime()`, `dur2sec()`, `mstime()`, `memk()`, `rmcomma()`, `rmunit()`, `none()`) |
 | `top` | `top [N] <field>` | Most frequent values |
 | `rare` | `rare <field>` | Least frequent values |
 
@@ -57,7 +66,9 @@ curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
 
 | Command | Syntax | Description |
 |---|---|---|
+| `bin` | `bin <field> [span=<int>] [bins=<n>] [minspan=<int>] [aligntime=...] [start=<v>] [end=<v>]` | Bucket numeric/time values into equal-width bins (⚠️ `bins=` on timestamps requires `plugins.calcite.pushdown.enabled=true` *and* the binned field must be in a `stats` aggregation; otherwise use `span=`) |
 | `timechart` | `timechart span=<interval> <agg> [by <field>]` | Time-bucketed aggregation |
+| `chart` | `chart <agg> [by <row> <col>] \| [over <row> [by <col>]] [limit=topN] [useother=<bool>] [usenull=<bool>]` | Aggregate + pivot (row split × column split) for 2D charts |
 | `span()` | `span(<field>, <interval>)` | Bucket numeric/date values |
 | `trendline` | `trendline sort <field> sma(<N>, <field>)` | Moving average |
 | `streamstats` | `streamstats <agg> [by <field>]` | Running statistics (⚠️ memory-intensive) |
@@ -65,7 +76,7 @@ curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
 
 ### Span Time Units
 
-`ms`, `s`, `m`, `h`, `d`, `w`, `M`, `q`, `y`
+`ms`, `s`, `m`, `h`, `d`, `w`, `M`, `q`, `y`. The `bin` command also accepts `us`, `cs`, `ds`, plus longhand forms (`sec`, `seconds`, `min`, `minutes`, `hr`, `hours`, etc.).
 
 ### Timechart Rate Functions
 
@@ -79,15 +90,21 @@ curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
 | `grok` | `grok <field> '<pattern>'` | Grok pattern extraction (⚠️ memory-intensive) |
 | `rex` | `rex field=<field> '<regex>'` | Named capture groups |
 | `patterns` | `patterns <field>` | Auto-discover log patterns |
+| `spath` | `spath input=<field> [output=<field>] [path=<path>]` | Extract from structured JSON (path-based or auto-extract) (⚠️ runs on coordinator node — slow on large datasets; prefer indexing fields directly) |
 
-## Join/Lookup Commands
+## Join/Lookup/Set Commands
 
 | Command | Syntax | Description |
 |---|---|---|
 | `join` | `join left=a right=b ON a.f = b.f <index>` | Cross-index join |
 | `lookup` | `lookup <index> <field> [OUTPUT <fields>]` | Enrich from another index |
 | `subquery` | `where <f> IN [source=<idx> \| ... \| fields <f>]` | Nested query filter |
+| `union` | `union [maxout=<n>] <ds1> <ds2> [...]` | UNION ALL across datasets/subsearches; auto type-coerces conflicting schemas |
+| `multisearch` | `multisearch [<sub1>] [<sub2>] [...]` | Run + merge subsearches; supports timestamp-based interleaving |
 | `append` | `append [source=<idx> \| ...]` | Append results from another query |
+| `appendcol` | `appendcol [override=<bool>] [<subsearch>]` | Append subsearch result as additional **columns** |
+| `appendpipe` | `appendpipe [<subpipeline>]` | Append subpipeline results to main results (subpipeline runs lazily) |
+| `graphLookup` | `graphLookup <idx> start=<expr> edge=<from><op><to> [maxDepth=<n>] ... as <out>` | (Experimental) Recursive BFS graph traversal |
 
 > **Caveat:** Cross-index `join` may return 0 rows on OpenSearch 3.x. Use separate queries + correlate by traceId as fallback.
 
@@ -98,7 +115,12 @@ curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
 | `fillnull` | Replace nulls (⚠️ backtick fields not supported in field list) |
 | `flatten` | Flatten nested fields to top-level |
 | `expand` | Expand arrays into separate rows |
+| `mvexpand` | Expand each value of a multivalue (array) field into a separate row (`mvexpand <field> [limit=<n>]`) |
+| `mvcombine` | Group rows identical except for target field; combine target into multivalue array |
+| `nomv` | Convert multivalue field to single-value string (joined by `\n`) |
 | `transpose` | Pivot rows into columns |
+| `addtotals` | `addtotals [field-list] [row=<bool>] [col=<bool>] [label=<s>] [labelfield=<f>] [fieldname=<f>]` — row/column totals (numeric fields only) |
+| `addcoltotals` | Column-only totals; equivalent to `addtotals row=false col=true` |
 
 ## Aggregation Functions
 
@@ -107,12 +129,21 @@ curl -sk -u "$OPENSEARCH_USER:$OPENSEARCH_PASSWORD" \
 | `count()` | Count of events |
 | `sum(field)` | Sum |
 | `avg(field)` | Mean |
-| `max(field)` / `min(field)` | Max / Min |
+| `max(field)` / `min(field)` | Max / Min (aggregate context) |
 | `distinct_count(field)` | Count distinct values |
 | `percentile(field, pct)` | Value at percentile |
 | `var_samp(field)` / `stddev_samp(field)` | Sample variance / std dev |
 | `earliest(field)` / `latest(field)` | First / last chronological value |
 | `values(field)` | Distinct values as list |
+
+## Statistical Functions (eval-context, scalar)
+
+> ⚠️ **Distinct from aggregates.** These take N arguments and return a single value within `eval` — they do **not** aggregate across rows. Use aggregate `max(field)` / `min(field)` inside `stats`.
+
+| Function | Description |
+|---|---|
+| `MAX(x, y, ...)` | Largest of the supplied arguments (strings rank greater than numbers; for strings, lexicographic comparison) |
+| `MIN(x, y, ...)` | Smallest of the supplied arguments |
 
 ## Condition Functions
 
@@ -166,6 +197,56 @@ Types: STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP
 
 `abs()`, `ceil()`, `floor()`, `round(val, decimals)`, `sqrt()`, `pow()`, `mod()`, `log()`, `log10()`, `exp()`
 
+## Collection Functions (multivalue / array)
+
+| Function | Description |
+|---|---|
+| `array(v1, v2, ...)` | Construct an array; mixed types coerced to least-restrictive type |
+| `array_length(arr)` | Number of elements |
+| `mvjoin(arr, sep)` | Join multivalue field with separator |
+| `mvfilter(expr)` | Keep only elements matching the expression |
+| `mvindex(arr, start [, end])` | Element at index (or slice) |
+| `mvappend(v1, v2, ...)` | Concatenate values into one multivalue |
+
+## JSON Functions
+
+> **JSON path notation:** `<key1>{<idx1>}.<key2>{<idx2>}...`. `{}` (no index) means *all elements* in the array at that level (wildcard).
+
+| Function | Description |
+|---|---|
+| `json(value)` | Validate + parse a JSON string; returns `NULL` if invalid |
+| `json_extract(json, path)` | Extract value at JSON path |
+| `json_array(v1, v2, ...)` | Construct a JSON array |
+| `json_object(k1, v1, k2, v2, ...)` | Construct a JSON object |
+| `json_keys(json)` | Return array of top-level keys |
+
+## IP Functions
+
+| Function | Description |
+|---|---|
+| `cidrmatch(ip, cidr)` | True if `ip` falls within the CIDR range (IPv4 or IPv6) |
+| `geoip(ip)` | Geographic enrichment (where supported) |
+
+## Cryptographic Functions
+
+`md5(str)`, `sha1(str)`, `sha2(str, bits)` — return hex-encoded digest as STRING.
+
+## System Functions
+
+| Function | Description |
+|---|---|
+| `typeof(expr)` | Returns the data type of the expression as a STRING (useful for debugging) |
+
+## Expressions & Operators
+
+Arithmetic: `+`, `-`, `*`, `/`, `%`. Use parentheses to control precedence.
+
+> ⚠️ **Division behavior depends on cluster setting.** When `plugins.ppl.syntax.legacy.preferred=true` (default), integer / integer is *truncated*. When `false`, operands are promoted to floating-point and the fractional part is preserved. **Division by zero returns `NULL`, not an error.**
+>
+> ⚠️ **Modulo (`%`) is integer-only.** Applying `%` to floats raises a type error.
+
+Implicit type coercion follows function-signature matching (e.g., `int + double` resolves to `+(double, double)` and returns `double`).
+
 ## ML Commands
 
 | Command | Description |
@@ -175,12 +256,13 @@ Types: STRING, INT, LONG, FLOAT, DOUBLE, BOOLEAN, DATE, TIMESTAMP
 
 > `ml action=rcf` is not valid in OpenSearch 3.x. Use `ad` command directly.
 
-## System Commands
+## System / Inspection Commands
 
 | Command | Description |
 |---|---|
 | `describe <index>` | Inspect index mapping and field types |
 | `show datasources` | List configured data sources |
+| `explain [<mode>] <query>` | Display execution plan (must be the first command). `mode` ∈ `standard` (default) / `simple` / `cost` / `extended`. Non-`standard` modes require v3 engine. |
 
 ## Observability Examples
 
@@ -210,23 +292,35 @@ source=otel-v1-apm-span-* | where startTime > DATE_SUB(NOW(), INTERVAL 1 HOUR) |
 
 ## Looking Up PPL Documentation
 
-This reference covers the most common commands and functions. If a PPL command isn't listed here, a query fails with a syntax error, or you need to check version-specific behavior:
+> **PPL syntax varies between OpenSearch versions.** The `opensearch-project/sql` repository is the canonical grammar source — always verify upstream when a query returns an error or when the user's cluster version differs from this cheatsheet's reference state.
 
-1. Search OpenSearch docs:
-   ```bash
-   uv run python scripts/opensearch_ops.py search-docs --query "PPL <command_name> syntax"
-   ```
+This reference covers common commands and functions. **If a command or function isn't listed here, the canonical bleeding-edge source is the [opensearch-project/sql](https://github.com/opensearch-project/sql) repository under `docs/user/ppl/`.** Fetch the raw markdown directly:
 
-2. Search specifically for PPL grammar:
-   ```bash
-   uv run python scripts/opensearch_ops.py search-docs --query "site:opensearch.org PPL <command_name>"
-   ```
+- **Commands:** `https://raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/cmd/<command>.md`
+- **Functions:** `https://raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/functions/<category>.md`
+  Categories: `aggregations`, `collection`, `condition`, `conversion`, `cryptographic`, `datetime`, `expressions`, `ip`, `json`, `math`, `relevance`, `statistical`, `string`, `system`.
 
-3. If a web search tool is available, search directly:
-   ```
-   site:opensearch.org PPL <command_name> command
-   ```
+**The agent MUST consult this upstream source if:**
 
-4. The canonical PPL grammar source is the [opensearch-project/sql](https://github.com/opensearch-project/sql) repository under `docs/user/ppl/`. Fetch the relevant page if you need exact syntax for a specific command.
+- The command/function isn't in this cheatsheet.
+- A query the agent emitted fails with a syntax error.
+- The user asks about behavior that may be version-specific.
 
-Always verify PPL syntax against the docs when a query returns an error — syntax can vary between OpenSearch versions.
+Always prefer the upstream `opensearch-project/sql` source over `opensearch.org` documentation pages, which may trail the SQL repo by one or more releases.
+
+Secondary fallbacks (only if the upstream raw URL is unreachable):
+
+```bash
+uv run python scripts/opensearch_ops.py search-docs --query "PPL <command_name> syntax"
+```
+
+Or a web search scoped to `site:opensearch.org PPL <command_name>`.
+
+## Verifying Queries Against a Cluster
+
+When a cluster endpoint is available (provided by the user, configured via `OPENSEARCH_URL`, or wired via the `opensearch-mcp-server` MCP), every PPL query the agent emits **must** be verified before being returned to the user. Use a **best-effort cascade**:
+
+1. **Execute via `_plugins/_ppl`** and capture row count and any error.
+2. **If the query succeeds but returns 0 rows** (target index empty or filter overly strict), fall back to **`_plugins/_ppl/_explain`** to confirm the plan parses and resolves field references. Surface the empty-result observation to the user along with the validated query.
+3. **If `_plugins/_ppl` errors**, fix the query (consult upstream docs as needed) and re-validate. Do not return unverified PPL.
+4. **If no endpoint is available**, state explicitly that the query is unverified and recommend the user run `_explain` against their cluster before relying on it.

--- a/skills/opensearch-skills/observability/trace-analytics/SKILL.md
+++ b/skills/opensearch-skills/observability/trace-analytics/SKILL.md
@@ -103,6 +103,8 @@ For Amazon OpenSearch Serverless (AOSS):
 - Always backtick-quote dotted field names: `` `attributes.gen_ai.operation.name` ``
 - Use PPL as the primary query language.
 - Use `head N` to limit results on large trace indices.
+- **Unknown commands → upstream docs.** If a PPL command or function isn't in [ppl-reference.md](../ppl-reference.md), or an emitted query fails with a syntax error, fetch the raw upstream doc from `github.com/opensearch-project/sql` under `docs/user/ppl/` before answering. See [ppl-reference.md](../ppl-reference.md) "Looking Up PPL Documentation" for exact URL patterns.
+- **Verify queries when an endpoint is available — best-effort cascade.** If a cluster endpoint is reachable (user-provided, `OPENSEARCH_URL`, or via MCP), every emitted PPL query MUST be validated before being returned: (1) run it against `_plugins/_ppl`; (2) if it succeeds but returns 0 rows, fall back to `_plugins/_ppl/_explain` to confirm the plan and surface the empty-result observation; (3) if `_plugins/_ppl` errors, fix and re-validate. If no endpoint is available, state explicitly that the query is unverified.
 
 ## Workflow
 
@@ -149,4 +151,4 @@ Based on user intent, build PPL queries:
 | File | Content |
 |---|---|
 | [traces.md](traces.md) | Trace query templates, field reference, curl examples |
-| [ppl-reference.md](../ppl-reference.md) | PPL syntax — 50+ commands, 14 function categories |
+| [ppl-reference.md](../ppl-reference.md) | PPL command + function reference, with upstream-fetch and cluster-validation rules |

--- a/tests/evals/fixtures/skill_rules.json
+++ b/tests/evals/fixtures/skill_rules.json
@@ -110,5 +110,37 @@
     "rule": "Must not claim Serverless scales to zero",
     "criteria": "The response must NOT claim that Amazon OpenSearch Serverless scales to zero. It should accurately describe the pricing model (OCU-based) and clarify that Serverless does not scale to zero.",
     "rationale": "Key rule: do not describe Amazon OpenSearch Serverless as scaling to zero"
+  },
+  {
+    "id": "log-analytics-upstream-lookup-on-unknown",
+    "skill": "log-analytics",
+    "prompt": "How do I use the 'graphLookup' command in PPL to traverse a graph structure?",
+    "rule": "Must consult upstream docs when a command is not fully documented in the cheatsheet",
+    "criteria": "The response must mention fetching or consulting the upstream documentation from opensearch-project/sql (e.g., raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/) for the graphLookup command, rather than guessing syntax or refusing outright. It may also note that the command is experimental or has limited documentation.",
+    "rationale": "Key rule: unknown commands must trigger upstream doc lookup before answering"
+  },
+  {
+    "id": "log-analytics-verify-query-against-cluster",
+    "skill": "log-analytics",
+    "prompt": "My cluster is at https://localhost:9200 with admin/admin. Write a PPL query to count logs by severity over the last hour from the 'app-logs' index.",
+    "rule": "Must validate the emitted PPL query against the cluster or disclose it is unverified",
+    "criteria": "The response must either (1) run the query against _plugins/_ppl to validate it, or (2) explicitly state that the query has not been verified against the cluster. It must not present a PPL query as correct without mentioning verification status.",
+    "rationale": "Key rule: verify queries when an endpoint is available, or disclose unverified status"
+  },
+  {
+    "id": "trace-analytics-upstream-lookup-on-unknown",
+    "skill": "trace-analytics",
+    "prompt": "Can I use the 'explain' command in PPL to see the query execution plan for my trace queries?",
+    "rule": "Must consult upstream docs for explain command details",
+    "criteria": "The response must reference upstream documentation from opensearch-project/sql for the explain command's mode and engine parameters, rather than guessing the syntax. It should mention that explain has specific requirements (mode, engine) documented upstream.",
+    "rationale": "Key rule: unknown or partially-documented commands must trigger upstream doc lookup"
+  },
+  {
+    "id": "trace-analytics-verify-query-against-cluster",
+    "skill": "trace-analytics",
+    "prompt": "My cluster is at https://localhost:9200 with admin/admin. Show me a PPL query to find the slowest spans in the last 30 minutes from otel-v1-apm-span-* index.",
+    "rule": "Must validate the emitted PPL query against the cluster or disclose it is unverified",
+    "criteria": "The response must either (1) run the query against _plugins/_ppl to validate it, or (2) explicitly state that the query has not been verified against the cluster. It must not present a PPL query as correct without mentioning verification status.",
+    "rationale": "Key rule: verify queries when an endpoint is available, or disclose unverified status"
   }
 ]


### PR DESCRIPTION
## Summary

Expands `ppl-reference.md` with commands and function categories that are documented upstream in [`opensearch-project/sql/docs/user/ppl/`](https://github.com/opensearch-project/sql/tree/main/docs/user/ppl) but missing from the cheatsheet, and adds two behavioral rules to the observability skills covering upstream doc lookup and cluster-side query verification.

The cheatsheet remains the in-context source the agent loads on activation; [`opensearch-project/sql/docs/user/ppl/`](https://github.com/opensearch-project/sql/tree/main/docs/user/ppl) is the authoritative source-of-truth fallback the agent fetches when the cheatsheet is insufficient.

### What changed

**Reference coverage** — added rows for commands (`bin`, `chart`, `convert`, `mvexpand`, `mvcombine`, `nomv`, `regex`, `replace`, `spath`, `table`, `union`, `multisearch`, `appendcol`, `appendpipe`, `addtotals`, `addcoltotals`, `reverse`, `fieldformat`, `search`, `explain`, `graphLookup`) and full sections for the Collection, JSON, IP, Cryptographic, Statistical (eval-context), and System function categories, plus an Expressions & Operators section.

**Behavioral quirks documented inline** — `reverse` no-op rules, `bin` pushdown requirements for timestamp fields, `spath` coordinator-side execution, `explain` mode/engine requirements, `eval MAX/MIN` distinction from aggregate `max()`/`min()`, division/modulo behavior under `plugins.ppl.syntax.legacy.preferred`.

**Two new Key Rules** in [`log-analytics/SKILL.md`](skills/opensearch-skills/observability/log-analytics/SKILL.md) and [`trace-analytics/SKILL.md`](skills/opensearch-skills/observability/trace-analytics/SKILL.md):

- If a PPL command or function isn't in the cheatsheet, or a query fails with a syntax error, fetch the raw upstream doc from `raw.githubusercontent.com/opensearch-project/sql/main/docs/user/ppl/{cmd|functions}/<name>.md` before answering.
- When a cluster endpoint is reachable, validate emitted PPL via a cascade: `_plugins/_ppl` first; on zero-result success, fall back to `_plugins/_ppl/_explain` to confirm the plan; on error, fix and re-validate; if no endpoint is available, state the query is unverified.

The cheatsheet's "Looking Up PPL Documentation" section was rewritten with explicit upstream URL patterns, and a new "Verifying Queries Against a Cluster" section documents the cascade mechanics.

The stale `"50+ commands, 14 function categories"` description in both observability SKILL.md files was replaced with a content-oriented description that won't drift as the reference is updated.

### Validation: before/after on representative prompts

To check that these changes produce different agent behavior, three prompts were run against (a) the `main` skill state in a `git worktree` and (b) this PR's skill state, with no other context. Each sub-agent was instructed to use *only* the skill files for PPL syntax. Excerpts:

**Prompt 1 — "How do I bucket OTel span durations into 100ms buckets in PPL?"**

Before:
> Here's the query: `... | eval duration_ms = durationInNanos / 1000000 | stats count() as span_count by span(duration_ms, 100) ...`
>
> `[CONFIDENCE: medium]`

After:
> `... | eval duration_ms = durationInNanos / 1000000 | bin duration_ms span=100ms | stats count() as span_count by duration_ms | sort + duration_ms`
>
> `[CONFIDENCE: medium]`

The new cheatsheet documents `bin <field> span=<int>` and explicitly lists `ms` as a valid span unit, so the agent reaches for the purpose-built command instead of approximating with `span()`.

**Prompt 2 — "In PPL, how do I filter records where the source IP falls in 10.0.0.0/8?"**

Before:
> The skill files don't document a CIDR function for PPL... As a workaround using only commands I can confirm from the reference, you can filter on the string prefix when your CIDR aligns to an octet boundary... `where like(\`source.ip\`, '10.%')`. This will not work for arbitrary CIDR ranges like `/12` or `/20`.
>
> `[CONFIDENCE: low]`

After:
> Use the `cidrmatch` function inside a `where` clause: `... | where cidrmatch(src_ip, '10.0.0.0/8')`. `cidrmatch(ip, cidr)` returns true when the given IP falls within the CIDR range, and works for both IPv4 and IPv6.
>
> `[CONFIDENCE: high]`

The new IP Functions section gives the agent the right tool; without it, the agent fell back to a string-prefix workaround that only works for octet-aligned CIDRs.

**Prompt 3 — "What's the difference between `eval x = max(a, b)` and `stats max(a)` in PPL? Are they the same function?"**

Before:
> `eval x = max(a, b)` ... is not explicitly documented in the reference. The `eval` command computes per-row expressions, so if this form is supported it would be a per-row scalar... but the two-argument form is not in this reference, and you should verify it against the OpenSearch docs before relying on it.
>
> `[CONFIDENCE: medium]`

After:
> They are different functions, not the same... `stats max(a)` uses the **aggregate** `max(field)` — collapses rows. `eval x = max(a, b)` uses the **scalar / statistical** `MAX(x, y, ...)` — eval-context, per-row, multi-argument. The reference explicitly calls this out: "Distinct from aggregates. These take N arguments and return a single value within `eval` — they do not aggregate across rows."
>
> `[CONFIDENCE: high]`

The new Statistical Functions (eval-context) section disambiguates a trap where the same name maps to two different operations depending on context.

## Test plan

- [x] `uv run pytest tests/ -q` — 393 passed, 2 skipped
- [x] `uv run pytest tests/test_agent_skills_spec_compliance.py -v` — 112 passed
- [x] `ppl-reference.md` is 269 lines (under the 500-line cap)
- [x] Before/after agent behavior captured against representative prompts (above)
- [ ] Reviewer: spot-check that the new reference rows match upstream syntax
- [ ] Reviewer: consider eval cases for the two new Key Rules in `tests/evals/fixtures/skill_rules.json` as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)