### PR TITLE
fix：Add structured query parsing and fix array handling in suggestions

### DIFF
--- a/skills/opensearch-skills/scripts/lib/search.py
+++ b/skills/opensearch-skills/scripts/lib/search.py
@@ -4,6 +4,7 @@ Provides smart field detection, semantic/hybrid search, agentic search,
 suggestions, autocomplete, and preview text generation.
 """
 
+import json
 import re
 from opensearchpy import OpenSearch
 
@@ -282,6 +283,116 @@ def _resolve_semantic_runtime_hints(
 
 
 # ---------------------------------------------------------------------------
+# Structured query detection and building
+# ---------------------------------------------------------------------------
+_STRUCTURED_PATTERN = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_.]*)\s*([:<>=!]+)\s*(.+)$")
+
+
+def _parse_structured_query(query_text: str, field_specs: dict) -> list[dict] | None:
+    """Parse a query string into structured filter clauses if it matches
+    field:value patterns. Returns None if the query is not structured.
+
+    Supports:
+      - field:value (exact match for keyword/ip, term for numeric/date)
+      - field:>value, field:>=value, field:<value, field:<=value (range)
+      - Multiple clauses separated by spaces/AND (all must match)
+    """
+    if not field_specs:
+        return None
+
+    clauses = []
+    # Split on " AND " or just try the whole string as a single clause
+    parts = re.split(r"\s+AND\s+", query_text.strip())
+
+    for part in parts:
+        part = part.strip()
+        m = _STRUCTURED_PATTERN.match(part)
+        if not m:
+            return None  # Not a structured query
+
+        field_name, operator, value = m.group(1), m.group(2), m.group(3).strip()
+
+        # Resolve field: check exact name, then try .keyword sub-field
+        resolved_field = None
+        field_type = None
+        if field_name in field_specs:
+            resolved_field = field_name
+            field_type = field_specs[field_name].get("type", "")
+        elif f"{field_name}.keyword" in field_specs:
+            resolved_field = f"{field_name}.keyword"
+            field_type = "keyword"
+        else:
+            # Try case-insensitive match
+            for spec_name, spec in field_specs.items():
+                if spec_name.lower() == field_name.lower():
+                    resolved_field = spec_name
+                    field_type = spec.get("type", "")
+                    break
+            if not resolved_field:
+                return None  # Unknown field, not structured
+
+        if field_type not in _EXACT_TERM_FIELD_TYPES and field_type != "text":
+            return None
+
+        # Build clause based on operator
+        if operator in (":", ":=", "="):
+            # For text fields, use match; for exact types, use term
+            if field_type == "text":
+                clauses.append({"match": {resolved_field: value}})
+            else:
+                # Coerce numeric values
+                coerced = _coerce_value(value, field_type)
+                clauses.append({"term": {resolved_field: coerced}})
+        elif operator in (":>", ">"):
+            clauses.append({"range": {resolved_field: {"gt": _coerce_value(value, field_type)}}})
+        elif operator in (":>=", ">="):
+            clauses.append({"range": {resolved_field: {"gte": _coerce_value(value, field_type)}}})
+        elif operator in (":<", "<"):
+            clauses.append({"range": {resolved_field: {"lt": _coerce_value(value, field_type)}}})
+        elif operator in (":<=", "<="):
+            clauses.append({"range": {resolved_field: {"lte": _coerce_value(value, field_type)}}})
+        elif operator in (":!", "!="):
+            if field_type == "text":
+                clauses.append({"bool": {"must_not": [{"match": {resolved_field: value}}]}})
+            else:
+                coerced = _coerce_value(value, field_type)
+                clauses.append({"bool": {"must_not": [{"term": {resolved_field: coerced}}]}})
+        else:
+            return None  # Unsupported operator
+
+    return clauses if clauses else None
+
+
+def _coerce_value(value: str, field_type: str):
+    """Coerce a string value to the appropriate Python type for the field.
+
+    For keyword, date, ip, and version fields, the string is kept as-is
+    since OpenSearch expects string values for those types in term queries.
+    For numeric and boolean fields, we parse to the native Python type
+    so the JSON payload matches what OpenSearch expects.
+    """
+    # Keep string types as strings — OpenSearch handles them natively
+    if field_type in _KEYWORD_FIELD_TYPES or field_type in ("date", "date_nanos", "ip", "version"):
+        return value
+    # For all other types (numeric, boolean, unsigned_long), attempt JSON parsing
+    # which naturally handles int, float, true/false without per-type branches
+    try:
+        parsed = json.loads(value.lower() if value.lower() in ("true", "false") else value)
+        if isinstance(parsed, (bool, int, float)):
+            return parsed
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return value
+
+
+def _build_structured_filter(clauses: list[dict]) -> dict:
+    """Build an OpenSearch query from parsed structured clauses."""
+    if len(clauses) == 1:
+        return clauses[0]
+    return {"bool": {"must": clauses}}
+
+
+# ---------------------------------------------------------------------------
 # Query builders
 # ---------------------------------------------------------------------------
 def _build_default_lexical_query(query: str, fields: list[str]) -> dict:
@@ -473,6 +584,11 @@ def generate_suggestions(
                 val = doc.get(kf)
                 if val is None:
                     continue
+                # For array fields, use the first element
+                if isinstance(val, list):
+                    val = val[0] if val else None
+                    if val is None:
+                        continue
                 val_str = str(val).strip()
                 if val_str and len(val_str) < 60:
                     _add(f"{kf}:{val_str}", "structured", "FILTER", field=kf)
@@ -488,6 +604,10 @@ def generate_suggestions(
                 kf_val = doc.get(kf)
                 if kf_val is None:
                     continue
+                if isinstance(kf_val, list):
+                    kf_val = kf_val[0] if kf_val else None
+                    if kf_val is None:
+                        continue
                 kf_val_str = str(kf_val).strip()
                 if title_val and kf_val_str and len(kf_val_str) < 40:
                     words = title_val.split()[:3]
@@ -776,6 +896,7 @@ def _introspect_search_config(client: OpenSearch, index_name: str) -> dict:
     return {
         "strategy": strategy,
         "lexical_fields": lexical_fields,
+        "field_specs": field_specs,
         "vector_field": vector_field,
         "vector_type": "sparse" if has_sparse else "dense",
         "model_id": model_id,
@@ -788,15 +909,20 @@ def _introspect_search_config(client: OpenSearch, index_name: str) -> dict:
 def _build_search_query(config: dict, query_text: str, size: int, memory_id: str = "") -> dict:
     """Build the search query clause from a search config and query text.
 
