### PR TITLE
add aoss agentic setup integrated with nextgen provisioning

### DIFF
--- a/skills/opensearch-skills/cloud/aws-setup/SKILL.md
+++ b/skills/opensearch-skills/cloud/aws-setup/SKILL.md
@@ -94,8 +94,8 @@ For Amazon OpenSearch Serverless (AOSS):
 ## Key Rules
 
 - Do not describe **Amazon OpenSearch Serverless** as scaling to zero.
-- **Agentic search** does not deploy to **Serverless V1** — use a **managed domain** or **Serverless V2**.
-- **Serverless V2 (NextGen)** supports only **flow agents** — conversational agents require a managed domain.
+- **Agentic search** does not deploy to **Serverless V1** — use a **managed domain** or **Serverless NextGen**.
+- **Serverless NextGen (V2)** supports only **flow agents** — conversational agents require a managed domain.
 - Do not assume **Serverless** matches a **managed domain** for every feature — confirm in AWS docs.
 - Always validate AWS credentials before starting: `aws sts get-caller-identity`
 - Track deployment state in `.opensearch-deploy-state.json` at the workspace root.
@@ -107,11 +107,11 @@ Default deployment target is **Serverless NextGen** for all strategies except co
 
 | Strategy | Target | Collection Type | Why |
 |---|---|---|---|
-| `bm25` | Serverless V2 | SEARCH | Simple, no ML models needed |
-| `neural_sparse` | Serverless V2 | SEARCH | Automatic semantic enrichment built-in |
-| `dense_vector` | Serverless V2 | VECTORSEARCH | GPU-accelerated kNN, Bedrock connector supported |
-| `hybrid` | Serverless V2 | VECTORSEARCH | Combines BM25 + vector with GPU acceleration |
-| `agentic` (flow) | Serverless V2 | SEARCH | Stateless query planning, low latency, managed infra |
+| `bm25` | Serverless NextGen | SEARCH | Simple, no ML models needed |
+| `neural_sparse` | Serverless NextGen | SEARCH | Automatic semantic enrichment built-in |
+| `dense_vector` | Serverless NextGen | VECTORSEARCH | GPU-accelerated kNN, Bedrock connector supported |
+| `hybrid` | Serverless NextGen | VECTORSEARCH | Combines BM25 + vector with GPU acceleration |
+| `agentic` (flow) | Serverless NextGen | SEARCH | Stateless query planning, low latency, managed infra |
 | `agentic` (conversational) | Domain | — | Stateful with RAG + memory, multi-turn conversations |
 | Any (V1 requested) | Serverless V1 | — | Standard SDK, `StandbyReplicas=DISABLED` for dev/test |
 

--- a/skills/opensearch-skills/cloud/aws-setup/SKILL.md
+++ b/skills/opensearch-skills/cloud/aws-setup/SKILL.md
@@ -94,7 +94,8 @@ For Amazon OpenSearch Serverless (AOSS):
 ## Key Rules
 
 - Do not describe **Amazon OpenSearch Serverless** as scaling to zero.
-- **Agentic search** does not deploy to **Amazon OpenSearch Serverless** — use a **managed domain**.
+- **Agentic search** does not deploy to **Serverless V1** — use a **managed domain** or **Serverless V2**.
+- **Serverless V2 (NextGen)** supports only **flow agents** — conversational agents require a managed domain.
 - Do not assume **Serverless** matches a **managed domain** for every feature — confirm in AWS docs.
 - Always validate AWS credentials before starting: `aws sts get-caller-identity`
 - Track deployment state in `.opensearch-deploy-state.json` at the workspace root.
@@ -102,15 +103,21 @@ For Amazon OpenSearch Serverless (AOSS):
 
 ## Deployment Target Selection
 
-| Strategy | Target | Why |
-|---|---|---|
-| `bm25` | Serverless | Simple, no ML models needed |
-| `neural_sparse` | Serverless | Automatic semantic enrichment built-in |
-| `dense_vector` | Serverless | Bedrock connector supported |
-| `hybrid` | Serverless | Combines BM25 + vector on serverless |
-| `agentic` | Domain | Requires agent framework, not available on serverless |
+Default deployment target is **Serverless NextGen** for all strategies except conversational agentic search. Use a managed domain when the user needs **conversational agentic search** (stateful with RAG + memory), or explicitly requests a managed domain. Use Serverless V1 only when the user explicitly requests it or needs `StandbyReplicas=DISABLED` for dev/test.
+
+| Strategy | Target | Collection Type | Why |
+|---|---|---|---|
+| `bm25` | Serverless V2 | SEARCH | Simple, no ML models needed |
+| `neural_sparse` | Serverless V2 | SEARCH | Automatic semantic enrichment built-in |
+| `dense_vector` | Serverless V2 | VECTORSEARCH | GPU-accelerated kNN, Bedrock connector supported |
+| `hybrid` | Serverless V2 | VECTORSEARCH | Combines BM25 + vector with GPU acceleration |
+| `agentic` (flow) | Serverless V2 | SEARCH | Stateless query planning, low latency, managed infra |
+| `agentic` (conversational) | Domain | — | Stateful with RAG + memory, multi-turn conversations |
+| Any (V1 requested) | Serverless V1 | — | Standard SDK, `StandbyReplicas=DISABLED` for dev/test |
 
 ## Workflow
