### PR TITLE
fix: AOSS NextGen rejects engine in knn_vector mappings

### DIFF
--- a/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-02-deploy-search.md
+++ b/skills/opensearch-skills/cloud/aws-setup/aoss/serverless-02-deploy-search.md
@@ -183,20 +183,22 @@ Update state: `"ingest_pipeline_name": "bedrock-embedding-pipeline"`
 PUT <collection-endpoint>/<index-name>
 {
   "settings": {
-    "index": { "knn": true, "knn.space_type": "cosinesimil", "default_pipeline": "bedrock-embedding-pipeline" }
+    "index.knn": true,
+    "index.default_pipeline": "bedrock-embedding-pipeline"
   },
   "mappings": {
     "properties": {
       "<text-field>": { "type": "text" },
       "<vector-field>": {
         "type": "knn_vector",
-        "dimension": 1024,
-        "method": { "name": "hnsw", "space_type": "cosinesimil", "engine": "faiss" }
+        "dimension": 1024
       }
     }
   }
 }
 ```
+
+> **Note:** Omit `engine`/`mode` on NextGen — they are rejected with `Field parameter 'engine' is not supported`. `space_type` is optional (defaults to L2); to use another metric, add it at the field level, e.g. `"space_type": "cosinesimil"`.
 
 Update state: `"index_name": "<index-name>"`
 


### PR DESCRIPTION
### Description

Tested live against two collections in the same account (us-east-1), created via the provisioning skill:
  - Classic
  - NextGen 
  
Ran create-index on each with and without the engine block:
  
| Mapping form | Classic | NextGen |
  | --- | --- | --- |
  | `method: { name: hnsw, engine: faiss }` | ✅ success | ❌ `400`: `Field parameter 'engine' is not supported` |
  | no `engine` (just `type` + `dimension`) | ✅ success | ✅ success |
  | `space_type` at field level | optional | optional (defaults to L2) |
  

 ### Change
  
  Updated the Step 5 index mapping in `serverless-02-deploy-search.md` to drop the `method`/`engine` block, plus a one-line note explaining the NextGen restriction.
  
  ```json
  "<vector-field>": {
    "type": "knn_vector",
    "dimension": 1024
  }
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