-    The same query structure is used for ALL query types (exact, fuzzy,
-    semantic, autocomplete) because the index's pipeline configuration
-    handles scoring and normalization.
+    If the query matches a structured pattern (field:value), build a term/range
+    query. Otherwise, use the configured strategy (BM25, hybrid, neural, etc.).
     """
     strategy = config.get("strategy", "bm25")
     lexical_fields = config.get("lexical_fields", ["*"])
     vector_field = config.get("vector_field", "")
     vector_type = config.get("vector_type", "sparse")
     model_id = config.get("model_id", "")
+    field_specs = config.get("field_specs", {})
+
+    # Try structured query parsing first (field:value, field:>value, etc.)
+    structured_clauses = _parse_structured_query(query_text, field_specs)
+    if structured_clauses is not None:
+        return _build_structured_filter(structured_clauses)
 
     lexical = _build_default_lexical_query(query_text, lexical_fields)
 

--- a/tests/test_agent_skills_search.py
+++ b/tests/test_agent_skills_search.py
@@ -36,6 +36,9 @@ from lib.search import (
     clear_search_config,
     _search_configs,
     _agent_prompts_cache,
+    _parse_structured_query,
+    _coerce_value,
+    _build_structured_filter,
 )
 
 
@@ -1312,3 +1315,372 @@ def test_search_ui_search_non_agentic_no_retry_on_zero_hits():
     result = search_ui_search(client, "idx", "hello world")
     assert call_count == 1, "Non-agentic search should not retry"
     assert len(result["hits"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# _parse_structured_query
+# ---------------------------------------------------------------------------
+def test_parse_structured_query_single_keyword_match():
+    specs = {"genre": {"type": "keyword", "normalizer": ""}}
+    clauses = _parse_structured_query("genre:Action", specs)
+
+    assert clauses == [{"term": {"genre": "Action"}}]
+
+
+def test_parse_structured_query_integer_field():
+    specs = {"year": {"type": "integer", "normalizer": ""}}
+    clauses = _parse_structured_query("year:1999", specs)
+
+    assert clauses == [{"term": {"year": 1999}}]
+
+
+def test_parse_structured_query_range_gt():
+    specs = {"price": {"type": "float", "normalizer": ""}}
+    clauses = _parse_structured_query("price:>9.99", specs)
+
+    assert clauses == [{"range": {"price": {"gt": 9.99}}}]
+
+
+def test_parse_structured_query_range_gte():
+    specs = {"score": {"type": "integer", "normalizer": ""}}
+    clauses = _parse_structured_query("score:>=80", specs)
+
+    assert clauses == [{"range": {"score": {"gte": 80}}}]
+
+
+def test_parse_structured_query_range_lt():
+    specs = {"price": {"type": "float", "normalizer": ""}}
+    clauses = _parse_structured_query("price:<100.0", specs)
+
+    assert clauses == [{"range": {"price": {"lt": 100.0}}}]
+
+
+def test_parse_structured_query_range_lte():
+    specs = {"year": {"type": "integer", "normalizer": ""}}
+    clauses = _parse_structured_query("year:<=2020", specs)
+
+    assert clauses == [{"range": {"year": {"lte": 2020}}}]
+
+
+def test_parse_structured_query_negation_keyword():
+    specs = {"status": {"type": "keyword", "normalizer": ""}}
+    clauses = _parse_structured_query("status:!archived", specs)
+
+    assert clauses == [{"bool": {"must_not": [{"term": {"status": "archived"}}]}}]
+
+
+def test_parse_structured_query_negation_text():
+    specs = {"title": {"type": "text", "normalizer": ""}}
+    clauses = _parse_structured_query("title:!secret", specs)
+
+    assert clauses == [{"bool": {"must_not": [{"match": {"title": "secret"}}]}}]
+
+
+def test_parse_structured_query_text_field_uses_match():
+    specs = {"title": {"type": "text", "normalizer": ""}}
+    clauses = _parse_structured_query("title:hello world", specs)
+
+    assert clauses == [{"match": {"title": "hello world"}}]
+
+
+def test_parse_structured_query_multiple_clauses_AND():
+    specs = {
+        "genre": {"type": "keyword", "normalizer": ""},
+        "year": {"type": "integer", "normalizer": ""},
+    }
+    clauses = _parse_structured_query("genre:Action AND year:>2000", specs)
+
+    assert len(clauses) == 2
+    assert clauses[0] == {"term": {"genre": "Action"}}
+    assert clauses[1] == {"range": {"year": {"gt": 2000}}}
+
+
+def test_parse_structured_query_resolves_keyword_subfield():
+    specs = {
+        "title": {"type": "text", "normalizer": ""},
+        "title.keyword": {"type": "keyword", "normalizer": ""},
+    }
+    clauses = _parse_structured_query("title:The Matrix", specs)
+
+    # Should use text field's match, not .keyword's term
+    assert clauses == [{"match": {"title": "The Matrix"}}]
+
+
+def test_parse_structured_query_falls_back_to_keyword_subfield():
+    # Only .keyword exists, not the base field
+    specs = {"name.keyword": {"type": "keyword", "normalizer": ""}}
+    clauses = _parse_structured_query("name:Alice", specs)
+
+    assert clauses == [{"term": {"name.keyword": "Alice"}}]
+
+
+def test_parse_structured_query_case_insensitive_field():
+    specs = {"Genre": {"type": "keyword", "normalizer": ""}}
+    clauses = _parse_structured_query("genre:Comedy", specs)
+
+    assert clauses == [{"term": {"Genre": "Comedy"}}]
+
+
+def test_parse_structured_query_unknown_field_returns_none():
+    specs = {"title": {"type": "text", "normalizer": ""}}
+    result = _parse_structured_query("unknown_field:value", specs)
+
+    assert result is None
+
+
+def test_parse_structured_query_non_structured_text_returns_none():
+    specs = {"title": {"type": "text", "normalizer": ""}}
+    result = _parse_structured_query("just a natural language query", specs)
+
+    assert result is None
+
+
+def test_parse_structured_query_empty_specs_returns_none():
+    result = _parse_structured_query("field:value", {})
+
+    assert result is None
+
+
+def test_parse_structured_query_unsupported_field_type_returns_none():
+    specs = {"embedding": {"type": "knn_vector", "normalizer": ""}}
+    result = _parse_structured_query("embedding:something", specs)
+
+    assert result is None
+
+
+def test_parse_structured_query_boolean_field():
+    specs = {"is_active": {"type": "boolean", "normalizer": ""}}
+    clauses = _parse_structured_query("is_active:true", specs)
+
+    assert clauses == [{"term": {"is_active": True}}]
+
+
+def test_parse_structured_query_date_field():
+    specs = {"created_at": {"type": "date", "normalizer": ""}}
+    clauses = _parse_structured_query("created_at:2024-01-15", specs)
+
+    assert clauses == [{"term": {"created_at": "2024-01-15"}}]
+
+
+def test_parse_structured_query_equals_operator():
+    specs = {"status": {"type": "keyword", "normalizer": ""}}
+    clauses = _parse_structured_query("status=active", specs)
+
+    assert clauses == [{"term": {"status": "active"}}]
+
+
+def test_parse_structured_query_colon_equals_operator():
+    specs = {"status": {"type": "keyword", "normalizer": ""}}
+    clauses = _parse_structured_query("status:=active", specs)
+
+    assert clauses == [{"term": {"status": "active"}}]
+
+
+# ---------------------------------------------------------------------------
+# _coerce_value
+# ---------------------------------------------------------------------------
+def test_coerce_value_integer():
+    assert _coerce_value("42", "integer") == 42
+
+
+def test_coerce_value_float():
+    assert _coerce_value("3.14", "float") == 3.14
+
+
+def test_coerce_value_boolean_true():
+    assert _coerce_value("true", "boolean") is True
+
+
+def test_coerce_value_boolean_false():
+    assert _coerce_value("false", "boolean") is False
+
+
+def test_coerce_value_keyword_stays_string():
+    assert _coerce_value("42", "keyword") == "42"
+
+
+def test_coerce_value_date_stays_string():
+    assert _coerce_value("2024-01-15", "date") == "2024-01-15"
+
+
+def test_coerce_value_ip_stays_string():
+    assert _coerce_value("192.168.1.1", "ip") == "192.168.1.1"
+
+
+def test_coerce_value_non_numeric_string_stays_string():
+    assert _coerce_value("hello", "integer") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# _build_structured_filter
+# ---------------------------------------------------------------------------
+def test_build_structured_filter_single_clause():
+    clauses = [{"term": {"genre": "Action"}}]
+    result = _build_structured_filter(clauses)
+
+    assert result == {"term": {"genre": "Action"}}
+
+
+def test_build_structured_filter_multiple_clauses():
+    clauses = [
+        {"term": {"genre": "Action"}},
+        {"range": {"year": {"gt": 2000}}},
+    ]
+    result = _build_structured_filter(clauses)
+
+    assert result == {"bool": {"must": clauses}}
+
+
+# ---------------------------------------------------------------------------
+# _build_search_query — structured query integration
+# ---------------------------------------------------------------------------
+def test_build_search_query_structured_takes_precedence():
+    """Structured query should bypass the normal strategy (BM25/hybrid/etc)."""
+    config = {
+        "strategy": "hybrid",
+        "lexical_fields": ["title"],
+        "vector_field": "embedding",
+        "vector_type": "dense",
+        "model_id": "model-1",
+        "field_specs": {
+            "genre": {"type": "keyword", "normalizer": ""},
+            "title": {"type": "text", "normalizer": ""},
+        },
+    }
+    query = _build_search_query(config, "genre:Action", 10)
+
+    # Should produce a term query, not a hybrid query
+    assert query == {"term": {"genre": "Action"}}
+
+
+def test_build_search_query_non_structured_uses_strategy():
+    """Non-structured text should use the configured strategy."""
+    config = {
+        "strategy": "bm25",
+        "lexical_fields": ["title"],
+        "field_specs": {
+            "title": {"type": "text", "normalizer": ""},
+        },
+    }
+    query = _build_search_query(config, "hello world", 10)
+
+    assert "multi_match" in query
+
+
+def test_build_search_query_structured_with_range():
+    config = {
+        "strategy": "bm25",
+        "lexical_fields": ["title"],
+        "field_specs": {
+            "price": {"type": "float", "normalizer": ""},
+        },
+    }
+    query = _build_search_query(config, "price:>50.0", 10)
+
+    assert query == {"range": {"price": {"gt": 50.0}}}
+
+
+def test_build_search_query_structured_multi_clause():
+    config = {
+        "strategy": "bm25",
+        "lexical_fields": ["title"],
+        "field_specs": {
+            "genre": {"type": "keyword", "normalizer": ""},
+            "year": {"type": "integer", "normalizer": ""},
+        },
+    }
+    query = _build_search_query(config, "genre:Action AND year:>2000", 10)
+
+    assert query == {"bool": {"must": [
+        {"term": {"genre": "Action"}},
+        {"range": {"year": {"gt": 2000}}},
+    ]}}
+
+
+def test_build_search_query_no_field_specs_skips_structured():
+    """Without field_specs in config, structured parsing is skipped."""
+    config = {
+        "strategy": "bm25",
+        "lexical_fields": ["title"],
+        # No field_specs key
+    }
+    query = _build_search_query(config, "genre:Action", 10)
+
+    # Should fall through to lexical since no field_specs
+    assert "multi_match" in query
+
+
+# ---------------------------------------------------------------------------
+# generate_suggestions — array field handling
+# ---------------------------------------------------------------------------
+def test_generate_suggestions_handles_array_values():
+    """Array values in keyword fields should use first element for suggestions."""
+    client = _FakeClient(search_response={
+        "hits": {
+            "hits": [
+                {"_source": {"title": "The Matrix movie classic", "tags": ["action", "sci-fi"]}},
+                {"_source": {"title": "Inception is mind bending", "tags": ["thriller", "sci-fi"]}},
+                {"_source": {"title": "The Godfather classic film", "tags": ["drama", "crime"]}},
+                {"_source": {"title": "Pulp Fiction great movie", "tags": ["crime", "drama"]}},
+                {"_source": {"title": "Forrest Gump heartwarming", "tags": ["drama", "comedy"]}},
+                {"_source": {"title": "The Dark Knight rises", "tags": ["action", "thriller"]}},
+            ],
+            "total": {"value": 6},
+        },
+        "took": 1,
+    })
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"movies": {"mappings": {"properties": {
+                "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+                "tags": {"type": "keyword"},
+            }}}}
+        def get_settings(self, index):
+            return {"movies": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = generate_suggestions(client, "movies", max_count=8)
+
+    # Should have structured suggestions that use a single tag value, not "[action, sci-fi]"
+    structured = [s for s in result["suggestions"] if s["capability"] == "structured"]
+    for s in structured:
+        assert "[" not in s["text"], f"Array not unwrapped in suggestion: {s['text']}"
+
+
+def test_generate_suggestions_handles_empty_array():
+    """Empty array values should be skipped in suggestions."""
+    client = _FakeClient(search_response={
+        "hits": {
+            "hits": [
+                {"_source": {"title": "Test Movie One great film", "tags": []}},
+                {"_source": {"title": "Test Movie Two good show", "tags": ["action"]}},
+                {"_source": {"title": "Test Movie Three nice pic", "tags": []}},
+                {"_source": {"title": "Test Movie Four best ever", "tags": []}},
+                {"_source": {"title": "Test Movie Five classic", "tags": []}},
+                {"_source": {"title": "Test Movie Six awesome", "tags": []}},
+            ],
+            "total": {"value": 6},
+        },
+        "took": 1,
+    })
+
+    class _FakeIndices:
+        def get_mapping(self, index):
+            return {"movies": {"mappings": {"properties": {
+                "title": {"type": "text", "fields": {"keyword": {"type": "keyword"}}},
+                "tags": {"type": "keyword"},
+            }}}}
+        def get_settings(self, index):
+            return {"movies": {"settings": {"index": {}}}}
+
+    client.indices = _FakeIndices()
+
+    result = generate_suggestions(client, "movies", max_count=8)
+
+    # Should not crash and structured suggestions (if any) should use "action"
+    structured = [s for s in result["suggestions"] if s["capability"] == "structured"]
+    for s in structured:
+        if "tags" in s["text"]:
+            assert "tags:action" in s["text"]


### PR DESCRIPTION
## Summary                                                                                                                                                                       
                                                                                                                                                                                   
Benchmarked search.py against 15 diverse datasets (JSON, CSV, TSV) across BM25, hybrid, and agentic strategies. Found and fixed 3 platform bugs; identified 2 data-quality issues with workarounds.         

## Changes                                                                                                                                                                       
   
- **Structured query parsing** — `field:value` syntax now builds term/range queries instead of falling through to BM25 multi_match (Bug #1)                                      
- **Array field handling** — `generate_suggestions` uses first element instead of serializing full list (Bug #2)
- **Value coercion** — boolean/numeric values properly typed in term queries (Bug #3)                                                                                            
- **field_specs propagation** — `_introspect_search_config` passes field specs to enable structured detection at query time         

 ## Benchmark Results                                                                                                                                                             
                                                                                                                                                                                   
  15 datasets, 197 queries total. Average nDCG: 0.86, Average MRR: 0.91.                                                                                                           
                  
  | # | Dataset | Format | Strategy | nDCG | MRR | Bugs Found |                                                                                                                    
  |---|---|---|---|---|---|---|
  | 1 | apache_access_logs | JSON | BM25 | 1.0 | 1.0 | — |                                                                                                                         
  | 2 | app_error_logs | JSON | BM25 | 1.0 | 1.0 | — |                                                                                                                             
  | 3 | arxiv_papers | JSON | BM25 | 0.8 | 0.8 | #2 (array) |                                                                                                                      
  | 4 | bestbuy_electronics | CSV | BM25 | 0.98 | 1.0 | — |                                                                                                                        
  | 5 | ecommerce_products | CSV | BM25 | 0.91 | 0.93 | #3 (boolean) |                                                                                                             
  | 6 | gov_reports | CSV | Hybrid | 0.92 | 0.92 | — |                                                                                                                             
  | 7 | imdb.title.basics | TSV | BM25 | 0.22 | — | #4 (data quality) |                                                                                                            
  | 8 | legal_cases | JSON | Agentic | 0.79 | 0.83 | — |                                                                                                                           
  | 9 | opensearch_docs | JSON | Hybrid | 0.68 | 0.88 | — |                                                                                                                        
  | 10 | pubmed_abstracts | CSV | Hybrid | 1.0 | 1.0 | — |                                                                                                                         
  | 11 | sec_filings | JSON | BM25 | 0.9 | 0.9 | — |                                                                                                                               
  | 12 | spreadsheet_inventory | CSV | BM25 | 0.9 | 0.9 | — |                                                                                                                      
  | 13 | stackoverflow_posts | JSON | Hybrid | 0.79 | 0.79 | — |                                                                                                                   
  | 14 | support_tickets | CSV | Hybrid | 0.71 | 0.71 | #5 (data quality) |                                                                                                        
  | 15 | wayfair_furniture | JSON | Hybrid | 0.92 | 0.92 | — |                                                                                                                     
  | 16 | wikipedia_simple | JSON | Hybrid | 0.84 | 0.88 | — |                                                                                                                      
                                                                                                                                                                                   
  ## Bugs Fixed (platform)                                                                                                                                                         
                                                                                                                                                                                   
  | # | Bug | Fix |                                                                                                                                                                
  |---|---|---|   
  | 1 | `field:value` queries return 0 results | Added `_parse_structured_query` to detect and build term/range queries |                                                          
  | 2 | Array fields serialize as `['val1', ...]` in suggestions | Extract first element with `isinstance(val, list)` guard |                                                      
  | 3 | `in_stock:true` sends string instead of boolean | `_coerce_value` uses `json.loads` for non-string field types |                                                           
                                                                                                                                                                                   
  ## Known Issues (data quality, not platform bugs)                                                                                                                                
                                                                                                                                                                                   
  | # | Dataset | Issue | Workaround |                                                                                                                                             
  |---|---|---|---|
  | 4 | imdb.title.basics.tsv | `\N` null values rejected by integer/date fields | `ignore_malformed: true` |                                                                      
  | 5 | support_tickets.csv | Empty string `""` in date fields | `ignore_malformed: true` |    

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
