### PR TITLE
feat(feedback): Add anonymous feedback collection via Google Forms

### DIFF
--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -42,6 +42,55 @@ Route to the right skill based on user intent:
 
 If the user's intent spans multiple skills (e.g., "build a search app and deploy it to AWS"), start with the appropriate skill and transition to the next when ready.
 
+## Feedback Collection (Required Behavior)
+
+**This applies to ALL skills in this collection** — opensearch-launchpad, log-analytics, trace-analytics, and aws-setup. Regardless of which skill is active, you MUST follow these rules.
+
+You MUST proactively collect feedback during every interaction. This is not optional — treat it as a core part of the workflow, not an afterthought.
+
+### Rules
+
+1. **Monitor continuously** — watch for failures, confusion, and unmet needs throughout the conversation, not just at the end.
+2. **Offer immediately on failure** — when any command errors or a step doesn't work, immediately offer to capture feedback before troubleshooting.
+3. **Offer on uncertainty** — if you're unsure how to proceed or the skill doesn't cover the user's request, flag it as a potential gap and offer to submit.
+4. **Ask at natural breakpoints** — after completing a major phase (not just at the very end), ask "Is this working as expected? Any friction so far?"
+5. **Always ask at end** — when the user says they're done or the workflow completes, ask for a 1-5 rating.
+6. **Never send without consent** — show the preview, get explicit "yes".
+
+### Triggers
+
+| When | What to do |
+|------|------------|
+| Command returns non-zero exit or error | → Immediately: "That failed. Can I capture this as feedback?" |
+| User says "that's not what I wanted" / "this is confusing" / expresses frustration | → "Sounds like friction. Can I note what went wrong?" |
+| User asks for something you can't do | → "This isn't supported yet. Can I flag this as a feature gap?" |
+| A workaround is needed (something should be simpler) | → "That was more steps than it should be. Can I flag this as friction?" |
+| Major phase completes | → "How's it going so far? Any issues?" |
+| User says "done" or workflow ends | → "How was the overall experience? (1-5)" |
+
+### How to Submit
+
+1. Compose the feedback (type + context).
+2. Show preview to user.
+3. Ask: "May I submit this anonymous feedback?"
+4. On consent:
+
+```bash
+uv run python scripts/opensearch_ops.py submit-feedback \
+  --type <failure|gap|friction|success> \
+  --skill <skill-name> \
+  --context "<error message, command, what happened>" \
+  --comment "<user's words>" \
+  --rating "<1-5, for success only>"
+```
+
+### Feedback Types
+
+- `failure` — A command or step produced an error
+- `gap` — User needs something the skill doesn't support
+- `friction` — Workflow was confusing, slow, or required workarounds
+- `success` — Workflow completed, user satisfied
+
 ## Shared Resources
 
 All skills share these resources:

--- a/skills/opensearch-skills/scripts/lib/feedback.py
+++ b/skills/opensearch-skills/scripts/lib/feedback.py
@@ -1,0 +1,92 @@
+"""Anonymous feedback collection for OpenSearch Agent Skills.
+
+Submits feedback via Google Forms POST endpoint.
+No authentication required from the submitter. Results visible only to form owner.
+"""
+
+import urllib.parse
+import urllib.request
+
+# Google Form configuration.
+GOOGLE_FORM_ID = "1FAIpQLScuPX1RdlAgzniUREg9E0wVtPG31lOCnbKUtRRKsMMxgzDpVQ"
+FIELD_IDS = {
+    "feedback_type": "entry.432142350",
+    "skill_name": "entry.843860941",
+    "context": "entry.1975973927",
+    "comment": "entry.414948368",
+    "rating": "entry.1436210928",
+}
+
+
+def format_feedback_preview(
+    feedback_type: str,
+    skill_name: str,
+    context: str = "",
+    comment: str = "",
+    rating: str = "",
+) -> str:
+    """Format feedback data for user review before submission."""
+    lines = [
+        "--- Feedback Preview ---",
+        f"Type: {feedback_type}",
+        f"Skill: {skill_name}",
+    ]
+    if rating:
+        lines.append(f"Rating: {rating}/5")
+    if context:
+        lines.append(f"Context: {context[:200]}{'...' if len(context) > 200 else ''}")
+    if comment:
+        lines.append(f"Comment: {comment}")
+    lines.append("------------------------")
+    return "\n".join(lines)
+
+
+def submit_feedback(
+    feedback_type: str,
+    skill_name: str,
+    context: str = "",
+    comment: str = "",
+    rating: str = "",
+) -> str:
+    """Submit anonymous feedback via Google Forms POST.
+
+    Args:
+        feedback_type: One of 'failure', 'gap', 'friction', 'success'.
+        skill_name: Name of the skill generating feedback.
+        context: Technical context (error message, command attempted, etc).
+        comment: User's free-text comment.
+        rating: Rating (1-5) for success feedback.
+
+    Returns:
+        Success or error message.
+    """
+    if not GOOGLE_FORM_ID or not FIELD_IDS.get("feedback_type"):
+        return (
+            "Feedback collection is not yet configured. "
+            "Set GOOGLE_FORM_ID and FIELD_IDS in scripts/lib/feedback.py"
+        )
+
+    url = f"https://docs.google.com/forms/d/e/{GOOGLE_FORM_ID}/formResponse"
+
+    payload = {}
+    if FIELD_IDS["feedback_type"]:
+        payload[FIELD_IDS["feedback_type"]] = feedback_type.capitalize()
+    if FIELD_IDS["skill_name"]:
+        payload[FIELD_IDS["skill_name"]] = skill_name
+    if FIELD_IDS["context"]:
+        payload[FIELD_IDS["context"]] = (context[:2000] if context else "")
+    if FIELD_IDS["comment"]:
+        payload[FIELD_IDS["comment"]] = (comment[:2000] if comment else "")
+    if FIELD_IDS["rating"] and rating:
+        payload[FIELD_IDS["rating"]] = rating
+
+    data = urllib.parse.urlencode(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data)
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status == 200:
+                return "✓ Feedback submitted anonymously. Thank you!"
+            return f"Submission failed with status {resp.status}"
+    except Exception as e:
+        return f"Failed to submit feedback: {e}"

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -22,6 +22,7 @@ Commands:
     index-bulk             Bulk index documents from sample data
     launch-ui              Launch the Search Builder UI (local or remote endpoint)
     search                 Run a search query
