### PR TITLE
ci(evals): use pull_request_target with environment approval gate

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,27 +3,25 @@ name: Skill Evals
 # Runs LLM-based skill evaluation tests (Layer 3b).
 #
 # Triggers:
-#   - Manual dispatch (workflow_dispatch) — run on demand, with optional ref input
-#     for evaluating fork PRs after maintainer review
+#   - Manual dispatch (workflow_dispatch) — run on demand
 #   - Weekly schedule — Monday 06:00 UTC
 #   - Push to main touching skill content or eval fixtures/tests
-#   - pull_request for org-member PRs (secrets available via OIDC)
+#   - pull_request_target for ALL PRs (including forks) — runs in base repo
+#     context so OIDC secrets are available. Protected by an environment
+#     approval gate (same pattern as opensearch-project/ml-commons).
 #
-# Security: pull_request_target has been intentionally removed to prevent
-# secret exfiltration via malicious fork PRs. For fork PRs, maintainers
-# should review the code then trigger evals via workflow_dispatch with
-# the reviewed commit SHA.
+# Security: Uses pull_request_target + environment approval gate.
+# - PR authors in CODEOWNERS: run immediately (eval-cicd-env)
+# - Other contributors (fork PRs): require maintainer approval via
+#   eval-cicd-env-require-approval environment before job executes
 #
-# Requires BEDROCK_ACCESS_ROLE repository secret (IAM role ARN).
-# The role is assumed via GitHub OIDC — no static AWS keys stored.
+# Setup required:
+#   1. Create 'eval-cicd-env' environment (no protection rules)
+#   2. Create 'eval-cicd-env-require-approval' environment with required reviewers
+#   3. BEDROCK_ACCESS_ROLE repository secret (IAM role ARN)
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref to evaluate (SHA or branch). Use for fork PRs after review.'
-        required: false
-        default: ''
   schedule:
     - cron: '0 6 * * 1'   # weekly, Monday 06:00 UTC
   push:
@@ -32,7 +30,8 @@ on:
       - 'skills/**'
       - 'tests/evals/**'
       - '.github/workflows/evals.yml'
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
     paths:
       - 'skills/**'
       - 'tests/evals/**'
@@ -43,23 +42,27 @@ permissions:
   id-token: write   # required for OIDC role assumption
 
 concurrency:
-  group: evals-${{ github.ref }}
+  group: evals-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  Get-Require-Approval:
+    uses: ./.github/workflows/require-approval.yml
+
   evals:
     name: Skill Evals (LLM)
+    needs: [Get-Require-Approval]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    # Skip fork PRs — secrets (OIDC) are unavailable. Maintainers can use
-    # workflow_dispatch with the fork PR's SHA after review.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 45
+    environment: ${{ needs.Get-Require-Approval.outputs.is-require-approval }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          # For pull_request_target: check out the PR head (fork code)
+          # For push/schedule/dispatch: check out the triggering SHA
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/require-approval.yml
+++ b/.github/workflows/require-approval.yml
@@ -1,0 +1,53 @@
+---
+name: Check if the workflow requires approval
+
+on:
+  workflow_call:
+    outputs:
+      is-require-approval:
+        description: The environment name to use (controls approval gate)
+        value: ${{ jobs.Require-Approval.outputs.output-is-require-approval }}
+
+jobs:
+  Require-Approval:
+    runs-on: ubuntu-latest
+    outputs:
+      output-is-require-approval: ${{ steps.step-is-require-approval.outputs.is-require-approval }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: Check if approval is required
+        id: step-is-require-approval
+        run: |
+          github_event=${{ github.event_name }}
+          author=${{ github.event.pull_request.user.login }}
+
+          if [[ "$github_event" == "push" ]] || [[ "$github_event" == "schedule" ]] || [[ "$github_event" == "workflow_dispatch" ]]; then
+            echo "Non-PR event does not need approval."
+            echo "is-require-approval=eval-cicd-env" >> $GITHUB_OUTPUT
+          else
+            # Check if the author is in the approvers list (CODEOWNERS)
+            if [ -f ".github/CODEOWNERS" ]; then
+              approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')
+            else
+              approvers=""
+            fi
+
+            is_approved=false
+            IFS=',' read -ra APPROVER_ARRAY <<< "$approvers"
+            for approver in "${APPROVER_ARRAY[@]}"; do
+              if [[ "$approver" == "$author" ]]; then
+                is_approved=true
+                break
+              fi
+            done
+
+            if [[ "$is_approved" == "true" ]]; then
+              echo "$author is in the approval list."
+              echo "is-require-approval=eval-cicd-env" >> $GITHUB_OUTPUT
+            else
+              echo "$author is not in the approval list."
+              echo "is-require-approval=eval-cicd-env-require-approval" >> $GITHUB_OUTPUT
+            fi
+          fi


### PR DESCRIPTION
## Summary

Switch eval workflow to use `pull_request_target` so fork PRs can run evals (secrets available in base repo context). Follows the same security pattern as [opensearch-project/ml-commons](https://github.com/opensearch-project/ml-commons/blob/main/.github/workflows/require-approval.yml).

### How it works

1. Any PR touching `skills/**` or `tests/evals/**` triggers the workflow
2. `require-approval.yml` checks if the PR author is in CODEOWNERS
3. **CODEOWNERS members** → `eval-cicd-env` environment (no approval needed, runs immediately)
4. **External contributors (fork PRs)** → `eval-cicd-env-require-approval` environment (job pauses until a maintainer approves in the Actions UI)

### Changes

- `.github/workflows/evals.yml` — switched from `pull_request` to `pull_request_target`, added `Get-Require-Approval` job dependency, bumped timeout from 15 to 45 minutes
- `.github/workflows/require-approval.yml` — new reusable workflow that checks CODEOWNERS and outputs the appropriate environment name

### Setup required (repo admin)

1. Create `eval-cicd-env` environment in Settings → Environments (no protection rules)
2. Create `eval-cicd-env-require-approval` environment with Required Reviewers set to maintainers

### Security

Same approach as opensearch-project/ml-commons and opensearch-project/opensearch-migrations. No secrets are accessed until after environment approval. The `require-approval.yml` job only checks out the base branch (not fork code) to read CODEOWNERS.