### PR TITLE
Add Claude Community Marketplace install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ npx skills add opensearch-project/opensearch-agent-skills --all
 npx skills add opensearch-project/opensearch-agent-skills --list
 ```
 
+### Claude Community Marketplace (Claude Code)
+
+```bash
+# Add the community marketplace (one-time setup)
+/plugin marketplace add anthropics/claude-plugins-community
+
+# Install the plugin
+/plugin install opensearch-agent-skills@claude-community
+
+# Reload to apply
+/reload-plugins
+```
+
 After installing, try:
 
 > *"I want to build a semantic search app with OpenSearch"*


### PR DESCRIPTION
The opensearch-agent-skills plugin is now available via the Anthropic community plugins marketplace. Add instructions for installing directly from Claude Code using /plugin commands.

## Testing

<img width="1509" height="771" alt="Screenshot 2026-05-28 at 4 19 42 PM copy" src="https://github.com/user-attachments/assets/afeb044f-69d5-4c98-a01e-1fabf4f6f351" />



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
