### PR TITLE
add AWS_SDK_UA_APP_ID to user-agent to collection commands

### DIFF
--- a/skills/opensearch-skills/cloud/SKILL.md
+++ b/skills/opensearch-skills/cloud/SKILL.md
@@ -31,3 +31,11 @@ Read [aws-setup/SKILL.md](aws-setup/SKILL.md) when the user wants to:
 - Deploy a local search setup to AWS
 - Set up Bedrock connectors for ML models
 - Configure IAM roles and access policies for OpenSearch
+
+## Usage Attribution
+
+For all cloud work under this category, tag AWS requests with the application id `opensearch-agent-skills` so calls made by these skills are attributable in AWS-side logs:
+- **Shell `aws` commands:** prefix per-command with `AWS_SDK_UA_APP_ID=opensearch-agent-skills` (never `export` globally).
+- **`awslabs.aws-api-mcp-server`:** set `"AWS_SDK_UA_APP_ID": "opensearch-agent-skills"` in the server's MCP `env` block.
+
+This applies to every AWS service (opensearch, opensearchserverless, iam, sts, s3, …), not just OpenSearch calls.

--- a/skills/opensearch-skills/cloud/aws-setup/SKILL.md
+++ b/skills/opensearch-skills/cloud/aws-setup/SKILL.md
@@ -36,7 +36,7 @@ You are an AWS deployment specialist for OpenSearch. You help users provision an
     "awslabs.aws-api-mcp-server": {
       "command": "uvx",
       "args": ["awslabs.aws-api-mcp-server@latest"],
-      "env": { "FASTMCP_LOG_LEVEL": "ERROR" }
+      "env": { "FASTMCP_LOG_LEVEL": "ERROR", "AWS_SDK_UA_APP_ID": "opensearch-agent-skills" }
     },
     "aws-knowledge-mcp-server": {
       "command": "uvx",
@@ -96,6 +96,7 @@ For Amazon OpenSearch Serverless (AOSS):
 - **Serverless NextGen** supports only **flow agents** — conversational agents require a **managed domain**.
 - Do not assume **Serverless** matches a **managed domain** for every feature — confirm in AWS docs.
 - Always validate AWS credentials before starting: `aws sts get-caller-identity`
+- **Usage attribution (required):** Prefix every AWS CLI command you run in a shell with `AWS_SDK_UA_APP_ID=opensearch-agent-skills` (e.g. `AWS_SDK_UA_APP_ID=opensearch-agent-skills aws <service> <command> ...`), regardless of service (opensearch, opensearchserverless, iam, sts, s3, …). Scope it per-command — do not `export` it globally. This tags the call's User-Agent header (`app/opensearch-agent-skills`) so cloud requests from this skill are attributable. AWS calls made through `awslabs.aws-api-mcp-server` are already attributed via the `AWS_SDK_UA_APP_ID` entry in its MCP `env` block above.
 - Track deployment state in `.opensearch-deploy-state.json` at the workspace root.
 - When a step fails, present the error and wait for guidance.
 

--- a/skills/opensearch-skills/cloud/aws-setup/aoss/aoss-nextgen-provisioning/SKILL.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/aoss-nextgen-provisioning/SKILL.md
@@ -22,6 +22,7 @@ Guided wizard for provisioning and deprovisioning Amazon OpenSearch Serverless (
 - `"generation": "NEXTGEN"` is REQUIRED for NextGen collection groups.
 - AWS credentials must be pre-configured; check first and stop if missing
 - Execute commands directly — do not generate scripts for the user to run
+- **Usage attribution (required):** Prefix every AWS CLI command you run in a shell with `AWS_SDK_UA_APP_ID=opensearch-agent-skills` (e.g. `AWS_SDK_UA_APP_ID=opensearch-agent-skills aws opensearchserverless ...`), regardless of service or subcommand. Scope it per-command — do not `export` it globally. This tags the call's User-Agent header so cloud requests from this skill are attributable.
 - Collections must be in ACTIVE status before they can be deleted. NextGen collections typically take ~30 seconds; standalone collections can take 3-5 minutes.
 - OCU capacity limits must be: 1, 2, 4, 8, 16, or any multiple of 16
 

--- a/tests/evals/fixtures/skill_rules.json
+++ b/tests/evals/fixtures/skill_rules.json
@@ -230,5 +230,21 @@
     "rule": "Must show the full chained workflow: provision → deploy agent (with data access policy for model/agent) → test → deprovision",
     "criteria": "The response must show the complete workflow in order: 1) Credential validation with aws sts get-caller-identity, 2) Collection provisioning including encryption policy, network policy, collection group with NextGen, and the correct collection type auto-selected for agentic search (SEARCH), 3) Data access policy that grants the connector IAM role access to all four ResourceTypes (collection, index, model, agent) — this is critical for pipeline-based agentic queries to work, 4) Model registration with inline Bedrock connector returning a model_id, 5) Flow agent creation using that model_id in QueryPlanningTool, 6) Search pipeline creation with agentic_query_translator using the agent_id, 7) An agentic search query test using the pipeline, 8) Deprovision/cleanup steps that remove resources in reverse dependency order. All steps must be present and correctly chained — outputs from earlier steps must feed into later steps. The collection type and model must not be explicitly told by the user — the skill must determine them from the strategy.",
     "rationale": "Validates the skill can guide an agent through the full lifecycle with correct collection type detection and the critical data access policy for model/agent permissions"
+  },
+  {
+    "id": "aoss-provisioning-usage-attribution",
+    "skill": "aoss-nextgen-provisioning",
+    "prompt": "Create an AOSS collection called my-search (SEARCH) in us-east-1. Show me the exact commands you would run.",
+    "rule": "Must prefix shell AWS CLI commands with AWS_SDK_UA_APP_ID=opensearch-agent-skills, per-command",
+    "criteria": "The aws CLI commands in the response must be prefixed per-command with 'AWS_SDK_UA_APP_ID=opensearch-agent-skills' (e.g. 'AWS_SDK_UA_APP_ID=opensearch-agent-skills aws opensearchserverless create-collection ...'). The variable must be set inline on each command, not exported globally with a separate 'export' statement. It is acceptable if not every single command is prefixed, but the collection-related commands must clearly carry the prefix.",
+    "rationale": "Usage attribution: cloud requests from this skill must carry the app/opensearch-agent-skills application id in the User-Agent header"
+  },
+  {
+    "id": "aws-setup-usage-attribution",
+    "skill": "aws-setup",
+    "prompt": "How do I make sure AWS calls made while deploying OpenSearch are attributed to this tooling? I run some commands in the shell and some through the AWS API MCP server.",
+    "rule": "Must set AWS_SDK_UA_APP_ID=opensearch-agent-skills for both the shell path (per-command prefix) and the MCP path (env block in the aws-api-mcp-server config)",
+    "criteria": "The response must explain both mechanisms: (1) for shell aws commands, prefix each command with 'AWS_SDK_UA_APP_ID=opensearch-agent-skills' (not a global export); and (2) for calls through awslabs.aws-api-mcp-server, set \"AWS_SDK_UA_APP_ID\": \"opensearch-agent-skills\" in that server's env block in the MCP configuration. Both the shell and MCP mechanisms must be mentioned.",
+    "rationale": "Usage attribution must cover all cloud requests across both execution paths (shell CLI and MCP-routed calls)"
   }
 ]

