### PR TITLE
Add Fen Qin as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @arjunkumargiri @saratvemulapalli @sean-zheng-amazon
+* @arjunkumargiri @saratvemulapalli @sean-zheng-amazon @fen-qin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,3 +9,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Arjun kumar Giri  | [arjunkumargiri](https://github.com/arjunkumargiri)       | Amazon      |
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli)   | Amazon      |
 | Sean Zheng        | [sean-zheng-amazon](https://github.com/sean-zheng-amazon) | Amazon      |
+| Fen Qin           | [fen-qin](https://github.com/fen-qin)                     | Amazon      |


### PR DESCRIPTION
## Summary
- Add Fen Qin (@fen-qin) to MAINTAINERS.md

## Test plan
- [ ] Verify GitHub ID link resolves correctly