### PR TITLE
Fix: workflow security, SSRF, path traversal, CORS, TLS, git injection

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,4 +1,9 @@
 name: Backport
+
+# Security note: This workflow uses pull_request_target but does NOT check out
+# PR code. It only runs after a PR is merged (github.event.pull_request.merged)
+# and uses a GitHub App token to create backport PRs from already-merged commits.
+# Risk is minimal: no untrusted code execution occurs in this workflow.
 on:
   pull_request_target:
     types:

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,22 +3,27 @@ name: Skill Evals
 # Runs LLM-based skill evaluation tests (Layer 3b).
 #
 # Triggers:
-#   - Manual dispatch (workflow_dispatch) — run on demand
+#   - Manual dispatch (workflow_dispatch) — run on demand, with optional ref input
+#     for evaluating fork PRs after maintainer review
 #   - Weekly schedule — Monday 06:00 UTC
 #   - Push to main touching skill content or eval fixtures/tests
-#   - pull_request_target with 'safe to test' label — allows fork PRs to run
-#     evals after a maintainer reviews and labels the PR. Uses the base repo
-#     context so BEDROCK_ACCESS_ROLE secret is available.
+#   - pull_request for org-member PRs (secrets available via OIDC)
 #
-# Security note: pull_request_target runs in the base repo context (has secrets)
-# but checks out the PR head. This is safe here because the eval tests only read
-# skill markdown files — they do not build or execute untrusted code from the PR.
+# Security: pull_request_target has been intentionally removed to prevent
+# secret exfiltration via malicious fork PRs. For fork PRs, maintainers
+# should review the code then trigger evals via workflow_dispatch with
+# the reviewed commit SHA.
 #
 # Requires BEDROCK_ACCESS_ROLE repository secret (IAM role ARN).
 # The role is assumed via GitHub OIDC — no static AWS keys stored.
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to evaluate (SHA or branch). Use for fork PRs after review.'
+        required: false
+        default: ''
   schedule:
     - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
   push:
@@ -28,12 +33,6 @@ on:
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
   pull_request:
-    paths:
-      - 'skills/**'
-      - 'tests/evals/**'
-      - '.github/workflows/evals.yml'
-  pull_request_target:
-    types: [labeled]
     paths:
       - 'skills/**'
       - 'tests/evals/**'
@@ -52,20 +51,15 @@ jobs:
     name: Skill Evals (LLM)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # For pull_request_target: only run when a maintainer adds 'safe to test' label.
-    # For all other triggers (push, schedule, workflow_dispatch, pull_request from
-    # org members): always run.
-    if: |
-      github.event_name != 'pull_request_target' ||
-      contains(github.event.pull_request.labels.*.name, 'safe to test')
+    # Skip fork PRs — secrets (OIDC) are unavailable. Maintainers can use
+    # workflow_dispatch with the fork PR's SHA after review.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # For pull_request_target, check out the PR head so evals run against
-          # the contributor's skill changes, not the base branch.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/skills/opensearch-skills/scripts/lib/client.py
+++ b/skills/opensearch-skills/scripts/lib/client.py
@@ -56,11 +56,16 @@ def resolve_http_auth() -> tuple[str, str] | None:
 
 
 def build_client(use_ssl: bool, http_auth: tuple[str, str] | None = None) -> OpenSearch:
+    # This client targets local Docker dev clusters. TLS verification is
+    # disabled only for loopback hosts (self-signed certs). For non-loopback
+    # hosts, verify certificates to prevent MITM credential theft.
+    is_local = OPENSEARCH_HOST in ("localhost", "127.0.0.1", "::1") or OPENSEARCH_HOST.startswith("127.")
+    verify = use_ssl and not is_local
     kwargs = {
         "hosts": [{"host": OPENSEARCH_HOST, "port": OPENSEARCH_PORT}],
         "use_ssl": use_ssl,
-        "verify_certs": False,
-        "ssl_show_warn": False,
+        "verify_certs": verify,
+        "ssl_show_warn": verify,
         "timeout": 60,
     }
     if http_auth is not None:

--- a/skills/opensearch-skills/scripts/lib/samples.py
+++ b/skills/opensearch-skills/scripts/lib/samples.py
@@ -1,11 +1,14 @@
 """Sample data loading for OpenSearch search builder."""
 
 import csv
+import ipaddress
 import json
 import os
+import socket
 import sys
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .client import create_client
 
@@ -100,8 +103,24 @@ def load_sample_from_file(file_path: str) -> str:
     }, ensure_ascii=False, default=str)
 
 
+def _validate_url(url: str) -> None:
+    """Validate URL to prevent SSRF and local file disclosure."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme must be http or https, got: {parsed.scheme!r}")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL must include a hostname")
+    # Resolve hostname and reject private/loopback/link-local addresses
+    for info in socket.getaddrinfo(hostname, parsed.port or 443, proto=socket.IPPROTO_TCP):
+        addr = ipaddress.ip_address(info[4][0])
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise ValueError(f"URL resolves to a restricted address: {addr}")
+
+
 def load_sample_from_url(url: str) -> str:
     try:
+        _validate_url(url)
         req = urllib.request.Request(url, headers={"User-Agent": "opensearch-skills/1.0"})
         with urllib.request.urlopen(req, timeout=30) as resp:
             content = resp.read().decode("utf-8", errors="replace")

--- a/skills/opensearch-skills/scripts/lib/ui.py
+++ b/skills/opensearch-skills/scripts/lib/ui.py
@@ -101,9 +101,25 @@ def _resolve_asset(path: str) -> Path | None:
     return None
 
 
+_ALLOWED_HOSTNAMES = ("127.0.0.1", "localhost")
+
+
 class _UIHandler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass  # Suppress request logging
+
+    def _is_allowed_origin(self) -> str | None:
+        """Return the Origin if it's from a loopback address, else None."""
+        origin = self.headers.get("Origin", "")
+        if not origin:
+            return None
+        try:
+            parsed = urlparse(origin)
+            if parsed.hostname in _ALLOWED_HOSTNAMES:
+                return origin
+        except Exception:
+            pass
+        return None
 
     def _send_json(self, data: dict, status: int = 200):
         body = json.dumps(data, default=str, ensure_ascii=False).encode("utf-8")