+    submit-feedback        Submit anonymous skill feedback
     load-sample            Load sample data (file, URL, builtin IMDB)
     cleanup                Stop UI and clean up
     read-knowledge         Read a knowledge base reference file
@@ -142,6 +143,26 @@ def cmd_launch_ui(args):
                 time.sleep(1)
         except KeyboardInterrupt:
             print("\nStopping UI server.", file=sys.stderr)
+
+
+def cmd_submit_feedback(args):
+    from lib.feedback import format_feedback_preview, submit_feedback
+    preview = format_feedback_preview(
+        feedback_type=args.type,
+        skill_name=args.skill,
+        context=args.context or "",
+        comment=args.comment or "",
+        rating=args.rating or "",
+    )
+    print(preview)
+    result = submit_feedback(
+        feedback_type=args.type,
+        skill_name=args.skill,
+        context=args.context or "",
+        comment=args.comment or "",
+        rating=args.rating or "",
+    )
+    print(result)
 
 
 def cmd_search(args):
@@ -379,6 +400,14 @@ def main():
     p.add_argument("--username", default="", help="Basic auth username (non-AWS remote)")
     p.add_argument("--password", default="", help="Basic auth password (non-AWS remote)")
 
+    # submit-feedback
+    p = sub.add_parser("submit-feedback", help="Submit anonymous skill feedback")
+    p.add_argument("--type", required=True, choices=["failure", "gap", "friction", "success"])
+    p.add_argument("--skill", required=True, help="Skill name (e.g. opensearch-launchpad)")
+    p.add_argument("--context", default="", help="Technical context (error, command, etc)")
+    p.add_argument("--comment", default="", help="User comment")
+    p.add_argument("--rating", default="", help="Rating 1-5 (for success feedback)")
+
     # search
     p = sub.add_parser("search", help="Run a search query")
     p.add_argument("--index", required=True)
@@ -463,6 +492,7 @@ def main():
         "launch-ui": cmd_launch_ui,
         "compare-ui": cmd_compare_ui,
         "search": cmd_search,
+        "submit-feedback": cmd_submit_feedback,
         "load-sample": cmd_load_sample,
         "cleanup": cmd_cleanup,
         "read-knowledge": cmd_read_knowledge,

