### PR TITLE
Consolidate launch-ui and add dual-path (local/AWS) search app workflow                                                                        

### DIFF
--- a/skills/opensearch-skills/cloud/aws-setup/SKILL.md
+++ b/skills/opensearch-skills/cloud/aws-setup/SKILL.md
@@ -138,14 +138,14 @@ Follow the guides linked in the table above, in order:
 | Conversational Agent Search | [aos/domain-03-agentic-setup.md](aos/domain-03-agentic-setup.md) |
 | Flow Agent Search | [aoss/serverless-04-agentic-setup.md](aoss/serverless-04-agentic-setup.md) |
 
-### Step 4 — Connect Search UI
+### Step 4 — Launch Search UI
 
 ```bash
-uv run python scripts/opensearch_ops.py connect-ui \
+uv run python scripts/opensearch_ops.py launch-ui \
+  --index <index-name> \
   --endpoint <endpoint> \
   --aws-region <region> \
-  --aws-service <es|aoss> \
-  --index <index-name>
+  --aws-service <es|aoss>
 ```
 
 ### Step 5 — Provide Access Information

--- a/skills/opensearch-skills/cloud/aws-setup/aoss/aoss-nextgen-provisioning/SKILL.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/aoss-nextgen-provisioning/SKILL.md
@@ -141,9 +141,11 @@ If yes, collect the IAM principal ARN (role or user ARN), then run:
 aws opensearchserverless create-access-policy --cli-input-json '{
   "type": "data",
   "name": "<name>-access-policy",