@@ -111,15 +127,23 @@ class _UIHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        origin = self._is_allowed_origin()
+        if origin:
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
         self.end_headers()
         self.wfile.write(body)
 
     def do_OPTIONS(self):
+        origin = self._is_allowed_origin()
+        if not origin:
+            self.send_error(403, "Forbidden: origin not allowed")
+            return
         self.send_response(204)
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Origin", origin)
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Vary", "Origin")
         self.end_headers()
 
     def do_GET(self):

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -181,10 +181,13 @@ def cmd_cleanup(args):
 
 
 def cmd_read_knowledge(args):
-    knowledge_dir = os.path.join(
-        os.path.dirname(__file__), "..", "references", "knowledge"
+    knowledge_dir = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "..", "references", "knowledge")
     )
-    target = os.path.join(knowledge_dir, args.file)
+    target = os.path.realpath(os.path.join(knowledge_dir, args.file))
+    if not target.startswith(knowledge_dir + os.sep) and target != knowledge_dir:
+        print(f"Error: path escapes knowledge directory: {args.file}", file=sys.stderr)
+        sys.exit(1)
     if not os.path.isfile(target):
         available = os.listdir(knowledge_dir) if os.path.isdir(knowledge_dir) else []
         print(f"File not found: {args.file}. Available: {available}", file=sys.stderr)

--- a/tests/test_agent_skills_samples.py
+++ b/tests/test_agent_skills_samples.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(_SCRIPTS_DIR))
 from lib.samples import (
     _load_records_from_file,
     _infer_text_fields,
+    _validate_url,
     load_sample_from_file,
     load_sample_from_paste,
 )
@@ -208,6 +209,59 @@ def test_load_sample_from_paste_text_field_detection():
 
     assert "title" in result["text_fields"]
     assert "code" not in result["text_fields"]
+
+
+# ---------------------------------------------------------------------------
+# _validate_url — SSRF prevention
+# ---------------------------------------------------------------------------
+def test_validate_url_rejects_file_scheme():
+    with pytest.raises(ValueError, match="http or https"):
+        _validate_url("file:///etc/passwd")
+
+
+def test_validate_url_rejects_ftp_scheme():
+    with pytest.raises(ValueError, match="http or https"):
+        _validate_url("ftp://example.com/data.csv")
+
+
+def test_validate_url_rejects_no_scheme():
+    with pytest.raises(ValueError, match="http or https"):
+        _validate_url("/etc/passwd")
+
+
+def test_validate_url_rejects_loopback(monkeypatch):
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *a, **kw: [(None, None, None, None, ("127.0.0.1", 443))],
+    )
+    with pytest.raises(ValueError, match="restricted address"):
+        _validate_url("https://localhost/secret")
+
+
+def test_validate_url_rejects_private_ip(monkeypatch):
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *a, **kw: [(None, None, None, None, ("10.0.0.1", 443))],
+    )
+    with pytest.raises(ValueError, match="restricted address"):
+        _validate_url("https://internal.corp/data")
+
+
+def test_validate_url_rejects_link_local(monkeypatch):
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *a, **kw: [(None, None, None, None, ("169.254.169.254", 80))],
+    )
+    with pytest.raises(ValueError, match="restricted address"):
+        _validate_url("http://169.254.169.254/latest/meta-data/")
+
+
+def test_validate_url_allows_public_ip(monkeypatch):
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        lambda *a, **kw: [(None, None, None, None, ("93.184.216.34", 443))],
+    )
+    _validate_url("https://example.com/data.json")  # should not raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description                                                                                                                                           

Addresses security findings 

 ### Changes by Commit

 | Commit | Description |
 |--------|-------------|
 | `018936c` | Remove `pull_request_target` from evals workflow; add `workflow_dispatch` with `ref` input; skip fork PRs on `pull_request` trigger; document
 | `f9499f8` | Prevent path traversal in `cmd_read_knowledge` — resolve path and verify it stays within knowledge directory |
 | `c020150` | Prevent SSRF in `load_sample_from_url` — restrict to http/https, resolve hostname and block private/link-local addresses; add 7 unit tests |
 | `a7ddca5` | Enable TLS cert verification for non-loopback hosts in `build_client` to prevent MITM credential theft |
 | `d1b3f8e` | Replace wildcard CORS (`*`) with loopback-only origin validation in UI server |
  backport.yml  | risk acceptance


 ### Eval Trigger Matrix (after evals.yml fix)

 | Scenario | Trigger | Secrets | Status |
 |----------|---------|---------|--------|
 | Org-member PR | `pull_request` | Yes (OIDC) | Auto |
 | Fork PR | -- | No | Skipped |
 | Fork PR (reviewed) | `workflow_dispatch` + SHA | Yes (OIDC) | Manual |
 | Push to main | `push` | Yes (OIDC) | Auto |
 | Weekly | `schedule` | Yes (OIDC) | Auto |

 ### Testing

 - [x] All 452 project unit tests passing
 - [x] All 44 sync-bot tests passing (integration + unit)
 - [x] New SSRF validation tests added (7 tests covering scheme/IP restrictions)
 - [x] No functional regressions — existing behavior preserved for local dev workflows

 ### References

 - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
