### PR TITLE
fix: lazily download IMDB sample dataset instead of bundling it

### DIFF
--- a/skills/opensearch-skills/cli-reference.md
+++ b/skills/opensearch-skills/cli-reference.md
@@ -21,8 +21,15 @@ uv run python scripts/opensearch_ops.py status
 ## Load sample data
 
 ```bash
-# Built-in IMDB dataset
+# Built-in IMDB dataset — uses a small bundled sample (20 titles) by
+# default, no network call.
 uv run python scripts/opensearch_ops.py load-sample --type builtin_imdb
+
+# Same, but fetch a larger sample (up to 100k rows) from IMDb's dataset
+# export instead. Downloads from datasets.imdbws.com on first use and
+# caches locally (~/.cache/opensearch-agent-skills/sample_data/); tell the
+# user this triggers a network download before using this flag.
+uv run python scripts/opensearch_ops.py load-sample --type builtin_imdb --allow-download
 
 # From a local file (JSON, JSONL, CSV, TSV, Parquet)
 uv run python scripts/opensearch_ops.py load-sample --type local_file --value /path/to/data.json

--- a/skills/opensearch-skills/scripts/lib/samples.py
+++ b/skills/opensearch-skills/scripts/lib/samples.py
@@ -68,17 +68,74 @@ def _infer_text_fields(doc: dict) -> list[str]:
     return text_fields
 
 
-def load_sample_builtin_imdb() -> str:
-    script_dir = Path(__file__).resolve().parent.parent
-    # Look for bundled sample data alongside this script
-    candidates = [
-        script_dir / "sample_data" / "imdb.title.basics.tsv",
-    ]
-    for path in candidates:
-        if path.exists():
-            return load_sample_from_file(str(path.resolve()))
+# IMDb publishes a non-commercial dataset export, refreshed daily, at a
+# stable public URL: https://developer.imdb.com/non-commercial-datasets/
+# title.basics.tsv.gz is the title metadata file (titles, types, years,
+# genres) and is used here as sample data for search app prototyping.
+_IMDB_SAMPLE_URL = "https://datasets.imdbws.com/title.basics.tsv.gz"
+_IMDB_SAMPLE_FILENAME = "imdb.title.basics.tsv"
+_IMDB_SAMPLE_MAX_ROWS = 100_000  # enough rows for a realistic sample without pulling the full multi-million-row dataset
 
-    return json.dumps({"error": "IMDB sample data not found."})
+
+def _imdb_cache_dir() -> Path:
+    """Local cache directory for downloaded sample data.
+
+    Respects XDG_CACHE_HOME when set, otherwise defaults to ~/.cache."""
+    xdg_cache = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg_cache) if xdg_cache else Path.home() / ".cache"
+    return base / "opensearch-agent-skills" / "sample_data"
+
+
+def _download_imdb_sample(dest: Path) -> None:
+    """Download IMDb's title.basics.tsv.gz, decompress it, and write the
+    first _IMDB_SAMPLE_MAX_ROWS data rows (plus header) to `dest`."""
+    import gzip
+
+    _validate_url(_IMDB_SAMPLE_URL)
+    req = urllib.request.Request(
+        _IMDB_SAMPLE_URL, headers={"User-Agent": "opensearch-skills/1.0"}
+    )
+    opener = _build_safe_opener()
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = dest.with_suffix(dest.suffix + ".part")
+
+    with opener.open(req, timeout=60) as resp:
+        with gzip.GzipFile(fileobj=resp) as gz, open(
+            tmp_path, "w", encoding="utf-8", newline=""
+        ) as out:
+            for i, raw_line in enumerate(gz):
+                if i > _IMDB_SAMPLE_MAX_ROWS:  # header + N data rows
+                    break
+                out.write(raw_line.decode("utf-8", errors="replace"))
+    tmp_path.replace(dest)
+
+
+def load_sample_builtin_imdb() -> str:
+    """Load the built-in IMDB sample dataset.
+
+    Checks, in order: a local copy bundled alongside this script, a cached
+    copy from a previous download, and finally downloads a fresh copy from
+    IMDb's dataset export (see _IMDB_SAMPLE_URL) and caches it for next time.
+    """
+    script_dir = Path(__file__).resolve().parent.parent
+
+    bundled_path = script_dir / "sample_data" / _IMDB_SAMPLE_FILENAME
+    if bundled_path.exists():
+        return load_sample_from_file(str(bundled_path.resolve()))
+
+    cached_path = _imdb_cache_dir() / _IMDB_SAMPLE_FILENAME
+    if cached_path.exists():
+        return load_sample_from_file(str(cached_path.resolve()))
+
+    try:
+        _download_imdb_sample(cached_path)
+    except Exception as e:
+        return json.dumps({
+            "error": f"IMDB sample data not found locally and download failed: {e}"
+        })
+
+    return load_sample_from_file(str(cached_path.resolve()))
 
 
 def load_sample_from_file(file_path: str) -> str:

--- a/skills/opensearch-skills/scripts/lib/samples.py
+++ b/skills/opensearch-skills/scripts/lib/samples.py
@@ -68,13 +68,14 @@ def _infer_text_fields(doc: dict) -> list[str]:
     return text_fields
 
 
-# IMDb publishes a non-commercial dataset export, refreshed daily, at a
-# stable public URL: https://developer.imdb.com/non-commercial-datasets/
-# title.basics.tsv.gz is the title metadata file (titles, types, years,
-# genres) and is used here as sample data for search app prototyping.
+# IMDb's non-commercial dataset export: https://developer.imdb.com/non-commercial-datasets/
 _IMDB_SAMPLE_URL = "https://datasets.imdbws.com/title.basics.tsv.gz"
 _IMDB_SAMPLE_FILENAME = "imdb.title.basics.tsv"
-_IMDB_SAMPLE_MAX_ROWS = 100_000  # enough rows for a realistic sample without pulling the full multi-million-row dataset
+_IMDB_SAMPLE_MAX_ROWS = 100_000  # cap applied when the full sample is downloaded
+
+# Small (20-title) fallback bundled with the skill so builtin_imdb works
+# offline by default. Pass allow_download=True to fetch from IMDb instead.
+_IMDB_FALLBACK_FILENAME = "imdb.title.basics.sample20.tsv"
 
 
 def _imdb_cache_dir() -> Path:
@@ -87,11 +88,20 @@ def _imdb_cache_dir() -> Path:
 
 
 def _download_imdb_sample(dest: Path) -> None:
-    """Download IMDb's title.basics.tsv.gz, decompress it, and write the
-    first _IMDB_SAMPLE_MAX_ROWS data rows (plus header) to `dest`."""
+    """Download IMDb's title.basics.tsv.gz and write the first
+    _IMDB_SAMPLE_MAX_ROWS rows to `dest`.
+
+    Stops reading once enough rows are collected, so only a small part of
+    the (200MB+) source file is actually downloaded. Requires HTTPS and
+    checks the decompressed header matches the expected TSV schema.
+    """
     import gzip
 
+    parsed = urlparse(_IMDB_SAMPLE_URL)
+    if parsed.scheme != "https":
+        raise ValueError(f"Refusing to fetch sample data over non-HTTPS URL: {_IMDB_SAMPLE_URL}")
     _validate_url(_IMDB_SAMPLE_URL)
+
     req = urllib.request.Request(
         _IMDB_SAMPLE_URL, headers={"User-Agent": "opensearch-skills/1.0"}
     )
@@ -99,30 +109,53 @@ def _download_imdb_sample(dest: Path) -> None:
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = dest.with_suffix(dest.suffix + ".part")
+    max_line_bytes = 1024 * 1024  # 1MB; real rows are well under 1KB
 
-    with opener.open(req, timeout=60) as resp:
-        with gzip.GzipFile(fileobj=resp) as gz, open(
-            tmp_path, "w", encoding="utf-8", newline=""
-        ) as out:
-            for i, raw_line in enumerate(gz):
-                if i > _IMDB_SAMPLE_MAX_ROWS:  # header + N data rows
-                    break
-                out.write(raw_line.decode("utf-8", errors="replace"))
-    tmp_path.replace(dest)
+    try:
+        with opener.open(req, timeout=60) as resp:
+            with gzip.GzipFile(fileobj=resp) as gz, open(
+                tmp_path, "w", encoding="utf-8", newline=""
+            ) as out:
+                for i, raw_line in enumerate(gz):
+                    if len(raw_line) > max_line_bytes:
+                        raise ValueError(
+                            "Sample data line exceeded the expected size; "
+                            "response does not look like valid TSV"
+                        )
+                    line = raw_line.decode("utf-8", errors="replace")
+                    if i == 0 and not line.startswith("tconst\t"):
+                        raise ValueError(
+                            "Unexpected sample data format: header does not "
+                            "match IMDb title.basics.tsv schema"
+                        )
+                    if i > _IMDB_SAMPLE_MAX_ROWS:  # header + N data rows
+                        break
+                    out.write(line)
+        tmp_path.replace(dest)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
-def load_sample_builtin_imdb() -> str:
+def load_sample_builtin_imdb(allow_download: bool = False) -> str:
     """Load the built-in IMDB sample dataset.
 
-    Checks, in order: a local copy bundled alongside this script, a cached
-    copy from a previous download, and finally downloads a fresh copy from
-    IMDb's dataset export (see _IMDB_SAMPLE_URL) and caches it for next time.
+    By default uses a small bundled fallback (no network call). Pass
+    allow_download=True to fetch a larger sample from IMDb instead,
+    caching it locally for reuse.
     """
     script_dir = Path(__file__).resolve().parent.parent
 
-    bundled_path = script_dir / "sample_data" / _IMDB_SAMPLE_FILENAME
-    if bundled_path.exists():
-        return load_sample_from_file(str(bundled_path.resolve()))
+    if not allow_download:
+        fallback_path = script_dir / "sample_data" / _IMDB_FALLBACK_FILENAME
+        if fallback_path.exists():
+            return load_sample_from_file(str(fallback_path.resolve()))
+        return json.dumps({
+            "error": (
+                "Bundled IMDB sample not found. Retry with allow_download=True "
+                "to fetch a larger sample from IMDb's dataset export."
+            )
+        })
 
     cached_path = _imdb_cache_dir() / _IMDB_SAMPLE_FILENAME
     if cached_path.exists():

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -183,7 +183,7 @@ def cmd_load_sample(args):
         load_sample_from_paste,
     )
     dispatch = {
-        "builtin_imdb": lambda: load_sample_builtin_imdb(),
+        "builtin_imdb": lambda: load_sample_builtin_imdb(allow_download=args.allow_download),
         "local_file": lambda: load_sample_from_file(args.value),
         "url": lambda: load_sample_from_url(args.value),
         "localhost_index": lambda: load_sample_from_index(args.value),
@@ -478,6 +478,10 @@ def main():
     p.add_argument("-t", "--type", required=True,
                     choices=["builtin_imdb", "local_file", "url", "localhost_index", "paste"])
     p.add_argument("-v", "--value", default="")
+    p.add_argument("--allow-download", action="store_true",
+                    help="For --type builtin_imdb: fetch a larger sample (up to 100k rows) "
+                         "from IMDb's dataset export instead of the small bundled fallback. "
+                         "Tell the user this triggers a network download before using it.")
 
     # cleanup
     sub.add_parser("cleanup", help="Stop UI and clean up")

--- a/skills/opensearch-skills/scripts/sample_data/imdb.title.basics.sample20.tsv
+++ b/skills/opensearch-skills/scripts/sample_data/imdb.title.basics.sample20.tsv
@@ -1,0 +1,21 @@
+tconst	titleType	primaryTitle	originalTitle	isAdult	startYear	endYear	runtimeMinutes	genres
+tt0000001	short	Carmencita	Carmencita	0	1894	\N	1	Documentary,Short
+tt0000002	short	Le clown et ses chiens	Le clown et ses chiens	0	1892	\N	5	Animation,Short
+tt0000003	short	Poor Pierrot	Pauvre Pierrot	0	1892	\N	5	Animation,Comedy,Romance
+tt0000004	short	Un bon bock	Un bon bock	0	1892	\N	12	Animation,Short
+tt0000005	short	Blacksmith Scene	Blacksmith Scene	0	1893	\N	1	Short
+tt0000006	short	Chinese Opium Den	Chinese Opium Den	0	1894	\N	1	Short
+tt0000007	short	Corbett and Courtney Before the Kinetograph	Corbett and Courtney Before the Kinetograph	0	1894	\N	1	Short,Sport
+tt0000008	short	Edison Kinetoscopic Record of a Sneeze	Edison Kinetoscopic Record of a Sneeze	0	1894	\N	1	Documentary,Short
+tt0000009	movie	Miss Jerry	Miss Jerry	0	1894	\N	45	Romance
+tt0000010	short	Leaving the Factory	La sortie de l'usine Lumière à Lyon	0	1895	\N	1	Documentary,Short
+tt0000011	short	Akrobatisches Potpourri	Akrobatisches Potpourri	0	1895	\N	1	Documentary,Short
+tt0000012	short	The Arrival of a Train	L'arrivée d'un train à La Ciotat	0	1896	\N	1	Documentary,Short
+tt0000013	short	The Photographical Congress Arrives in Lyon	Le Débarquement du congrès de photographie à Lyon	0	1895	\N	1	Documentary,Short
+tt0000014	short	The Waterer Watered	L'arroseur arrosé	0	1895	\N	1	Comedy,Short
+tt0000015	short	Around a Cabin	Autour d'une cabine	0	1894	\N	2	Animation,Comedy,Short
+tt0000016	short	Boat Leaving the Port	Barque sortant du port	0	1895	\N	1	Documentary,Short
+tt0000017	short	Italienischer Bauerntanz	Italienischer Bauerntanz	0	1895	\N	1	Documentary,Short
+tt0000018	short	Das boxende Känguruh	Das boxende Känguruh	0	1895	\N	1	Short,Sport
+tt0000019	short	The Clown Barber	The Clown Barber	0	1898	\N	\N	Comedy,Short
+tt0000020	short	The Derby 1895	The Derby 1895	0	1895	\N	1	Documentary,Short,Sport

--- a/skills/opensearch-skills/search/opensearch-launchpad/SKILL.md
+++ b/skills/opensearch-skills/search/opensearch-launchpad/SKILL.md
@@ -130,7 +130,7 @@ See [cli-reference.md](../../cli-reference.md) for the full command reference.
 ### Phase 1 — Collect Sample Data
 
 Ask for the data source. Supported inputs:
-- Built-in datasets (`load-sample --type builtin_imdb`)
+- Built-in datasets (`load-sample --type builtin_imdb`) — uses a small bundled sample (20 titles) by default, no network call. If the user wants a larger sample, ask first, then rerun with `--allow-download` to fetch up to 100k rows from IMDb's public dataset export.
 - Local files: JSON, JSONL, CSV, TSV, Parquet (`load-sample --type local_file --value <path>`)
 - PDF, DOCX, PPTX, XLSX — use Docling to process. Read [document_processing_guide.md](document_processing_guide.md).
 - URLs or pasted JSON

--- a/tests/test_agent_skills_standalone_assets.py
+++ b/tests/test_agent_skills_standalone_assets.py
@@ -60,10 +60,9 @@ class TestUIAssetsStandalone:
 # ---------------------------------------------------------------------------
 # Sample data
 # ---------------------------------------------------------------------------
-# The built-in IMDB sample dataset is fetched on demand from IMDb's dataset
-# export (https://datasets.imdbws.com/title.basics.tsv.gz) and cached
-# locally rather than shipped as a static file. These tests mock the network
-# call so they run offline and don't depend on IMDb's live dataset.
+# builtin_imdb uses a small bundled fallback by default (no network call).
+# allow_download=True fetches a larger sample from IMDb instead. These
+# tests mock the network call so they run offline.
 _SAMPLE_TSV_BYTES = (
     b"tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\t"
     b"endYear\truntimeMinutes\tgenres\n"
@@ -72,7 +71,7 @@ _SAMPLE_TSV_BYTES = (
 
 
 def _make_fake_gzip_response(payload: bytes):
-    """Build a gzip-compressed byte string mimicking the IMDb .gz response body."""
+    """Gzip-compress `payload`, mimicking the IMDb .gz response body."""
     import gzip
     import io
 
@@ -83,15 +82,41 @@ def _make_fake_gzip_response(payload: bytes):
 
 
 class TestSampleDataStandalone:
-    """Verify the IMDB sample dataset is fetched and cached on demand,
-    rather than requiring a bundled copy inside the skill."""
+    """builtin_imdb uses a small bundled fallback by default and only
+    fetches a larger sample when explicitly requested."""
 
-    def test_sample_data_not_bundled(self):
-        """The skill ships no static sample_data/ directory; sample data
-        is fetched at runtime instead."""
-        assert not (_SCRIPTS_DIR / "sample_data").exists(), (
-            "sample_data/ should not be bundled; samples.py fetches data at runtime"
+    def test_fallback_sample_is_bundled(self):
+        from lib import samples
+
+        fallback_path = _SCRIPTS_DIR / "sample_data" / samples._IMDB_FALLBACK_FILENAME
+        assert fallback_path.is_file(), f"Bundled fallback sample missing: {fallback_path}"
+        assert fallback_path.stat().st_size < 10_000, (
+            "Bundled fallback sample should be small (~20 rows), not a full dataset dump"
         )
+
+    def test_full_sample_not_bundled(self):
+        from lib import samples
+
+        full_path = _SCRIPTS_DIR / "sample_data" / samples._IMDB_SAMPLE_FILENAME
+        assert not full_path.exists(), (
+            "Full-size IMDB sample should not be bundled; only the small fallback should ship"
+        )
+
+    def test_load_sample_builtin_imdb_default_uses_bundled_fallback_offline(self, monkeypatch):
+        import json
+
+        from lib import samples
+
+        def _fail(*args, **kwargs):
+            raise AssertionError("Should not attempt network access without allow_download=True")
+
+        monkeypatch.setattr(samples, "_download_imdb_sample", _fail)
+        monkeypatch.setattr(samples, "_build_safe_opener", _fail)
+
+        result = json.loads(samples.load_sample_builtin_imdb())
+        assert "error" not in result, f"load_sample_builtin_imdb failed: {result}"
+        assert result["status"] == "loaded"
+        assert result["record_count"] > 0
 
     def test_load_sample_builtin_imdb_downloads_and_caches(self, monkeypatch, tmp_path):
         import io
@@ -111,7 +136,7 @@ class TestSampleDataStandalone:
         monkeypatch.setattr(samples, "_validate_url", lambda url: None)
         monkeypatch.setattr(samples, "_build_safe_opener", lambda: _FakeOpener())
 
-        result = json.loads(samples.load_sample_builtin_imdb())
+        result = json.loads(samples.load_sample_builtin_imdb(allow_download=True))
         assert "error" not in result, f"load_sample_builtin_imdb failed: {result}"
         assert result["status"] == "loaded"
         assert result["record_count"] > 0
@@ -122,7 +147,6 @@ class TestSampleDataStandalone:
     def test_load_sample_builtin_imdb_uses_cache_without_reopening_network(
         self, monkeypatch, tmp_path
     ):
-        """Second call should read from cache and must not hit the network."""
         import json
 
         from lib import samples
@@ -139,7 +163,7 @@ class TestSampleDataStandalone:
 
         monkeypatch.setattr(samples, "_download_imdb_sample", _fail_download)
 
-        result = json.loads(samples.load_sample_builtin_imdb())
+        result = json.loads(samples.load_sample_builtin_imdb(allow_download=True))
         assert "error" not in result, f"load_sample_builtin_imdb failed: {result}"
         assert result["status"] == "loaded"
 
@@ -156,9 +180,93 @@ class TestSampleDataStandalone:
 
         monkeypatch.setattr(samples, "_download_imdb_sample", _raise)
 
-        result = json.loads(samples.load_sample_builtin_imdb())
+        result = json.loads(samples.load_sample_builtin_imdb(allow_download=True))
         assert "error" in result
-        assert "download failed" in result["error"]
+
+    def test_download_rejects_unexpected_schema(self, monkeypatch, tmp_path):
+        import io
+
+        from lib import samples
+
+        cache_dir = tmp_path / "cache"
+        bogus_payload = b"not\tthe\texpected\theader\n1\t2\t3\t4\n"
+        gz_bytes = _make_fake_gzip_response(bogus_payload)
+
+        class _FakeOpener:
+            def open(self, req, timeout=None):
+                return io.BytesIO(gz_bytes)
+
+        monkeypatch.setattr(samples, "_validate_url", lambda url: None)
+        monkeypatch.setattr(samples, "_build_safe_opener", lambda: _FakeOpener())
+
+        dest = cache_dir / samples._IMDB_SAMPLE_FILENAME
+        with pytest.raises(ValueError, match="Unexpected sample data format"):
+            samples._download_imdb_sample(dest)
+
+        assert not dest.exists(), "Rejected download should not be written to the cache path"
+        assert not dest.with_suffix(dest.suffix + ".part").exists(), (
+            "Temp file should be cleaned up after a failed validation"
+        )
+
+    def test_download_stops_early_without_reading_full_response(self, monkeypatch, tmp_path):
+        """IMDb's full catalog is 200MB+ compressed; the download should
+        stop once enough rows are read rather than consuming it all."""
+        import io
+
+        from lib import samples
+
+        cache_dir = tmp_path / "cache"
+
+        header = b"tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres\n"
+        row = b"tt0000001\tshort\tCarmencita\tCarmencita\t0\t1894\t\\N\t1\tDocumentary,Short\n"
+        many_rows = header + row * (samples._IMDB_SAMPLE_MAX_ROWS * 3)
+        gz_bytes = _make_fake_gzip_response(many_rows)
+
+        class _FakeOpener:
+            def open(self, req, timeout=None):
+                return io.BytesIO(gz_bytes)
+
+        monkeypatch.setattr(samples, "_validate_url", lambda url: None)
+        monkeypatch.setattr(samples, "_build_safe_opener", lambda: _FakeOpener())
+
+        dest = cache_dir / samples._IMDB_SAMPLE_FILENAME
+        samples._download_imdb_sample(dest)
+
+        assert dest.is_file()
+        with open(dest) as f:
+            line_count = sum(1 for _ in f)
+        assert line_count <= samples._IMDB_SAMPLE_MAX_ROWS + 1  # header + N rows, not 3x
+
+    def test_download_rejects_oversized_line(self, monkeypatch, tmp_path):
+        """Guards against a malformed/malicious response with no newlines
+        that would otherwise buffer unbounded data."""
+        import io
+
+        from lib import samples
+
+        cache_dir = tmp_path / "cache"
+        header = b"tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\tendYear\truntimeMinutes\tgenres\n"
+        huge_line = b"tt0000001\t" + b"a" * (2 * 1024 * 1024) + b"\n"  # 2MB, over the 1MB cap
+        gz_bytes = _make_fake_gzip_response(header + huge_line)
+
+        class _FakeOpener:
+            def open(self, req, timeout=None):
+                return io.BytesIO(gz_bytes)
+
+        monkeypatch.setattr(samples, "_validate_url", lambda url: None)
+        monkeypatch.setattr(samples, "_build_safe_opener", lambda: _FakeOpener())
+
+        dest = cache_dir / samples._IMDB_SAMPLE_FILENAME
+        with pytest.raises(ValueError, match="exceeded the expected size"):
+            samples._download_imdb_sample(dest)
+
+        assert not dest.exists()
+
+    def test_download_url_is_https(self):
+        from lib import samples
+        from urllib.parse import urlparse
+
+        assert urlparse(samples._IMDB_SAMPLE_URL).scheme == "https"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_skills_standalone_assets.py
+++ b/tests/test_agent_skills_standalone_assets.py
@@ -60,44 +60,105 @@ class TestUIAssetsStandalone:
 # ---------------------------------------------------------------------------
 # Sample data
 # ---------------------------------------------------------------------------
+# The built-in IMDB sample dataset is fetched on demand from IMDb's dataset
+# export (https://datasets.imdbws.com/title.basics.tsv.gz) and cached
+# locally rather than shipped as a static file. These tests mock the network
+# call so they run offline and don't depend on IMDb's live dataset.
+_SAMPLE_TSV_BYTES = (
+    b"tconst\ttitleType\tprimaryTitle\toriginalTitle\tisAdult\tstartYear\t"
+    b"endYear\truntimeMinutes\tgenres\n"
+    b"tt0000001\tshort\tCarmencita\tCarmencita\t0\t1894\t\\N\t1\tDocumentary,Short\n"
+)
+
+
+def _make_fake_gzip_response(payload: bytes):
+    """Build a gzip-compressed byte string mimicking the IMDb .gz response body."""
+    import gzip
+    import io
+
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
+        gz.write(payload)
+    return buf.getvalue()
+
+
 class TestSampleDataStandalone:
-    """Verify IMDB sample data is bundled and samples.py finds it locally."""
+    """Verify the IMDB sample dataset is fetched and cached on demand,
+    rather than requiring a bundled copy inside the skill."""
 
-    IMDB_TSV = _SCRIPTS_DIR / "sample_data" / "imdb.title.basics.tsv"
+    def test_sample_data_not_bundled(self):
+        """The skill ships no static sample_data/ directory; sample data
+        is fetched at runtime instead."""
+        assert not (_SCRIPTS_DIR / "sample_data").exists(), (
+            "sample_data/ should not be bundled; samples.py fetches data at runtime"
+        )
 
-    def test_sample_data_directory_exists(self):
-        assert (_SCRIPTS_DIR / "sample_data").is_dir()
-
-    def test_imdb_tsv_exists(self):
-        assert self.IMDB_TSV.is_file(), f"IMDB TSV missing: {self.IMDB_TSV}"
-
-    def test_imdb_tsv_not_empty(self):
-        assert self.IMDB_TSV.stat().st_size > 0
-
-    def test_imdb_tsv_has_header_row(self):
-        with open(self.IMDB_TSV, "r") as f:
-            header = f.readline().strip()
-        assert "tconst" in header, f"Unexpected header: {header}"
-
-    def test_load_sample_builtin_imdb_succeeds(self):
+    def test_load_sample_builtin_imdb_downloads_and_caches(self, monkeypatch, tmp_path):
+        import io
         import json
-        from lib.samples import load_sample_builtin_imdb
 
-        result = json.loads(load_sample_builtin_imdb())
+        from lib import samples
+
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(samples, "_imdb_cache_dir", lambda: cache_dir)
+
+        gz_bytes = _make_fake_gzip_response(_SAMPLE_TSV_BYTES)
+
+        class _FakeOpener:
+            def open(self, req, timeout=None):
+                return io.BytesIO(gz_bytes)
+
+        monkeypatch.setattr(samples, "_validate_url", lambda url: None)
+        monkeypatch.setattr(samples, "_build_safe_opener", lambda: _FakeOpener())
+
+        result = json.loads(samples.load_sample_builtin_imdb())
         assert "error" not in result, f"load_sample_builtin_imdb failed: {result}"
         assert result["status"] == "loaded"
         assert result["record_count"] > 0
 
-    def test_builtin_imdb_resolves_to_local_path(self):
-        import json
-        from lib.samples import load_sample_builtin_imdb
+        cached_file = cache_dir / samples._IMDB_SAMPLE_FILENAME
+        assert cached_file.is_file(), "Downloaded sample should be cached to disk"
 
-        result = json.loads(load_sample_builtin_imdb())
-        source = result.get("source", "")
-        # Must resolve inside the skill, not opensearch_orchestrator/
-        assert "opensearch_orchestrator" not in source, (
-            f"IMDB sample resolved outside the skill: {source}"
-        )
+    def test_load_sample_builtin_imdb_uses_cache_without_reopening_network(
+        self, monkeypatch, tmp_path
+    ):
+        """Second call should read from cache and must not hit the network."""
+        import json
+
+        from lib import samples
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+        cached_file = cache_dir / samples._IMDB_SAMPLE_FILENAME
+        cached_file.write_text(_SAMPLE_TSV_BYTES.decode("utf-8"))
+
+        monkeypatch.setattr(samples, "_imdb_cache_dir", lambda: cache_dir)
+
+        def _fail_download(dest):
+            raise AssertionError("Should not attempt download when cache exists")
+
+        monkeypatch.setattr(samples, "_download_imdb_sample", _fail_download)
+
+        result = json.loads(samples.load_sample_builtin_imdb())
+        assert "error" not in result, f"load_sample_builtin_imdb failed: {result}"
+        assert result["status"] == "loaded"
+
+    def test_load_sample_builtin_imdb_surfaces_download_errors(self, monkeypatch, tmp_path):
+        import json
+
+        from lib import samples
+
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(samples, "_imdb_cache_dir", lambda: cache_dir)
+
+        def _raise(dest):
+            raise OSError("network unreachable")
+
+        monkeypatch.setattr(samples, "_download_imdb_sample", _raise)
+
+        result = json.loads(samples.load_sample_builtin_imdb())
+        assert "error" in result
+        assert "download failed" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -115,9 +176,9 @@ class TestResolvedPathsAreRelative:
             f"SEARCH_UI_STATIC_DIR escapes the scripts dir: {resolved}"
         )
 
-    def test_samples_imdb_candidates_are_under_skill_root(self):
-        """Check that the candidate paths in load_sample_builtin_imdb
-        stay within the skill tree."""
+    def test_samples_imdb_resolution_has_no_repo_root_assumptions(self):
+        """Check that load_sample_builtin_imdb's bundled-path fallback and
+        cache-dir logic never hardcode a path outside the skill/user cache."""
         import inspect
         from lib.samples import load_sample_builtin_imdb
 


### PR DESCRIPTION
### Description

The bundled IMDB sample TSV (7.6MB, 100k rows) accounted for ~90% of the shared scripts/ folder's size, downloaded for every skill install regardless of whether the built-in sample was used. This fetches it on demand from IMDb's official dataset export instead, caching locally after first use.

Here's the table on its own to confirm the exact syntax:
  
  | Component | Size | % of `scripts/` |
  | --- | --- | --- |
  | `sample_data/` (IMDB TSV) | 7.6M | ~90% |
  | `lib/` (Python source) | 592K | ~7% |
  | `ui/` (React frontend) | 172K | ~2% |
  | `opensearch_ops.py` | 28K | <1% |
  
### Why
  
  - Cuts unnecessary download weight from every skill install
  - Removes a static 8MB data file from version control
  - Sources from IMDb's live export instead of a stale point-in-time snapshot
  - No behavior change — same output, same fallback order (bundled → cache → download)

### Change  
**Default behavior — no network call:**
  
- `load-sample --type builtin_imdb` now uses a small bundled fallback (20 real IMDb titles, ~2KB) shipped with the skill. No download, no external request, works fully offline.
  
**Opt-in for a larger sample:**
  
 -  `--allow-download` fetches up to 100k rows from IMDb's official dataset export (datasets.imdbws.com) and caches them locally (`~/.cache/opensearch-agent-skills/sample_data/`). SKILL.md instructs the
  agent to tell the user a download will happen before using this flag — the network call is never silent.
  
**Hardening on the download path (used only when --allow-download is passed):**
  
  - HTTPS enforced explicitly
  - Response header validated against the expected IMDb TSV schema before being trusted
  - Reads incrementally and stops once enough rows are collected — the live source is 200MB+ compressed; only a small fraction is ever actually fetched
  - Per-line size cap guards against a malformed/adversarial response with no newlines
  - Failed downloads clean up their temp file rather than leaving debris
  
### Testing
  
  - uv run pytest tests/ -v — 604 passed
  - Manual end-to-end runs against the live IMDb endpoint: verified default (offline, bundled fallback) and --allow-download (live fetch, correct row count/schema, cache-hit on second run) both
  work correctly
  - Verified sibling load-sample types (paste, local_file) unaffected

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