-  "policy": "[{\"Rules\":[{\"Resource\":[\"collection/<name>\"],\"Permission\":[\"aoss:*\"],\"ResourceType\":\"collection\"},{\"Resource\":[\"index/<name>/*\"],\"Permission\":[\"aoss:*\"],\"ResourceType\":\"index\"}],\"Principal\":[\"<principal-arn>\"]}]"
+  "policy": "[{\"Rules\":[{\"Resource\":[\"collection/<name>\"],\"Permission\":[\"aoss:*\"],\"ResourceType\":\"collection\"},{\"Resource\":[\"index/<name>/*\"],\"Permission\":[\"aoss:*\"],\"ResourceType\":\"index\"},{\"Resource\":[\"model/*/*\"],\"Permission\":[\"aoss:*\"],\"ResourceType\":\"model\"},{\"Resource\":[\"agent/*/*\"],\"Permission\":[\"aoss:*\"],\"ResourceType\":\"agent\"}],\"Principal\":[\"<principal-arn>\"]}]"
 }' --region <region>
 ```
+
+**Important:** The `model` and `agent` resource types are required for semantic enrichment (CreateIndex with `semantic_enrichment`) and for deploying ML models or agents on the collection. The `model/*/*` wildcard pattern is needed because semantic enrichment creates ML connectors at the account level, not scoped to a single collection name. Always include both `model` and `agent` rules.
 
 ### Success Output
 

--- a/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-02-deploy-search.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-02-deploy-search.md
@@ -254,17 +254,16 @@ After index creation (all paths):
    - Dense Vector: use `neural` query with `model_id`
    - BM25: use standard `match` queries
 
-## Connect Search UI to AWS Endpoint
+## Launch Search UI with AWS Endpoint
 
-After deployment is complete, switch the local Search Builder UI to query the AWS collection:
+After deployment is complete, launch the Search Builder UI pointing at the AWS collection:
 
-```
-Call connect_search_ui_to_endpoint(
-  endpoint="<collection-endpoint>",
-  port=443,
-  use_ssl=true,
-  index_name="<index-name>"
-)
+```bash
+uv run python scripts/opensearch_ops.py launch-ui \
+  --index <index-name> \
+  --endpoint <collection-endpoint> \
+  --aws-region <region> \
+  --aws-service aoss
 ```
 
 The UI header badge will change from "Local" to "AWS Cloud" with a green connection indicator.

--- a/skills/opensearch-skills/scripts/lib/client.py
+++ b/skills/opensearch-skills/scripts/lib/client.py
@@ -406,21 +406,28 @@ def create_remote_client(
     aws_region: str = "",
     aws_service: str = "",
 ) -> OpenSearch:
+    # AWS path: boto3 reads credentials from environment (AWS_PROFILE, env vars, etc.)
+    if aws_region and aws_service:
+        import boto3
+        from opensearchpy import AWSV4SignerAuth, RequestsHttpConnection
+        session = boto3.Session(region_name=aws_region)
+        credentials = session.get_credentials()
+        return OpenSearch(
+            hosts=[{"host": endpoint, "port": 443}],
+            http_auth=AWSV4SignerAuth(credentials, aws_region, aws_service),
+            use_ssl=True,
+            verify_certs=True,
+            ssl_show_warn=False,
+            connection_class=RequestsHttpConnection,
+        )
+
+    # Basic auth or no-auth path
     kwargs: dict = {
         "hosts": [{"host": endpoint, "port": port}],
         "use_ssl": use_ssl,
         "verify_certs": use_ssl,
         "ssl_show_warn": False,
     }
-
-    if aws_region and aws_service:
-        import boto3
-        from opensearchpy import AWSV4SignerAuth, RequestsHttpConnection
-        session = boto3.Session()
-        credentials = session.get_credentials()
-        kwargs["http_auth"] = AWSV4SignerAuth(credentials, aws_region, aws_service)
-        kwargs["connection_class"] = RequestsHttpConnection
-    elif username and password:
+    if username and password:
         kwargs["http_auth"] = (username, password)
-
     return OpenSearch(**kwargs)

--- a/skills/opensearch-skills/scripts/lib/ui.py
+++ b/skills/opensearch-skills/scripts/lib/ui.py
@@ -16,7 +16,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-from .client import create_client, can_connect
+from .client import create_client, create_remote_client, can_connect
 from .search import (
     autocomplete,
     extract_index_field_specs,
@@ -42,9 +42,9 @@ _CONTENT_TYPES = {
     ".svg": "image/svg+xml",
 }
 
-# Mutable state
+# Mutable state — set once at launch time, immutable for the lifetime of the server.
 _default_index = ""
-_endpoint_override = {}  # {host, port, use_ssl, auth, aws_region, aws_service}
+_endpoint_override = {}  # {host, port, use_ssl, username, password, aws_region, aws_service}
 _comparison_config = {
     "comparison_enabled": False,
     "baseline_index": "",
@@ -53,15 +53,7 @@ _comparison_config = {
 
 
 def set_comparison_mode(baseline_index: str, improved_index: str) -> str:
-    """Configure the UI server for comparison mode.
-
-    Args:
-        baseline_index: The first index name.
-        improved_index: The second index name.
-
-    Returns:
-        Success message or error string.
-    """
+    """Configure the UI server for comparison mode."""
     global _comparison_config
     if not baseline_index or not improved_index:
         return "Both baseline and improved index names are required."
@@ -74,11 +66,7 @@ def set_comparison_mode(baseline_index: str, improved_index: str) -> str:
 
 
 def clear_comparison_mode() -> str:
-    """Disable comparison mode and clear stored index names.
-
-    Returns:
-        Confirmation message.
-    """
+    """Disable comparison mode and clear stored index names."""
     global _comparison_config
     _comparison_config = {
         "comparison_enabled": False,
@@ -91,7 +79,6 @@ def clear_comparison_mode() -> str:
 def _get_client():
     override = _endpoint_override
     if override.get("host"):
-        from .client import create_remote_client
         return create_remote_client(
             endpoint=override["host"],
             port=override.get("port", 443),
@@ -357,8 +344,7 @@ def _get_backend_info() -> dict:
         endpoint = override["host"]
         backend_type = "aws" if override.get("aws_region") else "remote"
         try:
-            client = _get_client()
-            ok, _ = can_connect(client)
+            ok, _ = can_connect(_get_client())
             connected = ok
         except Exception:
             connected = False
@@ -366,8 +352,7 @@ def _get_backend_info() -> dict:
     from .client import OPENSEARCH_HOST, OPENSEARCH_PORT
     endpoint = f"{OPENSEARCH_HOST}:{OPENSEARCH_PORT}"
     try:
-        client = _get_client()
-        ok, _ = can_connect(client)
+        ok, _ = can_connect(_get_client())
         connected = ok
     except Exception:
         connected = False
@@ -392,10 +377,55 @@ def _kill_existing_ui() -> None:
         pass
 
 
-def launch_ui(index_name: str = "") -> str:
-    global _default_index
+def launch_ui(
+    index_name: str = "",
+    endpoint: str = "",
+    aws_region: str = "",
+    aws_service: str = "",
+    username: str = "",
+    password: str = "",
+) -> str:
+    """Launch the Search Builder UI.
+
+    Args:
+        index_name: Default index to search.
+        endpoint: Remote endpoint host. If empty, uses local cluster.
+        aws_region: AWS region (triggers SigV4 auth via boto3 credential chain).
+        aws_service: AWS service type ('aoss' or 'es').
+        username: Basic auth username (for non-AWS remote clusters).
+        password: Basic auth password (for non-AWS remote clusters).
+    """
+    global _default_index, _endpoint_override
+
     if index_name:
         _default_index = index_name
+
+    # Set endpoint override from explicit parameters
+    if endpoint:
+        # Auto-detect AWS service/region from endpoint hostname
+        if not aws_service and aws_region:
+            if ".aoss." in endpoint:
+                aws_service = "aoss"
+            elif ".es." in endpoint or ".aos." in endpoint:
+                aws_service = "es"
+        if not aws_region and (".aoss." in endpoint or ".es." in endpoint):
+            m = re.search(r"\.([a-z]{2}-[a-z]+-\d+)\.", endpoint)
+            if m:
+                aws_region = m.group(1)
+                if not aws_service:
+                    aws_service = "aoss" if ".aoss." in endpoint else "es"
+
+        _endpoint_override = {
+            "host": endpoint,
+            "port": 443 if (aws_region and aws_service) else 443,
+            "use_ssl": True,
+            "username": username,
+            "password": password,
+            "aws_region": aws_region,
+            "aws_service": aws_service,
+        }
+    else:
+        _endpoint_override = {}
 
     if not SEARCH_UI_STATIC_DIR.exists():
         return (
@@ -424,6 +454,8 @@ def launch_ui(index_name: str = "") -> str:
         msg = f"Search Builder UI started at: {url}"
         if _default_index:
             msg += f"\nDefault index: {_default_index}"
+        if endpoint:
+            msg += f"\nEndpoint: {endpoint}"
         return msg
 
     except OSError as e:
@@ -431,61 +463,6 @@ def launch_ui(index_name: str = "") -> str:
             url = f"http://{SEARCH_UI_HOST}:{SEARCH_UI_PORT}"
             return f"Search Builder UI already running at: {url}"
         return f"Failed to start Search UI: {e}"
-
-
-def connect_ui(
-    endpoint: str,
-    port: int = 443,
-    use_ssl: bool = True,
-    username: str = "",
-    password: str = "",
-    aws_region: str = "",
-    aws_service: str = "",
-    index_name: str = "",
-) -> str:
-    global _default_index, _endpoint_override
-
-    if not endpoint:
-        return "Error: endpoint is required."
-
-    # Auto-detect AWS service from endpoint
-    if not aws_service and aws_region:
-        if ".aoss." in endpoint:
-            aws_service = "aoss"
-        elif ".es." in endpoint or ".aos." in endpoint:
-            aws_service = "es"
-    if not aws_region and (".aoss." in endpoint or ".es." in endpoint):
-        m = re.search(r"\.([a-z]{2}-[a-z]+-\d+)\.", endpoint)
-        if m:
-            aws_region = m.group(1)
-            if not aws_service:
-                aws_service = "aoss" if ".aoss." in endpoint else "es"
-
-    _endpoint_override = {
-        "host": endpoint, "port": port, "use_ssl": use_ssl,
-        "username": username, "password": password,
-        "aws_region": aws_region, "aws_service": aws_service,
-    }
-
-    # Verify connectivity
-    try:
-        from .client import create_remote_client
-        client = create_remote_client(
-            endpoint, port, use_ssl, username, password, aws_region, aws_service
-        )
-        ok, _ = can_connect(client)
-        if not ok:
-            _endpoint_override = {}
-            return f"Error: Could not connect to {endpoint}:{port}."
-    except Exception as e:
-        _endpoint_override = {}
-        return f"Error connecting: {e}"
-
-    if index_name:
-        _default_index = index_name
-
-    auth_mode = f"SigV4 ({aws_service}/{aws_region})" if aws_region else "basic" if username else "none"
-    return f"Search UI connected to {endpoint} (auth: {auth_mode})"
 
 
 def cleanup_ui() -> str:

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -20,8 +20,7 @@ Commands:
     create-pipeline        Create and attach an ingest/search pipeline
     index-doc              Index a single document
     index-bulk             Bulk index documents from sample data
-    launch-ui              Launch the Search Builder UI
-    connect-ui             Connect Search UI to a remote endpoint
+    launch-ui              Launch the Search Builder UI (local or remote endpoint)
     search                 Run a search query
     load-sample            Load sample data (file, URL, builtin IMDB)
     cleanup                Stop UI and clean up
@@ -123,17 +122,16 @@ def cmd_index_bulk(args):
 
 
 def cmd_launch_ui(args):
-    from lib import client as client_lib
     from lib.ui import launch_ui
 
-    user = (getattr(args, "username", None) or "").strip()
-    pwd = (getattr(args, "password", None) or "").strip()
-    if user and pwd:
-        os.environ[client_lib.OPENSEARCH_AUTH_MODE_ENV] = client_lib.OPENSEARCH_AUTH_MODE_CUSTOM
-        os.environ[client_lib.OPENSEARCH_USER_ENV] = user
-        os.environ[client_lib.OPENSEARCH_PASSWORD_ENV] = pwd
-
-    result = launch_ui(args.index or "")
+    result = launch_ui(
+        index_name=args.index or "",
+        endpoint=args.endpoint or "",
+        aws_region=args.aws_region or "",
+        aws_service=args.aws_service or "",
+        username=args.username or "",
+        password=args.password or "",
+    )
     print(result)
     if "started" in result.lower() or "running" in result.lower():
         # Keep process alive while UI is running
@@ -144,20 +142,6 @@ def cmd_launch_ui(args):
                 time.sleep(1)
         except KeyboardInterrupt:
             print("\nStopping UI server.", file=sys.stderr)
-
-
-def cmd_connect_ui(args):
-    from lib.ui import connect_ui
-    print(connect_ui(
-        endpoint=args.endpoint,
-        port=args.port,
-        use_ssl=not args.no_ssl,
-        username=args.username or "",
-        password=args.password or "",
-        aws_region=args.aws_region or "",
-        aws_service=args.aws_service or "",
-        index_name=args.index or "",
-    ))
 
 
 def cmd_search(args):
@@ -389,27 +373,11 @@ def main():
     # launch-ui
     p = sub.add_parser("launch-ui", help="Launch Search Builder UI")
     p.add_argument("--index", default="")
-    p.add_argument(
-        "--username",
-        default="",
-        help="OpenSearch username (sets custom auth for this process; same as OPENSEARCH_USER)",
-    )
-    p.add_argument(
-        "--password",
-        default="",
-        help="OpenSearch password (sets custom auth for this process; same as OPENSEARCH_PASSWORD)",
-    )
-
-    # connect-ui
-    p = sub.add_parser("connect-ui", help="Connect UI to remote endpoint")
-    p.add_argument("--endpoint", required=True)
-    p.add_argument("--port", type=int, default=443)
-    p.add_argument("--no-ssl", action="store_true")
-    p.add_argument("--username", default="")
-    p.add_argument("--password", default="")
-    p.add_argument("--aws-region", default="")
-    p.add_argument("--aws-service", default="")
-    p.add_argument("--index", default="")
+    p.add_argument("--endpoint", default="", help="Remote endpoint host (omit for local cluster)")
+    p.add_argument("--aws-region", default="", help="AWS region (enables SigV4 auth)")
+    p.add_argument("--aws-service", default="", help="AWS service: 'aoss' or 'es'")
+    p.add_argument("--username", default="", help="Basic auth username (non-AWS remote)")
+    p.add_argument("--password", default="", help="Basic auth password (non-AWS remote)")
 
     # search
     p = sub.add_parser("search", help="Run a search query")
@@ -493,7 +461,6 @@ def main():
         "index-doc": cmd_index_doc,
         "index-bulk": cmd_index_bulk,
         "launch-ui": cmd_launch_ui,
-        "connect-ui": cmd_connect_ui,
         "compare-ui": cmd_compare_ui,
         "search": cmd_search,
         "load-sample": cmd_load_sample,

--- a/skills/opensearch-skills/scripts/ui/index.html
+++ b/skills/opensearch-skills/scripts/ui/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/styles.css" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/skills/opensearch-skills/search/opensearch-launchpad/SKILL.md
+++ b/skills/opensearch-skills/search/opensearch-launchpad/SKILL.md
@@ -8,7 +8,7 @@ description: >
   or any related search topic. Activate even if the user says search quality,
   evaluation, nDCG, precision, relevance tuning, or search builder without
   mentioning OpenSearch.
-compatibility: Requires Docker and uv. AWS deployment requires AWS credentials.
+compatibility: Requires uv. Target local requires Docker. Target aws requires AWS credentials (no Docker).
 metadata:
   author: opensearch-project
   version: "2.0"
@@ -20,9 +20,10 @@ You are an OpenSearch solution architect. You guide users from initial requireme
 
 ## Prerequisites
 
-- Docker installed and running
 - `uv` installed (for running Python scripts)
 - The skill directory available locally
+- **Target `local`:** Docker installed and running
+- **Target `aws`:** AWS credentials configured (no Docker needed)
 
 ## Optional MCP Servers
 
@@ -113,37 +114,37 @@ See [cli-reference.md](../../cli-reference.md) for the full command reference.
 ## Key Rules
 
 - Ask **one** preference question per message.
-- **Never skip Phase 1** (sample document collection).
+- **Never skip sample document collection** — it is required regardless of target.
 - Show architecture proposals to the user before execution.
 - Follow the phases **in order** — do not jump ahead.
 - When a step fails, present the error and wait for guidance.
 
 ## Workflow Phases
 
-### Phase 1 — Start OpenSearch & Collect Sample
+### Phase 1 — Collect Sample Data
 
-Check if a cluster is already running:
+Ask for the data source. Supported inputs:
+- Built-in datasets (`load-sample --type builtin_imdb`)
+- Local files: JSON, JSONL, CSV, TSV, Parquet (`load-sample --type local_file --value <path>`)
+- PDF, DOCX, PPTX, XLSX — use Docling to process. Read [document_processing_guide.md](document_processing_guide.md).
+- URLs or pasted JSON
 
-```bash
-uv run python scripts/opensearch_ops.py preflight-check
-```
-
-- **`status: "available"`** — Cluster running. Use it directly.
-- **`status: "auth_required"`** — Ask for credentials, then retry with `--auth-mode custom`.
-- **`status: "no_cluster"`** — Start one: `bash scripts/start_opensearch.sh`
-
-Once available, ask for the data source. Use `load-sample` to load data.
-
-If the user provides PDF, DOCX, PPTX, or XLSX files, use Docling to process them. Read [document_processing_guide.md](document_processing_guide.md) for the workflow.
+Inspect and validate the data (read a sample, confirm schema).
 
 ### Phase 2 — Gather Preferences
 
-Ask **one at a time**: search strategy and deployment preference. Present all five strategies:
-- `bm25` (keyword)
-- `dense_vector` (semantic via embeddings)
-- `neural_sparse` (semantic via learned sparse representations)
-- `hybrid` (combines keyword + semantic)
-- `agentic` (LLM-driven multi-step retrieval, requires OpenSearch 3.2+)
+Ask **one at a time**:
+
+1. **Search strategy.** Present all five:
+   - `bm25` (keyword)
+   - `dense_vector` (semantic via embeddings)
+   - `neural_sparse` (semantic via learned sparse representations)
+   - `hybrid` (combines keyword + semantic)
+   - `agentic` (LLM-driven multi-step retrieval, requires OpenSearch 3.2+)
+
+2. **Target.** Where should the search app run?
+   - `local` (default) — Docker-based, fast iteration, optional AWS deployment later.
+   - `aws` — Deploy directly to Amazon OpenSearch Serverless. No Docker needed.
 
 ### Phase 3 — Plan
 
@@ -159,20 +160,45 @@ Present the plan and wait for user approval.
 
 ### Phase 4 — Execute
 
-Execute the plan using `opensearch_ops.py` commands. When launching the UI, present the URL (default: `http://127.0.0.1:8765`).
+Execute the plan against the chosen target. Both targets end with the Search Builder UI connected and running.
 
-**For Agentic Search:** Ask for AWS credentials for Bedrock, then ask about agent type (Flow vs Conversational). See [cli-reference.md](../../cli-reference.md) for agentic setup commands.
+#### Target: `local`
 
-After the UI is running:
-> "Your search app is live! Here's what you can do next:"
-> 1. **Evaluate search quality** (Phase 4.5)
-> 2. **Deploy to Amazon OpenSearch Service** — use the `aws-setup` skill
-> 3. **Done for now** — Keep experimenting with the Search Builder UI.
+1. Start or connect to local cluster:
+   ```bash
+   uv run python scripts/opensearch_ops.py preflight-check
+   ```
+   - `"available"` → use it. `"auth_required"` → ask for credentials. `"no_cluster"` → `bash scripts/start_opensearch.sh`
+2. Create index, load data, configure pipelines using `opensearch_ops.py` commands.
+3. Launch the UI:
+   ```bash
+   uv run python scripts/opensearch_ops.py launch-ui --index <index-name>
+   ```
+4. Present: http://127.0.0.1:8765
 
-### Phase 4.5 — Evaluate (Optional)
+**For Agentic Search:** Ask for AWS credentials for Bedrock, then ask about agent type (Flow vs Conversational). See [cli-reference.md](../../cli-reference.md).
+
+After the UI is running, offer:
+> 1. **Evaluate search quality** (Phase 5)
+> 2. **Deploy to AWS** (Phase 6)
+> 3. **Done for now**
+
+#### Target: `aws`
+
+Hand off to [aws-setup](../../cloud/aws-setup/SKILL.md) skill — it handles provisioning, creating the index, loading data, and launching the UI connected to the AWS endpoint.
+
+After the UI is running, offer:
+> 1. **Evaluate search quality** (Phase 5)
+> 2. **Done for now**
+
+### Phase 5 — Evaluate (Optional)
 
 Read and follow [evaluation_guide.md](evaluation_guide.md). If HIGH severity findings exist, offer to restart from Phase 3.
 
-### Phase 5 — Deploy to AWS (Optional)
+### Phase 6 — Deploy to AWS (Optional, target: `local` only)
 
-Refer the user to the [aws-setup](../../cloud/aws-setup/SKILL.md) skill for the full deployment workflow.
+For users who iterated locally and now want to deploy to AWS.
+
+Hand off to [aws-setup](../../cloud/aws-setup/SKILL.md) skill — it handles provisioning, deploying the search config, and launching the UI connected to the AWS endpoint.
+
+**End state (both targets):** Search Builder UI at http://127.0.0.1:8765 connected to the endpoint.


### PR DESCRIPTION
### Description
- Restructure opensearch-launchpad SKILL.md for dual-path execution — clearly separates local (Docker) and aws (AOSS) target paths with distinct Phase 4 instructions. AWS target defers to aws-setup skill to avoid duplication.
- Merge connect-ui into launch-ui — eliminates .ui-endpoint.json file persistence that caused stale "Disconnected" AWS endpoints across sessions. The agent now passes the correct endpoint directly based on conversation context (local or AWS).
- Add model/*/* and agent/*/* to AOSS data access policy — required for neural sparse semantic enrichment (CreateIndex with semantic_enrichment). Without these, CreateIndex fails with AccessDeniedException: Access denied to create ML connector.
- fix babel compatibility issue

### Tests
- local path
<img width="415" height="98" alt="Screenshot 2026-06-17 at 1 35 51 PM" src="https://github.com/user-attachments/assets/2df808bb-17f2-484a-a40a-2671b1e129d5" />

- AWS path
<img width="734" height="128" alt="Screenshot 2026-06-17 at 1 35 36 PM" src="https://github.com/user-attachments/assets/8e97affb-dbd5-4be4-872b-1930e23d95d9" />

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