+
+Follow the guides linked in the table above, in order:
 
 ### Step 1 — Provision Infrastructure
 
@@ -126,10 +133,12 @@ For Amazon OpenSearch Serverless (AOSS):
 | Serverless collection | [aoss/serverless-02-deploy-search.md](aoss/serverless-02-deploy-search.md) |
 | Managed domain | [aos/domain-02-deploy-search.md](aos/domain-02-deploy-search.md) |
 
-### Step 3 — Configure Agentic Search (domain only)
+### Step 3 — Configure Agentic Search (if applicable)
 
-Only for agentic search on managed domains:
-- [aos/domain-03-agentic-setup.md](aos/domain-03-agentic-setup.md)
+| Target | Guide |
+|---|---|
+| Conversational Agent Search | [aos/domain-03-agentic-setup.md](aos/domain-03-agentic-setup.md) |
+| Flow Agent Search | [aoss/serverless-04-agentic-setup.md](aoss/serverless-04-agentic-setup.md) |
 
 ### Step 4 — Connect Search UI
 

--- a/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-04-agentic-setup.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-04-agentic-setup.md
@@ -29,7 +29,8 @@ aws iam create-role --role-name opensearch-bedrock-agent-role --assume-role-poli
     "Effect": "Allow",
     "Principal": { "Service": [
       "opensearchservice.amazonaws.com",
-      "aoss.amazonaws.com"
+      "aoss.amazonaws.com",
+      "global.prod.oasis.aoss.aws.internal"
     ]},
     "Action": "sts:AssumeRole"
   }]
