### PR TITLE
bump version to 0.4.0 and remove deprecated Solr references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "opensearch-agent-skills",
   "displayName": "OpenSearch Agent Skills",
-  "version": "0.3.0",
-  "description": "OpenSearch skills to help set up and deploy OpenSearch for a variety of use cases: build search applications with semantic, hybrid, neural sparse, and agentic search strategies; analyze observability data with log analytics (PPL and Query DSL) and distributed traces (OpenTelemetry); deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG; migrate from other platforms like Solr to OpenSearch. Just ask your AI assistant to set up a search app, query logs, investigate traces, migrate from Solr, or deploy to AWS.",
+  "version": "0.4.0",
+  "description": "OpenSearch skills to help set up and deploy OpenSearch for a variety of use cases: build search applications with semantic, hybrid, neural sparse, and agentic search strategies; analyze observability data with log analytics (PPL and Query DSL) and distributed traces (OpenTelemetry); deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG. Just ask your AI assistant to set up a search app, query logs, investigate traces, or deploy to AWS.",
   "author": {
     "name": "opensearch-project"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "opensearch-agent-skills",
   "displayName": "OpenSearch Agent Skills",
-  "version": "0.3.0",
-  "description": "OpenSearch skills to help set up and deploy OpenSearch for a variety of use cases: build search applications with semantic, hybrid, neural sparse, and agentic search strategies; analyze observability data with log analytics (PPL and Query DSL) and distributed traces (OpenTelemetry); deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG; migrate from other platforms like Solr to OpenSearch. Just ask your AI assistant to set up a search app, query logs, investigate traces, migrate from Solr, or deploy to AWS.",
+  "version": "0.4.0",
+  "description": "OpenSearch skills to help set up and deploy OpenSearch for a variety of use cases: build search applications with semantic, hybrid, neural sparse, and agentic search strategies; analyze observability data with log analytics (PPL and Query DSL) and distributed traces (OpenTelemetry); deploy to Amazon OpenSearch Service or OpenSearch Serverless with Bedrock integration for embeddings and RAG. Just ask your AI assistant to set up a search app, query logs, investigate traces, or deploy to AWS.",
   "author": {
     "name": "opensearch-project"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensearch-agent-skills"
-version = "0.1.0"
+version = "0.4.0"
 description = "OpenSearch Agent Skills"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary
- Bump version to 0.4.0 in plugin manifests and root pyproject.toml
- Remove deprecated Solr migration references from plugin descriptions (skill was removed in #47)

## Test plan
- [ ] Verify plugin.json files parse correctly
- [ ] Confirm no remaining Solr references in active descriptions