### PR TITLE
  Fix AppSec findings: bump urllib3 and idna, remove repo SECURITY.md                                                                                                        

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,0 @@
-# Security
-
-If you discover a potential security issue in this project, please do **not** create a public GitHub issue. Instead, notify the OpenSearch Security Team by emailing [security@opensearch.org](mailto:security@opensearch.org).
-
-Include as much detail as possible to help reproduce and resolve the issue quickly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ dev = ["pytest>=9.0.3", "pyyaml>=6.0"]
 evals = ["pytest>=9.0.3", "pytest-evals>=0.3", "boto3>=1.28", "deepeval>=2.0", "aiobotocore>=2.13"]
 
 [tool.uv]
-constraint-dependencies = ["urllib3>=2.7.0"]
+constraint-dependencies = ["urllib3>=2.7.0", "idna>=3.15"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,6 @@ dependencies = [
 [dependency-groups]
 dev = ["pytest>=9.0.3", "pyyaml>=6.0"]
 evals = ["pytest>=9.0.3", "pytest-evals>=0.3", "boto3>=1.28", "deepeval>=2.0", "aiobotocore>=2.13"]
+
+[tool.uv]
+constraint-dependencies = ["urllib3>=2.7.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[manifest]
+constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
+
 [[package]]
 name = "aiobotocore"
 version = "3.6.0"
@@ -1020,7 +1023,7 @@ wheels = [
 
 [[package]]
 name = "opensearch-agent-skills"
-version = "0.1.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "opensearch-py" },
@@ -1780,11 +1783,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 
 [manifest]
-constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
+constraints = [
+    { name = "idna", specifier = ">=3.15" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
 
 [[package]]
 name = "aiobotocore"
@@ -633,11 +636,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary                                                                                                                                                                 
  - Fix 2 HIGH findings (CVE-2026-44432, CVE-2026-44431): bump urllib3 to >=2.7.0 to address DoS via excessive decompression and info disclosure via cross-origin header forwarding                                                                                                                                                                 
  - Fix 2 MEDIUM findings:                                                                                                                                                   
    - Remove repo-level SECURITY.md (org-level policy in opensearch-project/.github applies automatically)                                                                   
    - Bump idna to >=3.15 (CVE-2026-45409): IDNA processing vulnerability enabling potential domain spoofing                                                                 
                                                                                                                                                                             
## Changes                                                                                                                                                                 
  - Added `[tool.uv] constraint-dependencies` for urllib3>=2.7.0 and idna>=3.15                                                                                              
  - Regenerated uv.lock (urllib3 2.6.3→2.7.0, idna 3.11→3.18)                                                                                                                
  - Deleted SECURITY.md from repository root

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