--- a/tests/test_agent_skills_feedback.py
+++ b/tests/test_agent_skills_feedback.py
@@ -1,0 +1,120 @@
+"""Tests for the feedback module."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "skills" / "opensearch-skills" / "scripts"))
+
+from lib.feedback import format_feedback_preview, submit_feedback
+
+
+def test_format_feedback_preview_shows_all_data():
+    preview = format_feedback_preview(
+        feedback_type="gap",
+        skill_name="opensearch-launchpad",
+        context="User asked for GraphQL integration",
+        comment="Would be nice to have",
+    )
+    assert "gap" in preview
+    assert "opensearch-launchpad" in preview
+    assert "GraphQL" in preview
+    assert "Would be nice" in preview
+
+
+def test_format_feedback_preview_shows_rating():
+    preview = format_feedback_preview(
+        feedback_type="success",
+        skill_name="log-analytics",
+        rating="4",
+    )
+    assert "4/5" in preview
+
+
+def test_format_feedback_preview_truncates_long_context():
+    preview = format_feedback_preview(
+        feedback_type="failure",
+        skill_name="test",
+        context="a" * 300,
+    )
+    assert "..." in preview
+
+
+def test_submit_feedback_returns_not_configured_when_empty():
+    """When GOOGLE_FORM_ID is empty, returns configuration message."""
+    import lib.feedback as fb
+    original_id = fb.GOOGLE_FORM_ID
+    fb.GOOGLE_FORM_ID = ""
+    try:
+        result = submit_feedback(feedback_type="success", skill_name="test")
+        assert "not yet configured" in result
+    finally:
+        fb.GOOGLE_FORM_ID = original_id
+
+
+def test_submit_feedback_posts_form_data(monkeypatch):
+    """When configured, POSTs form-urlencoded data to Google Forms."""
+    import lib.feedback as fb
+    monkeypatch.setattr(fb, "GOOGLE_FORM_ID", "1FAIpQLSeFAKE")
+    monkeypatch.setattr(fb, "FIELD_IDS", {
+        "feedback_type": "entry.100",
+        "skill_name": "entry.200",
+        "context": "entry.300",
+        "comment": "entry.400",
+        "rating": "entry.500",
+    })
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+        result = submit_feedback(
+            feedback_type="failure",
+            skill_name="opensearch-launchpad",
+            context="IndexNotFoundError",
+        )
+
+    assert "✓" in result
+    req = mock_urlopen.call_args[0][0]
+    assert "entry.100=Failure" in req.data.decode()
+    assert "entry.200=opensearch-launchpad" in req.data.decode()
+    assert "entry.300=IndexNotFoundError" in req.data.decode()
+
+
+def test_submit_feedback_handles_network_error(monkeypatch):
+    """Returns error message on network failure."""
+    import lib.feedback as fb
+    monkeypatch.setattr(fb, "GOOGLE_FORM_ID", "1FAIpQLSeFAKE")
+    monkeypatch.setattr(fb, "FIELD_IDS", {
+        "feedback_type": "entry.100", "skill_name": "entry.200",
+        "context": "entry.300", "comment": "entry.400", "rating": "entry.500",
+    })
+
+    with patch("urllib.request.urlopen", side_effect=Exception("timeout")):
+        result = submit_feedback(feedback_type="friction", skill_name="test")
+
+    assert "Failed" in result
+
+
+def test_submit_feedback_truncates_long_context(monkeypatch):
+    """Context is truncated to 2000 chars."""
+    import lib.feedback as fb
+    monkeypatch.setattr(fb, "GOOGLE_FORM_ID", "1FAIpQLSeFAKE")
+    monkeypatch.setattr(fb, "FIELD_IDS", {
+        "feedback_type": "entry.100", "skill_name": "entry.200",
+        "context": "entry.300", "comment": "entry.400", "rating": "entry.500",
+    })
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen:
+        submit_feedback(feedback_type="failure", skill_name="test", context="x" * 3000)
+
+    req = mock_urlopen.call_args[0][0]
+    # URL-encoded "x" is just "x", so check length of the context value
+    assert "x" * 2001 not in req.data.decode()


### PR DESCRIPTION
### Description

Add a feedback mechanism that agents proactively trigger during skill workflows to collect anonymous user feedback.

### How it works

1. The parent `opensearch-skills/SKILL.md` defines **Feedback Collection (Required Behavior)** — rules that apply to all child skills.
2. Agents monitor for failures, frustration, unsupported requests, and workarounds throughout the conversation (not just at the end).
3. On trigger, the agent composes a feedback preview, shows it to the user, and asks for explicit consent.
4. On consent, submits via `submit-feedback` CLI command which POSTs to a Google Form (anonymous, no auth needed from user).

### Trigger points

| When | Action |
|------|--------|
| Command fails | → "That failed. Can I capture this as feedback?" |
| User expresses frustration | → "Sounds like friction. Can I note what went wrong?" |
| Unsupported request | → "Can I flag this as a feature gap?" |
| Workaround needed | → "Can I flag this as friction?" |
| Major phase completes | → "How's it going so far?" |
| Workflow ends | → "How was the experience? (1-5)" |

### Persistence

- **Google Forms** — free, unlimited, anonymous submissions via POST, results visible only to form owner/admins.
- No browser needed — direct HTTP POST from Python.

### Files changed

- `skills/opensearch-skills/SKILL.md` — Feedback Collection section (after Routing, before Shared Resources)
- `skills/opensearch-skills/scripts/lib/feedback.py` — `submit_feedback()` and `format_feedback_preview()`
- `skills/opensearch-skills/scripts/opensearch_ops.py` — `submit-feedback` CLI command
- `tests/test_agent_skills_feedback.py` — 7 unit tests

### Testing

- [x] All 452 unit tests pass
- [x] Tested end-to-end with Strands agent — feedback triggered on command failure
- [x] Verified Google Form receives submissions via direct POST

### Issues Resolved

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).