--- a/tests/test_agent_skills_ua_attribution.py
+++ b/tests/test_agent_skills_ua_attribution.py
@@ -1,0 +1,124 @@
+"""Content-lint tests for cloud usage attribution.
+
+Guards the `AWS_SDK_UA_APP_ID=opensearch-agent-skills` attribution scheme wired
+into the cloud skills. See docs/aoss_metrics_collection.md.
+
+Scope: attribution applies to ALL cloud/AWS requests (any service), not just
+AOSS. It is delivered via two mechanisms:
+  1. Config — `AWS_SDK_UA_APP_ID` is set in the `awslabs.aws-api-mcp-server`
+     MCP `env` block, so every AWS call routed through that server is tagged.
+  2. Instruction — an always-loaded directive tells the agent to prefix every
+     shell `aws` command with `AWS_SDK_UA_APP_ID=opensearch-agent-skills`
+     (per-command, never exported), regardless of service.
+
+Design decision protected here (instruction-only for the shell path): example
+commands are NOT individually prefixed — the agent applies the rule from the
+directive. This keeps the pattern uniform across every skill file.
+
+No cluster, no network, no LLM — pure filesystem checks.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CLOUD = _REPO_ROOT / "skills" / "opensearch-skills" / "cloud"
+
+_APP_ID_VALUE = "opensearch-agent-skills"
+_APP_ID_ENV = f"AWS_SDK_UA_APP_ID={_APP_ID_VALUE}"
+
+# SKILL.md files that must carry the shell attribution directive. Each of these
+# can be installed independently, so each must state the rule itself.
+_DIRECTIVE_FILES = [
+    _CLOUD / "SKILL.md",
+    _CLOUD / "aws-setup" / "SKILL.md",
+    _CLOUD / "aws-setup" / "aoss" / "aoss-nextgen-provisioning" / "SKILL.md",
+]
+
+# File whose MCP config must carry the app id in the aws-api-mcp-server env.
+_MCP_CONFIG_FILE = _CLOUD / "aws-setup" / "SKILL.md"
+
+# All markdown files under cloud/ — used to assert the instruction-only pattern.
+_ALL_CLOUD_MDS = sorted(_CLOUD.rglob("*.md"))
+
+# Matches an example command line individually prefixed with the app id, e.g.
+# "AWS_SDK_UA_APP_ID=opensearch-agent-skills aws opensearchserverless ...".
+# Anchored at start-of-line so it only flags actual command invocations in code
+# blocks, not prose or the directive's inline example.
+_PREFIXED_CMD_RE = re.compile(
+    rf"^{re.escape(_APP_ID_ENV)}\s+aws\s+", re.MULTILINE
+)
+
+
+class TestFilesExist:
+    @pytest.mark.parametrize("path", _DIRECTIVE_FILES, ids=lambda p: str(p.relative_to(_CLOUD)))
+    def test_directive_file_exists(self, path):
+        assert path.is_file(), f"expected cloud skill file at {path}"
+
+
+class TestShellDirectivePresent:
+    """Every independently-installable cloud SKILL.md states the shell rule."""
+
+    @pytest.mark.parametrize("path", _DIRECTIVE_FILES, ids=lambda p: str(p.relative_to(_CLOUD)))
+    def test_app_id_directive_present(self, path):
+        text = path.read_text(encoding="utf-8")
+        assert _APP_ID_ENV in text, (
+            f"{path.relative_to(_REPO_ROOT)}: missing usage-attribution directive "
+            f"containing {_APP_ID_ENV!r}"
+        )
+
+    @pytest.mark.parametrize("path", _DIRECTIVE_FILES, ids=lambda p: str(p.relative_to(_CLOUD)))
+    def test_directive_is_service_agnostic(self, path):
+        """The rule must not be scoped to a single service (broadened from AOSS-only)."""
+        text = path.read_text(encoding="utf-8").lower()
+        assert "attribution" in text, (
+            f"{path.relative_to(_REPO_ROOT)}: expected a usage-attribution section"
+        )
+        # Guard against regressing to the old collection-only carve-out wording.
+        assert "do not add it to security-policy" not in text, (
+            f"{path.relative_to(_REPO_ROOT)}: directive still contains the old "
+            f"collection-only exclusion; attribution now applies to all AWS commands"
+        )
+
+
+class TestMcpEnvAttribution:
+    """The aws-api-mcp-server MCP config must carry the app id in its env."""
+
+    def _extract_mcp_json(self, text: str) -> dict:
+        """Pull the first ```json ... ``` block that defines mcpServers."""
+        for block in re.findall(r"```json\s*(.*?)```", text, re.DOTALL):
+            if "mcpServers" in block:
+                return json.loads(block)
+        pytest.fail("no mcpServers JSON block found in aws-setup/SKILL.md")
+
+    def test_mcp_server_env_has_app_id(self):
+        text = _MCP_CONFIG_FILE.read_text(encoding="utf-8")
+        config = self._extract_mcp_json(text)
+        servers = config.get("mcpServers", {})
+        assert "awslabs.aws-api-mcp-server" in servers, (
+            "aws-api-mcp-server missing from MCP config"
+        )
+        env = servers["awslabs.aws-api-mcp-server"].get("env", {})
+        assert env.get("AWS_SDK_UA_APP_ID") == _APP_ID_VALUE, (
+            f"awslabs.aws-api-mcp-server env must set "
+            f'AWS_SDK_UA_APP_ID="{_APP_ID_VALUE}" so MCP-routed AWS calls are '
+            f"attributed; found env={env!r}"
+        )
+
+
+class TestInstructionOnlyPattern:
+    """Example commands must NOT be individually prefixed (instruction-only)."""
+
+    @pytest.mark.parametrize("path", _ALL_CLOUD_MDS, ids=lambda p: str(p.relative_to(_CLOUD)))
+    def test_no_prefixed_example_commands(self, path):
+        text = path.read_text(encoding="utf-8")
+        prefixed = _PREFIXED_CMD_RE.findall(text)
+        assert not prefixed, (
+            f"{path.relative_to(_REPO_ROOT)}: found {len(prefixed)} example command(s) "
+            f"individually prefixed with the app id. Attribution is instruction-only for "
+            f"the shell path — the directive lives in the SKILL.md files; example "
+            f"commands should stay clean."
+        )


### PR DESCRIPTION
### Description                                                                                              
- MCP-routed calls — "AWS_SDK_UA_APP_ID": "opensearch-agent-skills" is added to the                      
  awslabs.aws-api-mcp-server env block in cloud/aws-setup/SKILL.md. Every AWS call routed through that      
  server is tagged automatically, regardless of service.                                                    
- Shell `aws` commands — a general, service-agnostic instruction directs the agent to prefix each command
  with AWS_SDK_UA_APP_ID=opensearch-agent-skills (per-command, never exported globally).     

### Changes
 - cloud/SKILL.md — Usage Attribution section (category-level; covers the partial-context /                
  whole-category-install path).                                                                             
  - cloud/aws-setup/SKILL.md — MCP env entry + shell attribution rule in Key Rules.                         
  - cloud/aws-setup/aoss/aoss-nextgen-provisioning/SKILL.md — shell attribution rule in Key Constraints.    
  - tests/test_agent_skills_ua_attribution.py — content-lint test suite.                                    
  - tests/evals/fixtures/skill_rules.json — two LLM-as-judge eval cases.     
                                                     
                                                                                                                                                                                              
### Testing                                                                     
- Content-lint (hermetic, always runs) — asserts the directive is present and service-agnostic in all    
  three SKILL.md files, the MCP env carries the app id, and example commands are not individually prefixed  
  (instruction-only pattern). Guards verified to fail on regressions (missing directive, missing MCP env,   
  re-introduced command prefix).    
                                                                        
 ```                                                                                                           
uv run pytest tests/ -v                                                                                
                                                                                                            
Full suite: 467 passed, 45 skipped.   
```                                                                 
                                                                                                            
- Behavioral eval (LLM-as-judge, Bedrock-gated) — two cases in skill_rules.json verify the agent, with   
  each SKILL.md loaded as its system prompt, actually applies the attribution (shell prefix + MCP env). Ran 
  live against Bedrock Haiku 4.5:                                                                           

```                                                                                                       
AWS_PROFILE=<profile> uv run --group evals pytest tests/evals/test_skill_rules.py --run-eval -k attribution                                                                                               
# 2 passed in 24.41s     
```                                                                              
- Runtime end-to-end (manual) — launched the real awslabs.aws-api-mcp-server via uvx with the skill's    
  env, drove call_aws over MCP stdio against a local endpoint, and confirmed the outbound User-Agent        
  contained app/opensearch-agent-skills alongside the MCP provenance marker md/via/AWS-API-MCP.             
                                                                                                                                               

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