@@ -46,7 +47,10 @@ aws iam put-role-policy --role-name opensearch-bedrock-agent-role \
     "Statement": [{
       "Effect": "Allow",
       "Action": "bedrock:InvokeModel",
-      "Resource": "arn:aws:bedrock:*::foundation-model/anthropic.claude-*"
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
     }]
   }'
 ```
@@ -140,14 +144,33 @@ Update state: `"search_pipeline_name": "agentic-search-pipeline"`
 
 ### Critical: Data Access Policy for Pipeline Search
 
-The IAM role used in the model connector's `credential.roleArn` (e.g., `bedrock-invocation-role`) **MUST** be added as a principal in the data access policy with access to all four ResourceTypes (`collection`, `index`, `model`, `agent`).
+The IAM role used in the model connector's `credential.roleArn` **MUST** be added as a principal in the data access policy with access to all four ResourceTypes (`collection`, `index`, `model`, `agent`).
 
 When the search pipeline invokes the agent internally, AOSS uses the connector's IAM role to:
 1. Read index mappings (requires `index` access)
 2. Execute the generated DSL query (requires `index` access)
 3. Invoke the model (requires `model` access)
+4. Execute the agent (requires `agent` access)
 
 Without this, pipeline-based `agentic` queries will fail with `403 Forbidden` even though direct `_execute` API calls work (because direct calls use the caller's identity).
+
+Required data access policy (set during provisioning or update now):
+
+```bash
+aws opensearchserverless create-access-policy --type data \
+  --name <collection-name>-access-policy \
+  --policy '[{
+    "Rules": [
+      {"Resource": ["collection/<collection-name>"], "Permission": ["aoss:*"], "ResourceType": "collection"},
+      {"Resource": ["index/<collection-name>/*"], "Permission": ["aoss:*"], "ResourceType": "index"},
+      {"Resource": ["model/<collection-name>/*"], "Permission": ["aoss:*"], "ResourceType": "model"},
+      {"Resource": ["agent/<collection-name>/*"], "Permission": ["aoss:*"], "ResourceType": "agent"}
+    ],
+    "Principal": ["<caller-principal-arn>", "<iam_role_arn>"]
+  }]' --region <aws_region>
+```
+
+Both the caller's principal (for manual API calls) and the connector IAM role (for pipeline-based invocation) must be listed as principals.
 
 ## Step 5: Test Agentic Search
 

--- a/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-04-agentic-setup.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-04-agentic-setup.md
@@ -1,4 +1,4 @@
-# Amazon OpenSearch Serverless V2 — Configure Flow Agent Search
+# Amazon OpenSearch Serverless NextGen — Configure Flow Agent Search
 
 This guide configures flow agent agentic search on a V2 serverless collection.
 

--- a/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-04-agentic-setup.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-04-agentic-setup.md
@@ -1,0 +1,215 @@
+# Amazon OpenSearch Serverless V2 — Configure Flow Agent Search
+
+This guide configures flow agent agentic search on a V2 serverless collection.
+
+Only **flow agents** are supported on V2 serverless. Flow agents are stateless — each query is independently planned and executed via `QueryPlanningTool`. For conversational agents (stateful with RAG + memory), use a managed domain instead.
+
+## Prerequisites
+
+- Completed [aoss-nextgen-provisioning/SKILL.md](aoss-nextgen-provisioning/SKILL.md) (collection active)
+- Completed [serverless-02-deploy-search.md](serverless-02-deploy-search.md) (index created with data)
+- Agent resource permissions included in data access policy (configured during provisioning)
+
+## State Input
+
+From `.opensearch-deploy-state.json`:
+- `resource_endpoint`: collection endpoint URL
+- `index_name`: target index
+- `aws_region`: for Bedrock endpoint
+- `principal_arn`: for IAM role
+
+## Step 1: Create IAM Role for Bedrock Access
+
+### Production trust policy:
+
+```bash
+aws iam create-role --role-name opensearch-bedrock-agent-role --assume-role-policy-document '{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Service": [
+      "opensearchservice.amazonaws.com",
+      "aoss.amazonaws.com"
+    ]},
+    "Action": "sts:AssumeRole"
+  }]
+}'
+```
+
+### Attach Bedrock invoke permissions:
+
+```bash
+aws iam put-role-policy --role-name opensearch-bedrock-agent-role \
+  --policy-name BedrockClaudeInvokePolicy \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": "bedrock:InvokeModel",
+      "Resource": "arn:aws:bedrock:*::foundation-model/anthropic.claude-*"
+    }]
+  }'
+```
+
+Update state: `"iam_role_arn": "<role-arn>"`
+
+## Step 2: Register Model with Inline Connector
+
+Register the model with an embedded connector in a single call. The connector's `request_body` must use the agent framework's template variables (`user_prompt`, `_chat_history`, `_interactions`, `tool_configs`).
+
+```
+POST <collection-endpoint>/_plugins/_ml/models/_register?deploy=true
+{
+  "name": "agentic search base model",
+  "function_name": "remote",
+  "connector": {
+    "name": "Bedrock Claude Connector",
+    "description": "Amazon Bedrock connector for Claude",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "parameters": {
+      "region": "<aws_region>",
+      "service_name": "bedrock",
+      "model": "us.anthropic.claude-sonnet-4-20250514-v1:0"
+    },
+    "credential": {
+      "roleArn": "<iam_role_arn>"
+    },
+    "actions": [{
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+      "headers": { "content-type": "application/json" },
+      "request_body": "{ \"system\": [{\"text\": \"${parameters.system_prompt}\"}], \"messages\": [${parameters._chat_history:-}{\"role\":\"user\",\"content\":[{\"text\":\"${parameters.user_prompt}\"}]}${parameters._interactions:-}]${parameters.tool_configs:-} }"
+    }]
+  }
+}
+```
+
+Wait for model state to reach `DEPLOYED`, then update state: `"model_id": "<model_id>"`
+
+## Step 3: Create Flow Agent
+
+```
+POST <collection-endpoint>/_plugins/_ml/agents/_register
+{
+  "name": "Agentic Search Agent",
+  "type": "flow",
+  "description": "Flow agent for natural language search with query planning",
+  "tools": [{
+    "type": "QueryPlanningTool",
+    "description": "A general tool to answer any question",
+    "parameters": {
+      "model_id": "<model_id>",
+      "response_filter": "$.output.message.content[0].text"
+    }
+  }]
+}
+```
+
+Notes:
+- `type` must be `flow` — conversational agents are not supported on V2 serverless
+- Only `QueryPlanningTool` is needed — it handles index mapping introspection internally
+- `response_filter` tells the tool how to extract the LLM response from the Bedrock Converse output
+- No `llm` block needed — the model is referenced inside the tool's `parameters`
+
+Update state: `"agent_id": "<agent_id>"`
+
+## Step 4: Create Agentic Search Pipeline
+
+```
+PUT <collection-endpoint>/_search/pipeline/agentic-search-pipeline
+{
+  "request_processors": [{
+    "agentic_query_translator": { "agent_id": "<agent_id>" }
+  }],
+  "response_processors": [{
+    "agentic_context": {
+      "agent_steps_summary": true,
+      "dsl_query": true
+    }
+  }]
+}
+```
+
+The `response_processors` with `agentic_context` adds metadata to the response:
+- `dsl_query`: the generated OpenSearch DSL
+- `agent_steps_summary`: reasoning steps the agent took
+
+Update state: `"search_pipeline_name": "agentic-search-pipeline"`
+
+### Critical: Data Access Policy for Pipeline Search
+
+The IAM role used in the model connector's `credential.roleArn` (e.g., `bedrock-invocation-role`) **MUST** be added as a principal in the data access policy with access to all four ResourceTypes (`collection`, `index`, `model`, `agent`).
+
+When the search pipeline invokes the agent internally, AOSS uses the connector's IAM role to:
+1. Read index mappings (requires `index` access)
+2. Execute the generated DSL query (requires `index` access)
+3. Invoke the model (requires `model` access)
+
+Without this, pipeline-based `agentic` queries will fail with `403 Forbidden` even though direct `_execute` API calls work (because direct calls use the caller's identity).
+
+## Step 5: Test Agentic Search
+
+```
+GET <collection-endpoint>/<index-name>/_search?search_pipeline=agentic-search-pipeline
+{
+  "query": {
+    "agentic": {
+      "query_text": "Find documents about machine learning"
+    }
+  }
+}
+```
+
+Expected response includes search hits plus `ext` metadata:
+```json
+{
+  "hits": { "total": {"value": N}, "hits": [...] },
+  "ext": {
+    "dsl_query": "{\"size\":10,\"query\":{\"multi_match\":{...}}}"
+  }
+}
+```
+
+The agent will:
+1. Analyze the natural language question
+2. Examine the index mapping via `QueryPlanningTool`
+3. Generate appropriate OpenSearch DSL
+4. Execute the query and return results
+
+## State Output
+
+Final `.opensearch-deploy-state.json`:
+```json
+{
+  "step_completed": "agentic-setup",
+  "collection_generation": "NEXTGEN",
+  "iam_role_arn": "<role-arn>",
+  "model_id": "<model-id>",
+  "agent_id": "<agent-id>",
+  "search_pipeline_name": "agentic-search-pipeline"
+}
+```
+
+## Connect Search UI to AWS Endpoint
+
+After agentic setup is complete:
+
+```
+Call connect_search_ui_to_endpoint(
+  endpoint="<collection-endpoint>",
+  port=443,
+  use_ssl=true,
+  index_name="<index-name>"
+)
+```
+
+## Provide Access Information
+
+Give the user:
+- Collection endpoint URL
+- Collection ARN
+- Agent ID for direct agent invocation
+- Sample agentic search queries
+- Search Builder UI URL (already connected to AWS endpoint)

--- a/tests/evals/fixtures/skill_rules.json
+++ b/tests/evals/fixtures/skill_rules.json
@@ -96,12 +96,36 @@
     "rationale": "Key rule: always validate AWS credentials before starting"
   },
   {
-    "id": "aws-setup-no-agentic-on-serverless",
+    "id": "aws-setup-no-agentic-on-serverless-non-nextgen",
     "skill": "aws-setup",
-    "prompt": "I want to deploy agentic search to Amazon OpenSearch Serverless",
-    "rule": "Must warn that agentic search requires a managed domain, not Serverless",
-    "criteria": "The response must clearly state that agentic search cannot be deployed to Amazon OpenSearch Serverless and requires a managed domain instead. It must not suggest Serverless is a valid deployment target for agentic search.",
-    "rationale": "Key rule: agentic search does not deploy to Amazon OpenSearch Serverless"
+    "prompt": "I want to deploy agentic search to Amazon OpenSearch Serverless non-nextgen",
+    "rule": "Must warn that agentic search does not deploy to Serverless non-nextgen",
+    "criteria": "The response must clearly state that agentic search cannot be deployed to Serverless non-nextgen. It should suggest using a managed domain or Serverless non-nextgen instead. It must not suggest non-nextgen is a valid target for agentic search.",
+    "rationale": "Key rule: agentic search does not deploy to Serverless non-nextgen"
+  },
+  {
+    "id": "aws-setup-flow-agent-on-nextgen",
+    "skill": "aws-setup",
+    "prompt": "I want to set up agentic search with a flow agent on Serverless nextgen",
+    "rule": "Must confirm nextgen supports flow agents and provide the correct deployment path",
+    "criteria": "The response must confirm that Serverless nextgen supports flow agents for agentic search. It should reference provisioning a nextgen collection (SEARCH type) and the agentic setup guide. It must not say agentic search is unavailable on serverless.",
+    "rationale": "nextgen supports flow agents natively — the skill should route correctly"
+  },
+  {
+    "id": "aws-setup-conversational-agent-needs-domain",
+    "skill": "aws-setup",
+    "prompt": "I want to deploy conversational agentic search with memory to AWS. What are my options?",
+    "rule": "Must state that conversational agents require a managed domain",
+    "criteria": "The response must clearly state that conversational agents (with memory/RAG) require a managed domain and are not supported on Serverless nextgen. It should explain that nextgen only supports flow agents (stateless). It must not suggest deploying conversational agents to serverless.",
+    "rationale": "Key rule: nextgen supports only flow agents — conversational requires managed domain"
+  },
+  {
+    "id": "aws-setup-collection-type-for-dense-vector",
+    "skill": "aws-setup",
+    "prompt": "I want to deploy dense vector search to Serverless V2. What collection type should I use?",
+    "rule": "Must recommend VECTORSEARCH collection type for dense vector",
+    "criteria": "The response must state that dense vector search requires a VECTORSEARCH collection type on Serverless V2. It must not suggest using a SEARCH type collection for dense vector or kNN workloads.",
+    "rationale": "Collection type constraint: VECTORSEARCH needed for dense/hybrid, SEARCH for BM25/sparse/agentic"
   },
   {
     "id": "aws-setup-no-serverless-scale-to-zero",
@@ -198,5 +222,13 @@
     "rule": "Must show a confirmation prompt listing resources before deleting",
     "criteria": "The response must list the resources that will be deleted and require explicit user confirmation (typing the group name) before executing any delete commands. It must not proceed with deletion without showing what will be removed and getting confirmation.",
     "rationale": "Deprovision flow requires typed confirmation of group name before destructive actions"
+  },
+  {
+    "id": "aws-setup-full-flow-agent-workflow",
+    "skill": "aws-setup",
+    "prompt": "I want to deploy flow agent agentic search for a collection called my-search-app in us-east-1. Provision the infrastructure, deploy the agent search, test it, then show me how to clean up. Show the full workflow with exact commands and API calls.",
+    "rule": "Must show the full chained workflow: provision → deploy agent (with data access policy for model/agent) → test → deprovision",
+    "criteria": "The response must show the complete workflow in order: 1) Credential validation with aws sts get-caller-identity, 2) Collection provisioning including encryption policy, network policy, collection group with NextGen/v2, and the correct collection type auto-selected for agentic search (SEARCH), 3) Data access policy that grants the connector IAM role access to all four ResourceTypes (collection, index, model, agent) — this is critical for pipeline-based agentic queries to work, 4) Model registration with inline Bedrock connector returning a model_id, 5) Flow agent creation using that model_id in QueryPlanningTool, 6) Search pipeline creation with agentic_query_translator using the agent_id, 7) An agentic search query test using the pipeline, 8) Deprovision/cleanup steps that remove resources in reverse dependency order. All steps must be present and correctly chained — outputs from earlier steps must feed into later steps. The collection type and model must not be explicitly told by the user — the skill must determine them from the strategy.",
+    "rationale": "Validates the skill can guide an agent through the full lifecycle with correct collection type detection and the critical data access policy for model/agent permissions"
   }
 ]


### PR DESCRIPTION
## Description

- Add flow agent agentic search support for AOSS Serverless (NextGen) collections.
- Add serverless-04-agentic-setup.md
- Update SKILL.md routing — NextGen as default target, collection type guidance (SEARCH vs VECTORSEARCH), flow agent on NextGen collection / conversational on domain
- Add aws-setup-full-flow-agent-workflow eval — validates full lifecycle chaining: collection type auto-detection, data access policy with 4 ResourceTypes (collection/index/model/agent), model→agent→pipeline chaining, agentic query invocation format, and deprovision ordering


## Test Plan

- E2E verified on gamma/prod: provision V2 collection → update data access and create new IAM role -> create index → register model → create agent → create pipeline (agentic_query_translator + agentic_context) → agentic query returns results
- Eval passing: uv run --group evals pytest tests/evals/test_skill_rules.py --run-eval -v -k "aws-setup" (7/7 pass)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
