### PR TITLE
fix: add uv prerequisite for feedback and document-processing skills

### DIFF
--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -74,6 +74,8 @@ You MUST proactively collect feedback during every interaction. This is not opti
 
 ### How to Submit
 
+Requires `uv` installed (for running Python scripts)
+
 1. Compose the feedback (type + context).
 2. Show preview to user.
 3. Ask: "May I submit this anonymous feedback?"

--- a/skills/opensearch-skills/ingest/document-processing/SKILL.md
+++ b/skills/opensearch-skills/ingest/document-processing/SKILL.md
@@ -16,6 +16,10 @@ metadata:
 
 Process unstructured documents into search-ready JSONL chunks using [Docling](https://docling.site/) (open-source, runs locally). No AWS credentials or cloud services needed.
 
+## Prerequisites
+
+- `uv` installed (for running Python scripts)
+
 ## When to Use
 
 - User has unstructured documents (PDF, DOCX, PPTX, XLSX)


### PR DESCRIPTION
### Description
- skill docs referenced uv run for the feedback workflow without stating uv as a prerequisite
- and document-processing had no prerequisites section at all — leaving agents to assume uv is installed.

### Local Validation
**Environment:** macOS, `uv` at `/opt/homebrew/bin/uv`
  
  | Check | Result |
  |---|---|
  | `skills/opensearch-skills/SKILL.md` states `uv` prerequisite before feedback submission steps | ✅ Requires `uv`  installed (for running Python scripts) present in "How to Submit" section |
  | `skills/opensearch-skills/ingest/document-processing/SKILL.md` has a Prerequisites section | ✅ Added — previously this skill had no Prerequisites section at all |
  | Full test suite still passes | ✅ `uv run pytest tests/ -v` — 658 passed, 68 skipped (skipped tests require `--run-eval` flag, unrelated to this change) |

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
