### PR TITLE
feat: add opensearch-blueprint skill for index design compilation and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Skills are organized in a tree — install the whole collection or pick individu
 | Category | Skill | Description |
 |----------|-------|-------------|
 | **Search** | [opensearch-launchpad](skills/opensearch-skills/search/opensearch-launchpad/) | Build search apps from scratch — BM25, semantic, hybrid, agentic search |
+| **Search** | [opensearch-blueprint](skills/opensearch-skills/search/opensearch-blueprint/) | Compile requirements into a linted, cluster-verified index design — mappings, analyzers, k-NN, pipelines, ISM |
 | **Observability** | [log-analytics](skills/opensearch-skills/observability/log-analytics/) | Query and analyze logs with PPL — error patterns, anomaly detection |
 | **Observability** | [trace-analytics](skills/opensearch-skills/observability/trace-analytics/) | Investigate distributed traces — slow spans, service maps, agent invocations |
 | **Cloud** | [aws-setup](skills/opensearch-skills/cloud/aws-setup/) | Deploy to Amazon OpenSearch Service or Serverless |
@@ -30,6 +31,7 @@ npx skills add opensearch-project/opensearch-agent-skills
 
 # Install a specific skill
 npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth
+npx skills add opensearch-project/opensearch-agent-skills@opensearch-blueprint --full-depth
 npx skills add opensearch-project/opensearch-agent-skills@log-analytics --full-depth
 npx skills add opensearch-project/opensearch-agent-skills@trace-analytics --full-depth
 npx skills add opensearch-project/opensearch-agent-skills@aws-setup --full-depth
@@ -94,6 +96,11 @@ skills/
       opensearch-launchpad/           # Search app builder
         SKILL.md
         *.md                          # Model guides, evaluation, strategies
+      opensearch-blueprint/           # Index design compiler + validator
+        SKILL.md
+        blueprint-format.md           # Bundle schema and density rules
+        opensearch-vocabulary.md      # Field types, analysis, k-NN, pipelines
+        example-bundle.json           # Reference hybrid blueprint
     observability/                    # Category: Observability
       SKILL.md
       log-analytics/                  # Log querying & analysis

--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -24,6 +24,7 @@ This is the top-level skill for OpenSearch. It contains four category skills tha
 | Category | Skill | Install individually |
 |---|---|---|
 | [search](search/SKILL.md) | [opensearch-launchpad](search/opensearch-launchpad/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth` |
+| [search](search/SKILL.md) | [opensearch-blueprint](search/opensearch-blueprint/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@opensearch-blueprint --full-depth` |
 | [observability](observability/SKILL.md) | [log-analytics](observability/log-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@log-analytics --full-depth` |
 | [observability](observability/SKILL.md) | [trace-analytics](observability/trace-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@trace-analytics --full-depth` |
 | [cloud](cloud/SKILL.md) | [aws-setup](cloud/aws-setup/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@aws-setup --full-depth` |
@@ -37,6 +38,7 @@ Route to the right skill based on user intent:
 | User Intent | Skill |
 |---|---|
 | Build a search app, set up an index, choose a search strategy | [opensearch-launchpad](search/opensearch-launchpad/SKILL.md) |
+| Design/review a mapping or analyzer, validate an index design, audit an existing index | [opensearch-blueprint](search/opensearch-blueprint/SKILL.md) |
 | Analyze logs, query with PPL, discover error patterns | [log-analytics](observability/log-analytics/SKILL.md) |
 | Investigate traces, debug spans, analyze service maps | [trace-analytics](observability/trace-analytics/SKILL.md) |
 | Deploy to AWS, provision a domain or collection | [aws-setup](cloud/aws-setup/SKILL.md) |

--- a/skills/opensearch-skills/cli-reference.md
+++ b/skills/opensearch-skills/cli-reference.md
@@ -171,6 +171,30 @@ uv run python scripts/opensearch_ops.py read-knowledge --file agentic_search_gui
 uv run python scripts/opensearch_ops.py read-knowledge --file evaluation_guide.md
 ```
 
+## Index blueprints
+
+Compile, verify, and extract complete index designs. See the
+[opensearch-blueprint](search/opensearch-blueprint/SKILL.md) skill.
+
+```bash
+# Static checks — no cluster required. Exits non-zero on errors.
+uv run python scripts/opensearch_ops.py blueprint-lint --bundle blueprint.json
+uv run python scripts/opensearch_ops.py blueprint-lint --bundle blueprint.json --json
+
+# Render the bundle as a dense single-block spec
+uv run python scripts/opensearch_ops.py blueprint-render --bundle blueprint.json
+
+# Lint and render without touching the cluster
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --dry-run
+
+# Create pipelines + index + ISM policy, probe analyzers via _analyze,
+# validate every named query via _validate/query
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace
+
+# Read an existing index back into a portable blueprint
+uv run python scripts/opensearch_ops.py blueprint-extract --index movies_v1 --out blueprint.json --lint
+```
+
 ## Cleanup
 
 ```bash

--- a/skills/opensearch-skills/cli-reference.md
+++ b/skills/opensearch-skills/cli-reference.md
@@ -184,12 +184,18 @@ uv run python scripts/opensearch_ops.py blueprint-lint --bundle blueprint.json -
 # Render the bundle as a dense single-block spec
 uv run python scripts/opensearch_ops.py blueprint-render --bundle blueprint.json
 
-# Lint and render without touching the cluster
+# Lint, render, and report the change plan without touching the cluster
 uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --dry-run
 
 # Create pipelines + index + ISM policy, probe analyzers via _analyze,
-# validate every named query via _validate/query
-uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace
+# validate every named query via _validate/query. Refused if the index exists.
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json
+
+# Recreate an existing index. --replace alone is not enough: --yes confirms the
+# delete (or confirm interactively), and --allow-nonempty is additionally
+# required if the index holds documents. Deleted documents are unrecoverable.
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace --yes
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace --yes --allow-nonempty
 
 # Read an existing index back into a portable blueprint
 uv run python scripts/opensearch_ops.py blueprint-extract --index movies_v1 --out blueprint.json --lint

--- a/skills/opensearch-skills/scripts/lib/blueprint.py
+++ b/skills/opensearch-skills/scripts/lib/blueprint.py
@@ -873,45 +873,313 @@ def validate_queries(client, index, bundle):
     return results
 
 
-def apply_bundle(client, bundle, replace=False):
-    """Create ingest pipeline, search pipeline, index, and ISM policy."""
-    applied = {}
+class BlueprintApplyError(RuntimeError):
+    """Raised when an apply is refused by a safety gate, or fails mid-flight.
+
+    ``code`` is a stable machine-readable reason; ``details`` carries the
+    preflight plan and, for a mid-flight failure, what was rolled back.
+    """
+
+    def __init__(self, code, message, details=None):
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
+
+
+def _count_docs(client, index):
+    """Document count for an index, or ``None`` if it cannot be determined.
+
+    ``None`` is deliberately distinct from ``0``: callers must treat an unknown
+    count as non-empty so an unreachable count API can never widen the blast
+    radius of a delete.
+    """
+    try:
+        response = client.count(index=index)
+    except Exception:  # noqa: BLE001 - count is advisory; fail closed instead
+        return None
+    if isinstance(response, dict):
+        count = response.get("count")
+        return count if isinstance(count, int) else None
+    return None
+
+
+def _existing_ingest_pipeline(client, name):
+    try:
+        response = client.ingest.get_pipeline(id=name)
+    except Exception:  # noqa: BLE001 - absent pipeline raises 404
+        return None
+    return response.get(name) if isinstance(response, dict) else None
+
+
+def _existing_search_pipeline(client, name):
+    try:
+        response = client.transport.perform_request("GET", f"/_search/pipeline/{name}")
+    except Exception:  # noqa: BLE001
+        return None
+    return response.get(name) if isinstance(response, dict) else None
+
+
+def _existing_ism_policy(client, name):
+    try:
+        response = client.transport.perform_request(
+            "GET", f"/_plugins/_ism/policies/{name}"
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if isinstance(response, dict) and response.get("policy"):
+        return response
+    return None
+
+
+def _index_shell(client, index):
+    """Capture an existing index's settings + mappings before a replace.
+
+    Lets a failed replace restore the empty index structure. Documents are
+    **not** recoverable — that is why deleting a non-empty index needs its own
+    opt-in rather than relying on this.
+    """
+    try:
+        settings_response = client.indices.get_settings(index=index)
+        mappings_response = client.indices.get_mapping(index=index)
+    except Exception:  # noqa: BLE001
+        return None
+
+    settings_key = _resolve_response_key(settings_response, index)
+    mappings_key = _resolve_response_key(
+        mappings_response, index, preferred=settings_key
+    )
+    raw_settings = (settings_response.get(settings_key) or {}).get("settings") or {}
+    index_settings = dict(raw_settings.get("index") or {})
+    for key in _NON_PORTABLE_SETTINGS:
+        index_settings.pop(key, None)
+    mappings = (mappings_response.get(mappings_key) or {}).get("mappings") or {}
+
+    body = {}
+    if index_settings:
+        body["settings"] = {"index": index_settings}
+    if mappings:
+        body["mappings"] = mappings
+    return body
+
+
+def preflight_apply(client, bundle, replace=False):
+    """Read-only report of everything applying this bundle would change.
+
+    Touches nothing. Returns a plan describing what would be created, what
+    would be overwritten, and every hazard the caller must clear before any
+    mutation happens.
+    """
     index = bundle.get("index")
+    plan = {
+        "index": index,
+        "index_exists": False,
+        "doc_count": 0,
+        "will_delete": False,
+        "creates": [],
+        "overwrites": [],
+        "hazards": [],
+    }
+
+    exists = bool(client.indices.exists(index=index))
+    plan["index_exists"] = exists
+    if exists:
+        count = _count_docs(client, index)
+        plan["doc_count"] = count
+        if replace:
+            plan["will_delete"] = True
+            shown = "an unknown number of" if count is None else count
+            plan["hazards"].append({
+                "code": "destructive.delete_index",
+                "message": (
+                    f"index '{index}' exists and holds {shown} document(s); "
+                    "--replace deletes it and the documents cannot be restored"
+                ),
+            })
+        else:
+            plan["hazards"].append({
+                "code": "conflict.index_exists",
+                "message": (
+                    f"index '{index}' already exists; pass --replace to delete "
+                    "and recreate it, or change the bundle's index name"
+                ),
+            })
+    else:
+        plan["creates"].append({"kind": "index", "name": index})
 
     ingest = bundle.get("ingest_pipeline") or {}
     if ingest.get("name") and ingest.get("body"):
-        client.ingest.put_pipeline(id=ingest["name"], body=ingest["body"])
-        applied["ingest_pipeline"] = ingest["name"]
+        target = "overwrites" if _existing_ingest_pipeline(client, ingest["name"]) else "creates"
+        plan[target].append({"kind": "ingest_pipeline", "name": ingest["name"]})
 
     search_pipeline = bundle.get("search_pipeline") or {}
     if search_pipeline.get("name") and search_pipeline.get("body"):
-        client.transport.perform_request(
-            "PUT",
-            f"/_search/pipeline/{search_pipeline['name']}",
-            body=search_pipeline["body"],
+        target = (
+            "overwrites"
+            if _existing_search_pipeline(client, search_pipeline["name"])
+            else "creates"
         )
-        applied["search_pipeline"] = search_pipeline["name"]
-
-    if replace and client.indices.exists(index=index):
-        client.indices.delete(index=index)
-        applied["deleted_existing"] = True
-
-    body = {}
-    if bundle.get("settings"):
-        body["settings"] = bundle["settings"]
-    if bundle.get("mappings"):
-        body["mappings"] = bundle["mappings"]
-    client.indices.create(index=index, body=body)
-    applied["index"] = index
+        plan[target].append({"kind": "search_pipeline", "name": search_pipeline["name"]})
 
     ism = bundle.get("ism_policy") or {}
     if ism.get("name") and ism.get("body"):
-        client.transport.perform_request(
-            "PUT", f"/_plugins/_ism/policies/{ism['name']}", body=ism["body"]
+        target = "overwrites" if _existing_ism_policy(client, ism["name"]) else "creates"
+        plan[target].append({"kind": "ism_policy", "name": ism["name"]})
+
+    return plan
+
+
+def _unwind(undo_steps):
+    """Run rollback steps newest-first. Never raises — reports what failed."""
+    rolled_back, failed = [], []
+    for label, action in reversed(undo_steps):
+        try:
+            action()
+            rolled_back.append(label)
+        except Exception as exc:  # noqa: BLE001 - report, do not mask the cause
+            failed.append({"step": label, "error": str(exc)})
+    return rolled_back, failed
+
+
+def apply_bundle(client, bundle, replace=False, confirm=False,
+                 allow_nonempty=False, rollback=True):
+    """Create ingest pipeline, search pipeline, index, and ISM policy.
+
+    Every hazard is resolved by a read-only preflight *before* the first
+    mutation, so a refused apply leaves the cluster untouched. Deleting an
+    existing index requires ``replace``; deleting one that holds documents
+    additionally requires ``allow_nonempty``; either way ``confirm`` must be
+    set. The delete runs as late as possible, and any failure after the first
+    mutation unwinds what this call created (restoring overwritten pipelines
+    and policies, and recreating the replaced index's empty shell).
+    """
+    index = bundle.get("index")
+    plan = preflight_apply(client, bundle, replace=replace)
+
+    if plan["index_exists"] and not replace:
+        raise BlueprintApplyError(
+            "index_exists",
+            f"index '{index}' already exists; refusing to apply without --replace",
+            {"plan": plan},
         )
-        applied["ism_policy"] = ism["name"]
+    if plan["will_delete"] and plan["doc_count"] != 0:
+        if not allow_nonempty:
+            shown = "an unknown number of" if plan["doc_count"] is None else plan["doc_count"]
+            raise BlueprintApplyError(
+                "index_not_empty",
+                f"index '{index}' holds {shown} document(s); refusing to delete it. "
+                "Re-run with --allow-nonempty if that data is genuinely disposable",
+                {"plan": plan},
+            )
+    if plan["will_delete"] and not confirm:
+        raise BlueprintApplyError(
+            "confirmation_required",
+            f"applying this blueprint deletes index '{index}'; confirm with --yes",
+            {"plan": plan},
+        )
+
+    applied = {"plan": plan}
+    undo = []
+
+    try:
+        ingest = bundle.get("ingest_pipeline") or {}
+        if ingest.get("name") and ingest.get("body"):
+            name = ingest["name"]
+            prior = _existing_ingest_pipeline(client, name)
+            client.ingest.put_pipeline(id=name, body=ingest["body"])
+            applied["ingest_pipeline"] = name
+            undo.append((
+                f"ingest_pipeline:{name}",
+                (lambda n=name, p=prior: client.ingest.put_pipeline(id=n, body=p))
+                if prior is not None
+                else (lambda n=name: client.ingest.delete_pipeline(id=n)),
+            ))
+
+        search_pipeline = bundle.get("search_pipeline") or {}
+        if search_pipeline.get("name") and search_pipeline.get("body"):
+            name = search_pipeline["name"]
+            prior = _existing_search_pipeline(client, name)
+            client.transport.perform_request(
+                "PUT", f"/_search/pipeline/{name}", body=search_pipeline["body"]
+            )
+            applied["search_pipeline"] = name
+            undo.append((
+                f"search_pipeline:{name}",
+                (lambda n=name, p=prior: client.transport.perform_request(
+                    "PUT", f"/_search/pipeline/{n}", body=p))
+                if prior is not None
+                else (lambda n=name: client.transport.perform_request(
+                    "DELETE", f"/_search/pipeline/{n}")),
+            ))
+
+        # Destructive step, deliberately as late as possible: everything above
+        # is restorable, so a failure before this point costs nothing.
+        if plan["will_delete"]:
+            shell = _index_shell(client, index)
+            client.indices.delete(index=index)
+            applied["deleted_existing"] = True
+            if shell is not None:
+                undo.append((
+                    f"index-shell:{index}",
+                    lambda i=index, b=shell: client.indices.create(index=i, body=b),
+                ))
+
+        body = {}
+        if bundle.get("settings"):
+            body["settings"] = bundle["settings"]
+        if bundle.get("mappings"):
+            body["mappings"] = bundle["mappings"]
+        client.indices.create(index=index, body=body)
+        applied["index"] = index
+        undo.append((f"index:{index}", lambda i=index: client.indices.delete(index=i)))
+
+        ism = bundle.get("ism_policy") or {}
+        if ism.get("name") and ism.get("body"):
+            name = ism["name"]
+            prior = _existing_ism_policy(client, name)
+            path = f"/_plugins/_ism/policies/{name}"
+            if prior is not None:
+                seq_no = prior.get("_seq_no")
+                primary_term = prior.get("_primary_term")
+                suffix = (
+                    f"?if_seq_no={seq_no}&if_primary_term={primary_term}"
+                    if seq_no is not None and primary_term is not None
+                    else ""
+                )
+                client.transport.perform_request("PUT", path + suffix, body=ism["body"])
+            else:
+                client.transport.perform_request("PUT", path, body=ism["body"])
+            applied["ism_policy"] = name
+            undo.append((
+                f"ism_policy:{name}",
+                (lambda p=path, b={"policy": prior["policy"]}: client.transport.perform_request(
+                    "PUT", p, body=b))
+                if prior is not None
+                else (lambda p=path: client.transport.perform_request("DELETE", p)),
+            ))
+    except Exception as exc:  # noqa: BLE001 - re-raised with rollback detail
+        if not rollback:
+            raise
+        # The index we just created (if any) is not part of the damage to undo
+        # when it is also the thing that failed — _unwind reports either way.
+        rolled_back, failed = _unwind(undo)
+        details = {"applied": applied, "rolled_back": rolled_back, "rollback_failed": failed}
+        if applied.get("deleted_existing"):
+            details["irreversible"] = [
+                f"index '{index}' was deleted before the failure; its structure was "
+                "restored if possible, but its documents are gone"
+            ]
+        raise BlueprintApplyError(
+            "apply_failed", f"blueprint apply failed: {exc}", details
+        ) from exc
 
     return applied
+
+
+# Cluster-assigned settings that describe *this* index instance rather than the
+# design, so they are stripped from anything meant to be portable or replayed.
+_NON_PORTABLE_SETTINGS = (
+    "uuid", "version", "provided_name", "creation_date", "routing",
+)
 
 
 def _resolve_response_key(response, index, preferred=None):
@@ -948,7 +1216,7 @@ def extract_bundle(client, index):
     index_settings = dict(raw_settings.get("index") or {})
 
     # Drop cluster-assigned metadata that is not part of a portable design.
-    for key in ("uuid", "version", "provided_name", "creation_date", "routing"):
+    for key in _NON_PORTABLE_SETTINGS:
         index_settings.pop(key, None)
 
     mappings = (mappings_response.get(mappings_key) or {}).get("mappings") or {}

--- a/skills/opensearch-skills/scripts/lib/blueprint.py
+++ b/skills/opensearch-skills/scripts/lib/blueprint.py
@@ -1,0 +1,947 @@
+"""Blueprint compile / lint / apply / extract for OpenSearch index designs.
+
+A *blueprint bundle* is a single JSON document describing a complete OpenSearch
+index design — settings, analysis chain, mappings, ingest pipeline, search
+pipeline, ISM policy, and named queries. This module:
+
+  - ``lint_bundle``      static correctness checks (no cluster required)
+  - ``render_blueprint`` bundle -> dense single-block human/agent-readable spec
+  - ``probe_analyzers``  verify analyzers via the ``_analyze`` API
+  - ``validate_queries`` verify query DSL via the ``_validate/query`` API
+  - ``apply_bundle``     create pipelines, index, and ISM policy on a cluster
+  - ``extract_bundle``   read an existing index back into a bundle
+
+The lint rules encode OpenSearch-specific failure modes that are easy to get
+wrong by hand and expensive to discover after data is loaded (hybrid weight
+sums, knn dimension/plugin mismatches, dangling analyzer references).
+"""
+
+import json
+
+# ---------------------------------------------------------------------------
+# Built-in analysis component names (non-exhaustive but covers common usage).
+# A reference to anything outside these sets must be defined in
+# settings.analysis or it is a dangling reference.
+# ---------------------------------------------------------------------------
+
+_LANGUAGE_ANALYZERS = {
+    "arabic", "armenian", "basque", "bengali", "brazilian", "bulgarian",
+    "catalan", "cjk", "czech", "danish", "dutch", "english", "estonian",
+    "finnish", "french", "galician", "german", "greek", "hindi", "hungarian",
+    "indonesian", "irish", "italian", "latvian", "lithuanian", "norwegian",
+    "persian", "portuguese", "romanian", "russian", "sorani", "spanish",
+    "swedish", "turkish", "thai",
+}
+
+BUILTIN_ANALYZERS = {
+    "standard", "simple", "whitespace", "stop", "keyword", "pattern",
+    "fingerprint", "default", "default_search",
+} | _LANGUAGE_ANALYZERS
+
+BUILTIN_TOKENIZERS = {
+    "standard", "letter", "lowercase", "whitespace", "uax_url_email",
+    "classic", "thai", "ngram", "edge_ngram", "keyword", "pattern",
+    "simple_pattern", "simple_pattern_split", "char_group", "path_hierarchy",
+}
+
+BUILTIN_TOKEN_FILTERS = {
+    "apostrophe", "asciifolding", "cjk_bigram", "cjk_width", "classic",
+    "common_grams", "condition", "decimal_digit", "delimited_payload",
+    "dictionary_decompounder", "edge_ngram", "elision", "fingerprint",
+    "flatten_graph", "hunspell", "hyphenation_decompounder", "keep",
+    "keep_types", "keyword_marker", "keyword_repeat", "kstem", "length",
+    "limit", "lowercase", "min_hash", "multiplexer", "ngram",
+    "pattern_capture", "pattern_replace", "phonetic", "porter_stem",
+    "predicate_token_filter", "remove_duplicates", "reverse", "shingle",
+    "snowball", "stemmer", "stemmer_override", "stop", "synonym",
+    "synonym_graph", "trim", "truncate", "unique", "uppercase",
+    "word_delimiter", "word_delimiter_graph",
+}
+
+BUILTIN_CHAR_FILTERS = {"html_strip", "mapping", "pattern_replace"}
+
+# k-NN engines and the space types each one actually supports.
+KNN_ENGINE_SPACES = {
+    "lucene": {"l2", "cosinesimil", "innerproduct"},
+    "faiss": {"l2", "innerproduct", "cosinesimil", "hamming"},
+    "nmslib": {"l2", "cosinesimil", "innerproduct", "l1", "linf"},
+}
+
+# Vector dimensions for embedding models bundled with the launchpad skill.
+KNOWN_MODEL_DIMENSIONS = {
+    "huggingface/sentence-transformers/all-MiniLM-L6-v2": 384,
+    "huggingface/sentence-transformers/all-MiniLM-L12-v2": 384,
+    "huggingface/sentence-transformers/all-mpnet-base-v2": 768,
+    "huggingface/sentence-transformers/all-distilroberta-v1": 768,
+    "huggingface/sentence-transformers/multi-qa-MiniLM-L6-cos-v1": 384,
+    "huggingface/sentence-transformers/multi-qa-mpnet-base-dot-v1": 768,
+    "huggingface/sentence-transformers/paraphrase-MiniLM-L3-v2": 384,
+    "huggingface/sentence-transformers/msmarco-distilbert-base-tas-b": 768,
+    "amazon.titan-embed-text-v1": 1536,
+    "amazon.titan-embed-text-v2:0": 1024,
+    "cohere.embed-english-v3": 1024,
+    "cohere.embed-multilingual-v3": 1024,
+}
+
+_HYBRID_COMBINATION_TECHNIQUES = {
+    "arithmetic_mean", "geometric_mean", "harmonic_mean",
+}
+_HYBRID_NORMALIZATION_TECHNIQUES = {"min_max", "l2", "z_score"}
+
+# Weights that sum to within this tolerance of 1.0 are accepted.
+_WEIGHT_TOLERANCE = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+def _finding(level, code, message, path=""):
+    return {"level": level, "code": code, "message": message, "path": path}
+
+
+def _error(code, message, path=""):
+    return _finding("error", code, message, path)
+
+
+def _warning(code, message, path=""):
+    return _finding("warning", code, message, path)
+
+
+# ---------------------------------------------------------------------------
+# Mapping traversal
+# ---------------------------------------------------------------------------
+
+def iter_fields(properties, prefix=""):
+    """Yield ``(dotted_path, field_definition)`` for every mapped field.
+
+    Recurses into ``properties`` (object/nested) and ``fields`` (multi-fields),
+    so ``title.raw`` and ``author.name`` are both visited.
+    """
+    if not isinstance(properties, dict):
+        return
+    for name, defn in properties.items():
+        if not isinstance(defn, dict):
+            continue
+        path = f"{prefix}{name}"
+        yield path, defn
+        if isinstance(defn.get("properties"), dict):
+            yield from iter_fields(defn["properties"], prefix=f"{path}.")
+        if isinstance(defn.get("fields"), dict):
+            yield from iter_fields(defn["fields"], prefix=f"{path}.")
+
+
+def _analysis(bundle):
+    settings = bundle.get("settings") or {}
+    index = settings.get("index")
+    # Accept both {"index": {"analysis": ...}} and {"analysis": ...} forms.
+    if isinstance(index, dict) and "analysis" in index:
+        return index.get("analysis") or {}
+    return settings.get("analysis") or {}
+
+
+def _index_settings(bundle):
+    """Return index-level settings, tolerating both nesting conventions."""
+    settings = bundle.get("settings") or {}
+    index = settings.get("index")
+    merged = {k: v for k, v in settings.items() if k not in ("index", "analysis")}
+    if isinstance(index, dict):
+        merged.update({k: v for k, v in index.items() if k != "analysis"})
+    return merged
+
+
+def _as_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Lint
+# ---------------------------------------------------------------------------
+
+def lint_bundle(bundle):
+    """Return a list of findings for a blueprint bundle. No cluster needed."""
+    findings = []
+
+    if not isinstance(bundle, dict):
+        return [_error("bundle.type", "Blueprint bundle must be a JSON object.")]
+
+    if not str(bundle.get("index", "")).strip():
+        findings.append(_error("index.missing", "Bundle must declare an 'index' name.", "index"))
+
+    mappings = bundle.get("mappings") or {}
+    properties = mappings.get("properties") or {}
+    if not properties:
+        findings.append(_error(
+            "mappings.empty",
+            "Bundle declares no mapped fields; dynamic mapping is not a design.",
+            "mappings.properties",
+        ))
+
+    fields = dict(iter_fields(properties))
+
+    findings.extend(_lint_analysis_refs(bundle, fields))
+    findings.extend(_lint_knn(bundle, fields))
+    findings.extend(_lint_ingest_pipeline(bundle, fields))
+    findings.extend(_lint_search_pipeline(bundle))
+    findings.extend(_lint_queries(bundle, fields))
+    findings.extend(_lint_index_settings(bundle))
+    findings.extend(_lint_ism(bundle))
+
+    return findings
+
+
+def _lint_analysis_refs(bundle, fields):
+    """Every analyzer/normalizer a field references must exist."""
+    findings = []
+    analysis = _analysis(bundle)
+    custom_analyzers = set((analysis.get("analyzer") or {}).keys())
+    custom_normalizers = set((analysis.get("normalizer") or {}).keys())
+    custom_tokenizers = set((analysis.get("tokenizer") or {}).keys())
+    custom_filters = set((analysis.get("filter") or {}).keys())
+    custom_char_filters = set((analysis.get("char_filter") or {}).keys())
+
+    for path, defn in fields.items():
+        for key in ("analyzer", "search_analyzer", "search_quote_analyzer"):
+            ref = defn.get(key)
+            if ref and ref not in custom_analyzers and ref not in BUILTIN_ANALYZERS:
+                findings.append(_error(
+                    "analysis.dangling_analyzer",
+                    f"Field '{path}' references analyzer '{ref}', "
+                    f"which is neither built-in nor defined in settings.analysis.analyzer.",
+                    f"mappings.properties.{path}.{key}",
+                ))
+        ref = defn.get("normalizer")
+        if ref and ref not in custom_normalizers:
+            findings.append(_error(
+                "analysis.dangling_normalizer",
+                f"Field '{path}' references normalizer '{ref}', "
+                f"which is not defined in settings.analysis.normalizer.",
+                f"mappings.properties.{path}.normalizer",
+            ))
+        if ref and defn.get("type") != "keyword":
+            findings.append(_error(
+                "analysis.normalizer_on_non_keyword",
+                f"Field '{path}' is type '{defn.get('type')}'; "
+                f"normalizers apply only to keyword fields.",
+                f"mappings.properties.{path}",
+            ))
+
+    # Custom analyzer internals must also resolve.
+    for name, defn in (analysis.get("analyzer") or {}).items():
+        if not isinstance(defn, dict):
+            continue
+        tok = defn.get("tokenizer")
+        if tok and tok not in custom_tokenizers and tok not in BUILTIN_TOKENIZERS:
+            findings.append(_error(
+                "analysis.dangling_tokenizer",
+                f"Analyzer '{name}' references tokenizer '{tok}', "
+                f"which is neither built-in nor defined in settings.analysis.tokenizer.",
+                f"settings.analysis.analyzer.{name}.tokenizer",
+            ))
+        for filt in defn.get("filter") or []:
+            if filt not in custom_filters and filt not in BUILTIN_TOKEN_FILTERS:
+                findings.append(_error(
+                    "analysis.dangling_filter",
+                    f"Analyzer '{name}' references token filter '{filt}', "
+                    f"which is neither built-in nor defined in settings.analysis.filter.",
+                    f"settings.analysis.analyzer.{name}.filter",
+                ))
+        for cf in defn.get("char_filter") or []:
+            if cf not in custom_char_filters and cf not in BUILTIN_CHAR_FILTERS:
+                findings.append(_error(
+                    "analysis.dangling_char_filter",
+                    f"Analyzer '{name}' references char filter '{cf}', which is "
+                    f"neither built-in nor defined in settings.analysis.char_filter.",
+                    f"settings.analysis.analyzer.{name}.char_filter",
+                ))
+
+    return findings
+
+
+def _lint_knn(bundle, fields):
+    """k-NN fields need the plugin enabled, a dimension, and a valid engine."""
+    findings = []
+    knn_fields = {p: d for p, d in fields.items() if d.get("type") == "knn_vector"}
+    if not knn_fields:
+        return findings
+
+    index_settings = _index_settings(bundle)
+    if not _as_bool(index_settings.get("knn")):
+        findings.append(_error(
+            "knn.plugin_disabled",
+            f"Index maps {len(knn_fields)} knn_vector field(s) but "
+            f"settings.index.knn is not true; the index will reject them.",
+            "settings.index.knn",
+        ))
+
+    for path, defn in knn_fields.items():
+        dim = _as_int(defn.get("dimension"))
+        if dim is None:
+            findings.append(_error(
+                "knn.missing_dimension",
+                f"knn_vector field '{path}' has no 'dimension'.",
+                f"mappings.properties.{path}.dimension",
+            ))
+        elif dim <= 0:
+            findings.append(_error(
+                "knn.invalid_dimension",
+                f"knn_vector field '{path}' has non-positive dimension {dim}.",
+                f"mappings.properties.{path}.dimension",
+            ))
+
+        method = defn.get("method") or {}
+        if not isinstance(method, dict) or not method:
+            continue
+        engine = method.get("engine", "nmslib")
+        space = method.get("space_type")
+        supported = KNN_ENGINE_SPACES.get(engine)
+        if supported is None:
+            findings.append(_error(
+                "knn.unknown_engine",
+                f"knn_vector field '{path}' uses unknown engine '{engine}'. "
+                f"Expected one of: {', '.join(sorted(KNN_ENGINE_SPACES))}.",
+                f"mappings.properties.{path}.method.engine",
+            ))
+        elif space and space not in supported:
+            findings.append(_error(
+                "knn.unsupported_space_type",
+                f"knn_vector field '{path}' uses space_type '{space}', which "
+                f"engine '{engine}' does not support "
+                f"({', '.join(sorted(supported))}).",
+                f"mappings.properties.{path}.method.space_type",
+            ))
+
+        params = method.get("parameters") or {}
+        ef = _as_int(params.get("ef_construction"))
+        m = _as_int(params.get("m"))
+        if ef is not None and m is not None and ef < m:
+            findings.append(_warning(
+                "knn.ef_below_m",
+                f"knn_vector field '{path}' has ef_construction={ef} below m={m}; "
+                f"recall will suffer. Typical: ef_construction 128-512, m 16-48.",
+                f"mappings.properties.{path}.method.parameters",
+            ))
+
+    return findings
+
+
+def _lint_ingest_pipeline(bundle, fields):
+    """Embedding processors must target real knn_vector fields of the right size."""
+    findings = []
+    pipeline = bundle.get("ingest_pipeline") or {}
+    body = pipeline.get("body") or {}
+    processors = body.get("processors") or []
+
+    for idx, processor in enumerate(processors):
+        if not isinstance(processor, dict):
+            continue
+        for kind in ("text_embedding", "sparse_encoding", "text_image_embedding"):
+            cfg = processor.get(kind)
+            if not isinstance(cfg, dict):
+                continue
+            field_map = cfg.get("field_map") or {}
+            for source, target in field_map.items():
+                if source not in fields:
+                    findings.append(_error(
+                        "ingest.unmapped_source",
+                        f"{kind} processor reads '{source}', which is not a mapped field.",
+                        f"ingest_pipeline.processors[{idx}].field_map",
+                    ))
+                target_def = fields.get(target)
+                if target_def is None:
+                    findings.append(_error(
+                        "ingest.unmapped_target",
+                        f"{kind} processor writes '{target}', which is not a mapped field.",
+                        f"ingest_pipeline.processors[{idx}].field_map",
+                    ))
+                    continue
+                expected_type = "rank_features" if kind == "sparse_encoding" else "knn_vector"
+                if target_def.get("type") != expected_type:
+                    findings.append(_error(
+                        "ingest.wrong_target_type",
+                        f"{kind} processor writes '{target}', which is type "
+                        f"'{target_def.get('type')}'; expected '{expected_type}'.",
+                        f"mappings.properties.{target}.type",
+                    ))
+                    continue
+                if expected_type != "knn_vector":
+                    continue
+                model_id = cfg.get("model_id", "")
+                expected_dim = KNOWN_MODEL_DIMENSIONS.get(model_id)
+                actual_dim = _as_int(target_def.get("dimension"))
+                if expected_dim and actual_dim and expected_dim != actual_dim:
+                    findings.append(_error(
+                        "ingest.dimension_mismatch",
+                        f"Model '{model_id}' emits {expected_dim}-dim vectors but "
+                        f"'{target}' is mapped with dimension {actual_dim}.",
+                        f"mappings.properties.{target}.dimension",
+                    ))
+
+    if processors and not str(pipeline.get("name", "")).strip():
+        findings.append(_error(
+            "ingest.missing_name",
+            "Ingest pipeline defines processors but has no 'name'.",
+            "ingest_pipeline.name",
+        ))
+
+    return findings
+
+
+def _iter_hybrid_queries(bundle):
+    """Yield ``(query_name, hybrid_clause)`` for every hybrid query in the bundle."""
+    for query in bundle.get("queries") or []:
+        if not isinstance(query, dict):
+            continue
+        clause = ((query.get("body") or {}).get("query") or {}).get("hybrid")
+        if isinstance(clause, dict):
+            yield query.get("name", "<unnamed>"), clause
+
+
+def _normalization_processors(bundle):
+    body = (bundle.get("search_pipeline") or {}).get("body") or {}
+    for processor in body.get("phase_results_processors") or []:
+        if isinstance(processor, dict) and isinstance(
+            processor.get("normalization-processor"), dict
+        ):
+            yield processor["normalization-processor"]
+
+
+def _lint_search_pipeline(bundle):
+    """Hybrid search has strict, easily-violated normalization constraints."""
+    findings = []
+    procs = list(_normalization_processors(bundle))
+    hybrids = list(_iter_hybrid_queries(bundle))
+
+    if hybrids and not procs:
+        findings.append(_error(
+            "hybrid.missing_normalization",
+            f"Query '{hybrids[0][0]}' uses a hybrid clause, but no search pipeline "
+            f"defines a normalization-processor. Hybrid queries require one.",
+            "search_pipeline.phase_results_processors",
+        ))
+    if procs and not hybrids:
+        findings.append(_warning(
+            "hybrid.unused_normalization",
+            "Search pipeline defines a normalization-processor but no bundled "
+            "query uses a hybrid clause.",
+            "search_pipeline",
+        ))
+
+    subquery_counts = {len(h.get("queries") or []) for _, h in hybrids}
+
+    for proc in procs:
+        technique = (proc.get("normalization") or {}).get("technique")
+        if technique and technique not in _HYBRID_NORMALIZATION_TECHNIQUES:
+            findings.append(_error(
+                "hybrid.unknown_normalization",
+                f"Unknown normalization technique '{technique}'. Expected one of: "
+                f"{', '.join(sorted(_HYBRID_NORMALIZATION_TECHNIQUES))}.",
+                "search_pipeline.normalization.technique",
+            ))
+
+        combination = proc.get("combination") or {}
+        ctechnique = combination.get("technique")
+        if ctechnique and ctechnique not in _HYBRID_COMBINATION_TECHNIQUES:
+            findings.append(_error(
+                "hybrid.unknown_combination",
+                f"Unknown combination technique '{ctechnique}'. Expected one of: "
+                f"{', '.join(sorted(_HYBRID_COMBINATION_TECHNIQUES))}.",
+                "search_pipeline.combination.technique",
+            ))
+
+        weights = (combination.get("parameters") or {}).get("weights")
+        if weights is None:
+            continue
+        if not isinstance(weights, list) or not all(
+            isinstance(w, (int, float)) and not isinstance(w, bool) for w in weights
+        ):
+            findings.append(_error(
+                "hybrid.invalid_weights",
+                "Combination weights must be a list of numbers.",
+                "search_pipeline.combination.parameters.weights",
+            ))
+            continue
+
+        total = sum(weights)
+        if abs(total - 1.0) > _WEIGHT_TOLERANCE:
+            findings.append(_error(
+                "hybrid.weights_sum",
+                f"Combination weights {weights} sum to {total:g}; OpenSearch "
+                f"requires them to sum to 1.0.",
+                "search_pipeline.combination.parameters.weights",
+            ))
+
+        for count in subquery_counts:
+            if count != len(weights):
+                findings.append(_error(
+                    "hybrid.weight_count",
+                    f"Combination declares {len(weights)} weight(s) but a hybrid "
+                    f"query has {count} sub-quer(ies); the counts must match.",
+                    "search_pipeline.combination.parameters.weights",
+                ))
+
+    return findings
+
+
+# Clauses shaped {clause: {<field>: {...}}} — the field is the key.
+_FIELD_KEYED_CLAUSES = frozenset({
+    "term", "terms", "match", "match_phrase", "match_phrase_prefix", "range",
+    "prefix", "wildcard", "regexp", "fuzzy", "knn", "neural", "neural_sparse",
+})
+
+# Clauses shaped {clause: {"field": "<field>", ...}} — the field is a value.
+_FIELD_VALUED_CLAUSES = frozenset({"exists", "rank_feature", "distance_feature"})
+
+# Clauses shaped {clause: {"fields": ["a^3", "b"], ...}}.
+_FIELD_LIST_CLAUSES = frozenset({"multi_match", "query_string", "simple_query_string"})
+
+_NON_FIELD_KEYS = frozenset({"boost", "_name"})
+
+
+def _collect_query_fields(node, found):
+    """Walk a query body collecting field names referenced by leaf clauses."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in _FIELD_VALUED_CLAUSES and isinstance(value, dict):
+                if isinstance(value.get("field"), str):
+                    found.add(value["field"])
+            elif key in _FIELD_KEYED_CLAUSES and isinstance(value, dict):
+                for field in value:
+                    if field not in _NON_FIELD_KEYS:
+                        found.add(field)
+            elif key in _FIELD_LIST_CLAUSES and isinstance(value, dict):
+                for field in value.get("fields") or []:
+                    found.add(str(field).split("^", 1)[0])
+            if isinstance(value, (dict, list)):
+                _collect_query_fields(value, found)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_query_fields(item, found)
+    return found
+
+
+def _lint_queries(bundle, fields):
+    """Named queries must only reference mapped fields."""
+    findings = []
+    known = set(fields)
+    for query in bundle.get("queries") or []:
+        if not isinstance(query, dict):
+            continue
+        name = query.get("name", "<unnamed>")
+        body = query.get("body")
+        if not isinstance(body, dict) or "query" not in body:
+            findings.append(_error(
+                "query.malformed",
+                f"Query '{name}' must be an object containing a 'query' clause.",
+                f"queries.{name}",
+            ))
+            continue
+        for field in sorted(_collect_query_fields(body, set())):
+            base = field.split(".")[0]
+            if field in known or base in known or field.startswith("_"):
+                continue
+            findings.append(_error(
+                "query.unmapped_field",
+                f"Query '{name}' references field '{field}', which is not mapped.",
+                f"queries.{name}",
+            ))
+    return findings
+
+
+def _lint_index_settings(bundle):
+    findings = []
+    settings = _index_settings(bundle)
+
+    shards = _as_int(settings.get("number_of_shards"))
+    if shards is not None and shards < 1:
+        findings.append(_error(
+            "settings.invalid_shards",
+            f"number_of_shards must be >= 1, got {shards}.",
+            "settings.index.number_of_shards",
+        ))
+
+    replicas = _as_int(settings.get("number_of_replicas"))
+    if replicas is not None and replicas > 0:
+        findings.append(_warning(
+            "settings.replicas_on_single_node",
+            f"number_of_replicas is {replicas}; on a single-node dev cluster the "
+            f"index will sit at yellow health. Use 0 locally.",
+            "settings.index.number_of_replicas",
+        ))
+
+    return findings
+
+
+def _lint_ism(bundle):
+    findings = []
+    policy = bundle.get("ism_policy") or {}
+    body = policy.get("body") or {}
+    if not body:
+        return findings
+
+    if not str(policy.get("name", "")).strip():
+        findings.append(_error(
+            "ism.missing_name", "ISM policy has a body but no 'name'.", "ism_policy.name"
+        ))
+
+    spec = body.get("policy") or {}
+    states = spec.get("states") or []
+    names = {s.get("name") for s in states if isinstance(s, dict)}
+
+    default_state = spec.get("default_state")
+    if default_state and default_state not in names:
+        findings.append(_error(
+            "ism.unknown_default_state",
+            f"ISM default_state '{default_state}' is not among the defined states "
+            f"({', '.join(sorted(n for n in names if n))}).",
+            "ism_policy.policy.default_state",
+        ))
+
+    for state in states:
+        if not isinstance(state, dict):
+            continue
+        for transition in state.get("transitions") or []:
+            target = transition.get("state_name") if isinstance(transition, dict) else None
+            if target and target not in names:
+                findings.append(_error(
+                    "ism.unknown_transition",
+                    f"ISM state '{state.get('name')}' transitions to unknown state "
+                    f"'{target}'.",
+                    "ism_policy.policy.states",
+                ))
+    return findings
+
+
+def has_errors(findings):
+    return any(f.get("level") == "error" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Render — bundle to the dense single-block blueprint
+# ---------------------------------------------------------------------------
+
+def _render_field(path, defn):
+    ftype = defn.get("type", "object")
+    bits = []
+    if ftype == "knn_vector":
+        dim = defn.get("dimension")
+        bits.append(f"dim {dim}" if dim is not None else "dim ?")
+        method = defn.get("method") or {}
+        if method:
+            triple = "/".join(
+                str(method.get(k)) for k in ("name", "engine", "space_type") if method.get(k)
+            )
+            if triple:
+                bits.append(triple)
+            params = method.get("parameters") or {}
+            bits.extend(f"{k} {v}" for k, v in sorted(params.items()))
+    else:
+        if defn.get("analyzer"):
+            bits.append(f"analyzer {defn['analyzer']}")
+        if defn.get("search_analyzer"):
+            bits.append(f"search_analyzer {defn['search_analyzer']}")
+        if defn.get("normalizer"):
+            bits.append(f"normalizer {defn['normalizer']}")
+        if defn.get("ignore_above") is not None:
+            bits.append(f"ignore_above {defn['ignore_above']}")
+        if defn.get("format"):
+            bits.append(f"format {defn['format']}")
+    inner = ", ".join([ftype] + bits)
+    return f"{path} ({inner})"
+
+
+def _render_analysis(analysis):
+    chunks = []
+    for name, defn in sorted((analysis.get("analyzer") or {}).items()):
+        parts = []
+        if defn.get("char_filter"):
+            parts.append("/".join(defn["char_filter"]) + " char_filters")
+        if defn.get("tokenizer"):
+            parts.append(f"{defn['tokenizer']} tokenizer")
+        if defn.get("filter"):
+            parts.append("/".join(defn["filter"]))
+        chunks.append(f"analyzer {name} ({', '.join(parts)})")
+    for name, defn in sorted((analysis.get("normalizer") or {}).items()):
+        filters = "/".join(defn.get("filter") or []) or "none"
+        chunks.append(f"normalizer {name} ({filters})")
+    return chunks
+
+
+def render_blueprint(bundle):
+    """Render a bundle as one dense, single-line OpenSearch blueprint."""
+    sections = []
+
+    version = bundle.get("opensearch_version") or "opensearch"
+    name = (bundle.get("name") or bundle.get("index") or "UNNAMED").upper()
+    pitch = bundle.get("pitch") or ""
+    head = f"{version}, {name}"
+    if pitch:
+        head += f" — {pitch}"
+    sections.append(head)
+
+    settings = _index_settings(bundle)
+    knobs = []
+    for key, label in (
+        ("number_of_shards", "shards"),
+        ("number_of_replicas", "replicas"),
+        ("refresh_interval", "refresh_interval"),
+        ("codec", "codec"),
+        ("knn", "knn"),
+    ):
+        if key not in settings:
+            continue
+        value = settings[key]
+        if label in ("shards", "replicas"):
+            count = _as_int(value)
+            noun = label[:-1] if count == 1 else label
+            knobs.append(f"{value} {noun}")
+        elif isinstance(value, bool):
+            knobs.append(f"{label} {'true' if value else 'false'}")
+        else:
+            knobs.append(f"{label} {value}")
+    index_section = f"INDEX {bundle.get('index', '?')}"
+    if knobs:
+        index_section += f" ({', '.join(knobs)})"
+    sections.append(index_section)
+
+    analysis_chunks = _render_analysis(_analysis(bundle))
+    if analysis_chunks:
+        sections.append("ANALYSIS " + ", ".join(analysis_chunks))
+
+    properties = (bundle.get("mappings") or {}).get("properties") or {}
+    rendered = [
+        _render_field(path, defn)
+        for path, defn in iter_fields(properties)
+        if defn.get("type")
+    ]
+    if rendered:
+        sections.append("MAPPINGS " + ", ".join(rendered))
+
+    ingest = bundle.get("ingest_pipeline") or {}
+    if ingest.get("body"):
+        moves = []
+        for processor in (ingest["body"].get("processors") or []):
+            for kind, cfg in (processor or {}).items():
+                if not isinstance(cfg, dict):
+                    continue
+                for source, target in (cfg.get("field_map") or {}).items():
+                    moves.append(f"{kind}: {source}→{target}")
+        label = f"INGEST PIPELINE {ingest.get('name', '?')}"
+        sections.append(f"{label} ({', '.join(moves)})" if moves else label)
+
+    search_pipeline = bundle.get("search_pipeline") or {}
+    if search_pipeline.get("body"):
+        bits = []
+        for proc in _normalization_processors(bundle):
+            technique = (proc.get("normalization") or {}).get("technique")
+            if technique:
+                bits.append(f"normalization {technique}")
+            combination = proc.get("combination") or {}
+            if combination.get("technique"):
+                bits.append(f"combination {combination['technique']}")
+            weights = (combination.get("parameters") or {}).get("weights")
+            if weights:
+                bits.append("weights " + "/".join(str(w) for w in weights))
+        label = f"SEARCH PIPELINE {search_pipeline.get('name', '?')}"
+        sections.append(f"{label} ({', '.join(bits)})" if bits else label)
+
+    ism = bundle.get("ism_policy") or {}
+    if ism.get("body"):
+        states = ((ism["body"].get("policy") or {}).get("states")) or []
+        chain = " → ".join(s.get("name", "?") for s in states if isinstance(s, dict))
+        label = f"ISM {ism.get('name', '?')}"
+        sections.append(f"{label} ({chain})" if chain else label)
+
+    queries = [q.get("name", "?") for q in (bundle.get("queries") or []) if isinstance(q, dict)]
+    if queries:
+        sections.append("QUERIES " + ", ".join(queries))
+
+    sections.append("validated against _analyze / _validate/query / _search")
+    return " — ".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Cluster interaction
+# ---------------------------------------------------------------------------
+
+def probe_analyzers(client, bundle):
+    """Run each declared probe through the ``_analyze`` API.
+
+    Probes prove an analyzer tokenizes the way the design claims, before any
+    data is indexed. Returns a list of ``{analyzer, text, tokens, ok}`` dicts.
+    """
+    results = []
+    analysis = _analysis(bundle)
+    index = bundle.get("index")
+    for probe in bundle.get("probes") or []:
+        analyzer = probe.get("analyzer")
+        text = probe.get("text", "")
+        body = {"text": text}
+        if analyzer in (analysis.get("analyzer") or {}):
+            # Analyzer is index-scoped: resolve it through the index itself.
+            body["analyzer"] = analyzer
+            target = index
+        else:
+            body["analyzer"] = analyzer
+            target = None
+        try:
+            response = client.indices.analyze(body=body, index=target)
+            tokens = [t.get("token") for t in response.get("tokens", [])]
+            entry = {"analyzer": analyzer, "text": text, "tokens": tokens, "ok": True}
+            expected = probe.get("expect_tokens")
+            if expected is not None:
+                entry["expected"] = expected
+                entry["ok"] = tokens == expected
+        except Exception as exc:  # noqa: BLE001 - surfaced to the agent verbatim
+            entry = {"analyzer": analyzer, "text": text, "error": str(exc), "ok": False}
+        results.append(entry)
+    return results
+
+
+def validate_queries(client, index, bundle):
+    """Validate every bundled query against the index via ``_validate/query``."""
+    results = []
+    for query in bundle.get("queries") or []:
+        if not isinstance(query, dict):
+            continue
+        name = query.get("name", "<unnamed>")
+        try:
+            response = client.indices.validate_query(
+                index=index, body=query.get("body") or {}, explain=True
+            )
+            results.append({
+                "name": name,
+                "valid": bool(response.get("valid")),
+                "explanations": response.get("explanations", []),
+            })
+        except Exception as exc:  # noqa: BLE001
+            results.append({"name": name, "valid": False, "error": str(exc)})
+    return results
+
+
+def apply_bundle(client, bundle, replace=False):
+    """Create ingest pipeline, search pipeline, index, and ISM policy."""
+    applied = {}
+    index = bundle.get("index")
+
+    ingest = bundle.get("ingest_pipeline") or {}
+    if ingest.get("name") and ingest.get("body"):
+        client.ingest.put_pipeline(id=ingest["name"], body=ingest["body"])
+        applied["ingest_pipeline"] = ingest["name"]
+
+    search_pipeline = bundle.get("search_pipeline") or {}
+    if search_pipeline.get("name") and search_pipeline.get("body"):
+        client.transport.perform_request(
+            "PUT",
+            f"/_search/pipeline/{search_pipeline['name']}",
+            body=search_pipeline["body"],
+        )
+        applied["search_pipeline"] = search_pipeline["name"]
+
+    if replace and client.indices.exists(index=index):
+        client.indices.delete(index=index)
+        applied["deleted_existing"] = True
+
+    body = {}
+    if bundle.get("settings"):
+        body["settings"] = bundle["settings"]
+    if bundle.get("mappings"):
+        body["mappings"] = bundle["mappings"]
+    client.indices.create(index=index, body=body)
+    applied["index"] = index
+
+    ism = bundle.get("ism_policy") or {}
+    if ism.get("name") and ism.get("body"):
+        client.transport.perform_request(
+            "PUT", f"/_plugins/_ism/policies/{ism['name']}", body=ism["body"]
+        )
+        applied["ism_policy"] = ism["name"]
+
+    return applied
+
+
+def extract_bundle(client, index):
+    """Read a live index back into a blueprint bundle.
+
+    Useful for documenting, reviewing, or migrating an index that was built by
+    hand — the inverse of ``apply_bundle``.
+    """
+    settings_response = client.indices.get_settings(index=index)
+    mappings_response = client.indices.get_mapping(index=index)
+
+    resolved = next(iter(settings_response), index)
+    raw_settings = (settings_response.get(resolved) or {}).get("settings") or {}
+    index_settings = dict(raw_settings.get("index") or {})
+
+    # Drop cluster-assigned metadata that is not part of a portable design.
+    for key in ("uuid", "version", "provided_name", "creation_date", "routing"):
+        index_settings.pop(key, None)
+
+    mappings = (mappings_response.get(resolved) or {}).get("mappings") or {}
+
+    bundle = {
+        "name": index.upper(),
+        "index": index,
+        "settings": {"index": index_settings},
+        "mappings": mappings,
+        "queries": [],
+    }
+
+    default_pipeline = index_settings.get("default_pipeline")
+    if default_pipeline:
+        try:
+            pipelines = client.ingest.get_pipeline(id=default_pipeline)
+            bundle["ingest_pipeline"] = {
+                "name": default_pipeline,
+                "body": pipelines.get(default_pipeline, {}),
+            }
+        except Exception:  # noqa: BLE001 - pipeline may have been deleted
+            pass
+
+    search_pipeline = index_settings.get("search", {})
+    if isinstance(search_pipeline, dict):
+        default_search = search_pipeline.get("default_pipeline")
+        if default_search:
+            try:
+                response = client.transport.perform_request(
+                    "GET", f"/_search/pipeline/{default_search}"
+                )
+                bundle["search_pipeline"] = {
+                    "name": default_search,
+                    "body": response.get(default_search, {}),
+                }
+            except Exception:  # noqa: BLE001
+                pass
+
+    return bundle
+
+
+def format_findings(findings):
+    """Render findings as a human-readable report."""
+    if not findings:
+        return "No findings. Blueprint is internally consistent."
+    lines = []
+    for f in findings:
+        marker = "ERROR  " if f["level"] == "error" else "WARN   "
+        location = f" [{f['path']}]" if f.get("path") else ""
+        lines.append(f"{marker} {f['code']}{location}: {f['message']}")
+    errors = sum(1 for f in findings if f["level"] == "error")
+    warnings = len(findings) - errors
+    lines.append(f"\n{errors} error(s), {warnings} warning(s).")
+    return "\n".join(lines)
+
+
+def load_bundle(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)

--- a/skills/opensearch-skills/scripts/lib/blueprint.py
+++ b/skills/opensearch-skills/scripts/lib/blueprint.py
@@ -222,19 +222,24 @@ def _lint_analysis_refs(bundle, fields):
                     f"mappings.properties.{path}.{key}",
                 ))
         ref = defn.get("normalizer")
-        if ref and ref not in custom_normalizers:
-            findings.append(_error(
-                "analysis.dangling_normalizer",
-                f"Field '{path}' references normalizer '{ref}', "
-                f"which is not defined in settings.analysis.normalizer.",
-                f"mappings.properties.{path}.normalizer",
-            ))
-        if ref and defn.get("type") != "keyword":
+        if not ref:
+            continue
+        # Report one problem per field: a normalizer on a non-keyword field is
+        # wrong regardless of whether the normalizer resolves, so that check
+        # takes precedence over the dangling-reference check.
+        if defn.get("type") != "keyword":
             findings.append(_error(
                 "analysis.normalizer_on_non_keyword",
                 f"Field '{path}' is type '{defn.get('type')}'; "
                 f"normalizers apply only to keyword fields.",
                 f"mappings.properties.{path}",
+            ))
+        elif ref not in custom_normalizers:
+            findings.append(_error(
+                "analysis.dangling_normalizer",
+                f"Field '{path}' references normalizer '{ref}', "
+                f"which is not defined in settings.analysis.normalizer.",
+                f"mappings.properties.{path}.normalizer",
             ))
 
     # Custom analyzer internals must also resolve.
@@ -336,6 +341,35 @@ def _lint_knn(bundle, fields):
     return findings
 
 
+# Expected mapping type for each embedding processor's target field.
+_EMBEDDING_TARGET_TYPES = {
+    "text_embedding": "knn_vector",
+    "text_image_embedding": "knn_vector",
+    "sparse_encoding": "rank_features",
+}
+
+
+def _embedding_pairs(kind, cfg):
+    """Yield ``(source_field, target_field)`` pairs for an embedding processor.
+
+    ``text_embedding`` and ``sparse_encoding`` use ``field_map`` as
+    ``{source: target}``. ``text_image_embedding`` inverts this: ``field_map`` is
+    ``{modality: source}`` (e.g. ``{"text": "name", "image": "image_binary"}``)
+    and the single vector target lives in ``embedding``.
+    """
+    field_map = cfg.get("field_map") or {}
+    if not isinstance(field_map, dict):
+        return
+    if kind == "text_image_embedding":
+        target = cfg.get("embedding")
+        for source in field_map.values():
+            if isinstance(source, str):
+                yield source, target
+        return
+    for source, target in field_map.items():
+        yield source, target
+
+
 def _lint_ingest_pipeline(bundle, fields):
     """Embedding processors must target real knn_vector fields of the right size."""
     findings = []
@@ -346,12 +380,19 @@ def _lint_ingest_pipeline(bundle, fields):
     for idx, processor in enumerate(processors):
         if not isinstance(processor, dict):
             continue
-        for kind in ("text_embedding", "sparse_encoding", "text_image_embedding"):
+        for kind, expected_type in _EMBEDDING_TARGET_TYPES.items():
             cfg = processor.get(kind)
             if not isinstance(cfg, dict):
                 continue
-            field_map = cfg.get("field_map") or {}
-            for source, target in field_map.items():
+            if kind == "text_image_embedding" and not cfg.get("embedding"):
+                findings.append(_error(
+                    "ingest.missing_embedding_target",
+                    "text_image_embedding processor has no 'embedding' field naming "
+                    "the target knn_vector.",
+                    f"ingest_pipeline.processors[{idx}].embedding",
+                ))
+                continue
+            for source, target in _embedding_pairs(kind, cfg):
                 if source not in fields:
                     findings.append(_error(
                         "ingest.unmapped_source",
@@ -366,7 +407,6 @@ def _lint_ingest_pipeline(bundle, fields):
                         f"ingest_pipeline.processors[{idx}].field_map",
                     ))
                     continue
-                expected_type = "rank_features" if kind == "sparse_encoding" else "knn_vector"
                 if target_def.get("type") != expected_type:
                     findings.append(_error(
                         "ingest.wrong_target_type",
@@ -547,7 +587,10 @@ def _lint_queries(bundle, fields):
                 f"queries.{name}",
             ))
             continue
-        for field in sorted(_collect_query_fields(body, set())):
+        # Scope collection to the query clause. Walking the whole body would
+        # misread aggregations — a `terms` agg is {"terms": {"field": "genres",
+        # "size": 10}}, whose keys are parameters, not field names.
+        for field in sorted(_collect_query_fields(body.get("query"), set())):
             base = field.split(".")[0]
             if field in known or base in known or field.startswith("_"):
                 continue
@@ -871,6 +914,21 @@ def apply_bundle(client, bundle, replace=False):
     return applied
 
 
+def _resolve_response_key(response, index, preferred=None):
+    """Pick the key an index-keyed API response is stored under.
+
+    Prefers an exact match on the requested name, then the key already resolved
+    from a sibling response, then the first key present.
+    """
+    if not isinstance(response, dict) or not response:
+        return index
+    if index in response:
+        return index
+    if preferred and preferred in response:
+        return preferred
+    return next(iter(response), index)
+
+
 def extract_bundle(client, index):
     """Read a live index back into a blueprint bundle.
 
@@ -880,15 +938,20 @@ def extract_bundle(client, index):
     settings_response = client.indices.get_settings(index=index)
     mappings_response = client.indices.get_mapping(index=index)
 
-    resolved = next(iter(settings_response), index)
-    raw_settings = (settings_response.get(resolved) or {}).get("settings") or {}
+    # Resolve each response independently. When `index` is an alias or pattern,
+    # the responses are keyed by concrete index name, and there is no guarantee
+    # both dicts enumerate in the same order.
+    settings_key = _resolve_response_key(settings_response, index)
+    mappings_key = _resolve_response_key(mappings_response, index, preferred=settings_key)
+
+    raw_settings = (settings_response.get(settings_key) or {}).get("settings") or {}
     index_settings = dict(raw_settings.get("index") or {})
 
     # Drop cluster-assigned metadata that is not part of a portable design.
     for key in ("uuid", "version", "provided_name", "creation_date", "routing"):
         index_settings.pop(key, None)
 
-    mappings = (mappings_response.get(resolved) or {}).get("mappings") or {}
+    mappings = (mappings_response.get(mappings_key) or {}).get("mappings") or {}
 
     bundle = {
         "name": index.upper(),

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -426,12 +426,34 @@ def cmd_blueprint_render(args):
     print(render_blueprint(load_bundle(args.bundle)))
 
 
+def _confirm_destructive_plan(plan, assume_yes):
+    """Gate a plan that deletes an index behind an explicit human confirmation.
+
+    ``--yes`` satisfies it non-interactively; otherwise an interactive session
+    is prompted. A non-TTY run without ``--yes`` is refused rather than assumed.
+    """
+    if not plan.get("will_delete"):
+        return True
+    if assume_yes:
+        return True
+
+    count = plan.get("doc_count")
+    shown = "an unknown number of" if count is None else count
+    print(f"\nThis will DELETE index '{plan['index']}' and its {shown} document(s).")
+    print("Deleted documents cannot be recovered.")
+    if not sys.stdin.isatty():
+        print("Refusing to delete without confirmation. Re-run with --yes.")
+        return False
+    return input("Type the index name to confirm: ").strip() == plan["index"]
+
+
 def cmd_blueprint_apply(args):
-    """Lint, probe analyzers, create the index, then validate every query."""
+    """Lint, preflight, create the index, then probe analyzers and queries."""
     from lib.client import create_client
     from lib.blueprint import (
         load_bundle, lint_bundle, has_errors, format_findings,
-        probe_analyzers, apply_bundle, validate_queries, render_blueprint,
+        probe_analyzers, apply_bundle, preflight_apply, validate_queries,
+        render_blueprint, BlueprintApplyError,
     )
 
     bundle = load_bundle(args.bundle)
@@ -444,12 +466,32 @@ def cmd_blueprint_apply(args):
     client = create_client()
     result = {"blueprint": render_blueprint(bundle)}
 
+    # Read-only: shows exactly what would change, including any delete, before
+    # anything is touched.
+    plan = preflight_apply(client, bundle, replace=args.replace)
+    result["plan"] = plan
+
     if args.dry_run:
         result["dry_run"] = True
         print(json.dumps(result, indent=2))
         return
 
-    result["applied"] = apply_bundle(client, bundle, replace=args.replace)
+    if not _confirm_destructive_plan(plan, args.yes):
+        sys.exit(1)
+
+    try:
+        result["applied"] = apply_bundle(
+            client, bundle,
+            replace=args.replace,
+            confirm=True,
+            allow_nonempty=args.allow_nonempty,
+            rollback=not args.no_rollback,
+        )
+    except BlueprintApplyError as exc:
+        result["error"] = {"code": exc.code, "message": str(exc), "details": exc.details}
+        print(json.dumps(result, indent=2))
+        sys.exit(1)
+
     result["analyzer_probes"] = probe_analyzers(client, bundle)
     result["query_validation"] = validate_queries(client, bundle.get("index"), bundle)
     print(json.dumps(result, indent=2))
@@ -709,8 +751,11 @@ def main():
     # blueprint-apply — lint, probe analyzers, create, validate queries
     p = sub.add_parser("blueprint-apply", help="Apply a blueprint bundle to a cluster and verify it")
     p.add_argument("--bundle", required=True, help="Path to the blueprint bundle JSON")
-    p.add_argument("--replace", action="store_true", help="Delete the index first if it exists")
-    p.add_argument("--dry-run", action="store_true", help="Lint and render only; touch nothing")
+    p.add_argument("--replace", action="store_true", help="Delete the index first if it exists (requires --yes)")
+    p.add_argument("--yes", action="store_true", help="Confirm a destructive --replace non-interactively")
+    p.add_argument("--allow-nonempty", action="store_true", help="Permit --replace to delete an index that holds documents")
+    p.add_argument("--no-rollback", action="store_true", help="Leave partial state in place if the apply fails")
+    p.add_argument("--dry-run", action="store_true", help="Lint, render, and report the change plan; mutate nothing")
     p.add_argument("--force", action="store_true", help="Apply even if lint reports errors")
 
     # blueprint-extract — live index back to a bundle

--- a/skills/opensearch-skills/scripts/opensearch_ops.py
+++ b/skills/opensearch-skills/scripts/opensearch_ops.py
@@ -33,6 +33,10 @@ Commands:
     create-flow-agentic-pipeline Create and attach a flow agent search pipeline
     create-conversational-agent-pipeline Create and attach a conversational agent pipeline with RAG
     search-docs            Search documentation via DuckDuckGo (default: opensearch.org)
+    blueprint-lint         Statically check a blueprint bundle (no cluster required)
+    blueprint-render       Render a blueprint bundle as a dense single-block spec
+    blueprint-apply        Apply a blueprint to a cluster, probe analyzers, validate queries
+    blueprint-extract      Extract a blueprint from an existing index
 """
 
 import argparse
@@ -403,6 +407,75 @@ def cmd_save_quality(args):
     print(json.dumps(result, indent=2))
 
 
+def cmd_blueprint_lint(args):
+    """Statically check a blueprint bundle. No cluster required."""
+    from lib.blueprint import load_bundle, lint_bundle, format_findings, has_errors
+    bundle = load_bundle(args.bundle)
+    findings = lint_bundle(bundle)
+    if args.json:
+        print(json.dumps({"findings": findings, "ok": not has_errors(findings)}, indent=2))
+    else:
+        print(format_findings(findings))
+    if has_errors(findings):
+        sys.exit(1)
+
+
+def cmd_blueprint_render(args):
+    """Render a blueprint bundle as the dense single-block spec."""
+    from lib.blueprint import load_bundle, render_blueprint
+    print(render_blueprint(load_bundle(args.bundle)))
+
+
+def cmd_blueprint_apply(args):
+    """Lint, probe analyzers, create the index, then validate every query."""
+    from lib.client import create_client
+    from lib.blueprint import (
+        load_bundle, lint_bundle, has_errors, format_findings,
+        probe_analyzers, apply_bundle, validate_queries, render_blueprint,
+    )
+
+    bundle = load_bundle(args.bundle)
+    findings = lint_bundle(bundle)
+    print(format_findings(findings))
+    if has_errors(findings) and not args.force:
+        print("\nRefusing to apply a blueprint with errors. Fix them or pass --force.")
+        sys.exit(1)
+
+    client = create_client()
+    result = {"blueprint": render_blueprint(bundle)}
+
+    if args.dry_run:
+        result["dry_run"] = True
+        print(json.dumps(result, indent=2))
+        return
+
+    result["applied"] = apply_bundle(client, bundle, replace=args.replace)
+    result["analyzer_probes"] = probe_analyzers(client, bundle)
+    result["query_validation"] = validate_queries(client, bundle.get("index"), bundle)
+    print(json.dumps(result, indent=2))
+
+    failed = [p for p in result["analyzer_probes"] if not p.get("ok")]
+    invalid = [q for q in result["query_validation"] if not q.get("valid")]
+    if failed or invalid:
+        sys.exit(1)
+
+
+def cmd_blueprint_extract(args):
+    """Read an existing index back into a blueprint bundle."""
+    from lib.client import create_client
+    from lib.blueprint import extract_bundle, render_blueprint, lint_bundle
+
+    bundle = extract_bundle(create_client(), args.index)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            json.dump(bundle, handle, indent=2)
+    print(render_blueprint(bundle))
+    if args.lint:
+        from lib.blueprint import format_findings
+        print()
+        print(format_findings(lint_bundle(bundle)))
+
+
 def cmd_create_flow_agent(args):
     from lib.operations import create_flow_agent
     print(create_flow_agent(
@@ -624,9 +697,35 @@ def main():
     p.add_argument("--verdict", default="", help="Verdict as a JSON string")
     p.add_argument("--verdict-file", default="", help="Path to a JSON file with the verdict (alternative to --verdict)")
 
+    # blueprint-lint — static checks, no cluster
+    p = sub.add_parser("blueprint-lint", help="Statically check a blueprint bundle (no cluster)")
+    p.add_argument("--bundle", required=True, help="Path to the blueprint bundle JSON")
+    p.add_argument("--json", action="store_true", help="Emit findings as JSON")
+
+    # blueprint-render — bundle to dense spec
+    p = sub.add_parser("blueprint-render", help="Render a bundle as the dense blueprint spec")
+    p.add_argument("--bundle", required=True, help="Path to the blueprint bundle JSON")
+
+    # blueprint-apply — lint, probe analyzers, create, validate queries
+    p = sub.add_parser("blueprint-apply", help="Apply a blueprint bundle to a cluster and verify it")
+    p.add_argument("--bundle", required=True, help="Path to the blueprint bundle JSON")
+    p.add_argument("--replace", action="store_true", help="Delete the index first if it exists")
+    p.add_argument("--dry-run", action="store_true", help="Lint and render only; touch nothing")
+    p.add_argument("--force", action="store_true", help="Apply even if lint reports errors")
+
+    # blueprint-extract — live index back to a bundle
+    p = sub.add_parser("blueprint-extract", help="Extract a blueprint from an existing index")
+    p.add_argument("--index", required=True, help="Index to read")
+    p.add_argument("--out", default="", help="Write the extracted bundle JSON to this path")
+    p.add_argument("--lint", action="store_true", help="Also lint the extracted bundle")
+
     args = parser.parse_args()
 
     dispatch = {
+        "blueprint-lint": cmd_blueprint_lint,
+        "blueprint-render": cmd_blueprint_render,
+        "blueprint-apply": cmd_blueprint_apply,
+        "blueprint-extract": cmd_blueprint_extract,
         "status": cmd_status,
         "preflight-check": cmd_preflight_check,
         "create-index": cmd_create_index,

--- a/skills/opensearch-skills/search/SKILL.md
+++ b/skills/opensearch-skills/search/SKILL.md
@@ -21,6 +21,7 @@ Category skill for building search applications with OpenSearch.
 | Skill | Description |
 |---|---|
 | [opensearch-launchpad](opensearch-launchpad/SKILL.md) | End-to-end search application builder — from sample data to a running search UI with BM25, semantic, hybrid, or agentic search |
+| [opensearch-blueprint](opensearch-blueprint/SKILL.md) | Index design compiler — turns requirements into a linted, cluster-verified blueprint (analysis, mappings, k-NN, pipelines, ISM); also extracts a blueprint from an existing index |
 
 ## When to Use
 
@@ -30,3 +31,14 @@ Read [opensearch-launchpad/SKILL.md](opensearch-launchpad/SKILL.md) when the use
 - Deploy ML models for semantic or hybrid search
 - Evaluate and tune search quality
 - Process documents (PDF, DOCX) for search ingestion
+
+Read [opensearch-blueprint/SKILL.md](opensearch-blueprint/SKILL.md) when the user wants to:
+- Design or review an index mapping, analysis chain, or k-NN configuration
+- Validate a design before loading data (`_analyze`, `_validate/query`)
+- Debug an analyzer that tokenizes unexpectedly, or hybrid weights that misbehave
+- Document, audit, or migrate an index that already exists
+
+**Choosing between them:** launchpad is the guided build — sample data in,
+running UI out. Blueprint is the design artifact — a reviewable, portable,
+re-appliable spec. Users who already know what they want, or who need to review
+someone else's index, want blueprint. Hand off to launchpad to load data.

--- a/skills/opensearch-skills/search/opensearch-blueprint/SKILL.md
+++ b/skills/opensearch-skills/search/opensearch-blueprint/SKILL.md
@@ -54,6 +54,11 @@ last.
 4. **Probe analyzers before loading data** — every custom analyzer needs at
    least one `probes` entry. An analyzer that looks right and tokenizes wrong is
    the single most common cause of "search returns nothing".
+5. **Never pass `--replace --yes` on the user's behalf** — `--replace` deletes
+   an existing index and its documents, and no rollback can bring them back.
+   Run `--dry-run` first, show the user the reported `plan` (index name and doc
+   count), and let *them* confirm. `--allow-nonempty` means "delete data that
+   already exists"; only the user can make that call.
 
 ## Key Rules
 
@@ -73,9 +78,10 @@ uv run python scripts/opensearch_ops.py preflight-check
 uv run python scripts/opensearch_ops.py blueprint-lint --bundle blueprint.json
 uv run python scripts/opensearch_ops.py blueprint-render --bundle blueprint.json
 
-# Apply and verify against a cluster
+# Apply and verify against a cluster. --dry-run reports the change plan,
+# including anything that would be deleted, without mutating the cluster.
 uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --dry-run
-uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json
 
 # Reverse direction — read an existing index back into a blueprint
 uv run python scripts/opensearch_ops.py blueprint-extract --index movies_v1 --out blueprint.json --lint
@@ -135,10 +141,23 @@ rendered dense spec to the user and get approval.
 ### Phase 5 — Apply and verify
 
 ```bash
-uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace
+# 1. Read-only. Prints the change plan: what is created, what is overwritten,
+#    and whether an existing index (and how many documents) would be deleted.
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --dry-run
+
+# 2. Apply. Fresh index — no destructive flags needed.
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json
 ```
 
-This creates the ingest pipeline, search pipeline, index, and ISM policy, then:
+If the index already exists, the apply is **refused** rather than silently
+skipped. Show the user the dry-run plan and let them choose: rename the index in
+the bundle, or re-run with `--replace --yes` (and `--allow-nonempty` if it holds
+documents). Do not add those flags yourself.
+
+Applying creates the ingest pipeline, search pipeline, index, and ISM policy in
+that order. The delete, if any, runs last before index creation, and a failure
+at any point unwinds what this run created — pipelines it added are removed,
+pipelines it overwrote are restored. Then it:
 
 - Runs every `probes` entry through `_analyze` and reports the token stream
 - Runs every named query through `_validate/query?explain=true`

--- a/skills/opensearch-skills/search/opensearch-blueprint/SKILL.md
+++ b/skills/opensearch-skills/search/opensearch-blueprint/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: opensearch-blueprint
+description: >
+  Compile a plain-English search requirement into a complete, dense, executable
+  OpenSearch index blueprint — analysis chain, mappings, k-NN parameters,
+  ingest and search pipelines, ISM lifecycle, and named queries — then verify it
+  against a live cluster with the _analyze, _validate/query, and _search APIs.
+  Use this skill when the user wants an index design, a mapping, an analyzer
+  chain, a hybrid search pipeline, a k-NN/HNSW configuration, an ISM policy, or
+  a reviewable spec of an OpenSearch setup. Also use to document, audit, or
+  migrate an existing index — "what is this index actually doing", "extract the
+  mapping", "port this index to another cluster". Activate on index design,
+  mapping review, analyzer debugging, hybrid weight tuning, shard sizing, or
+  blueprint. Prefer opensearch-launchpad when the user wants a guided
+  end-to-end build with sample data and a running search UI.
+compatibility: Requires uv. Applying or extracting a blueprint requires a reachable OpenSearch cluster (Docker for local).
+metadata:
+  author: lalomorales22
+  version: "1.0"
+---
+
+# OpenSearch Blueprint
+
+You are an OpenSearch index architect. You compile requirements into a
+**blueprint bundle** — one JSON document that fully specifies an index — and
+then prove it works against a real cluster before any data is loaded.
+
+A blueprint has two faces:
+
+- **The bundle** (`blueprint.json`) — executable. Fed to the cluster.
+- **The dense spec** — one continuous line, rendered from the bundle. Readable
+  at a glance, reviewable in a PR comment, portable between agents.
+
+Both are generated from the same source, so they can never drift.
+
+## Why this exists
+
+Index design failures are expensive and late-binding. A wrong `dimension`, a
+dangling analyzer reference, or hybrid weights that don't sum to 1.0 all fail
+*after* you've loaded a million documents. This skill front-loads those checks:
+static lint first, `_analyze` probes second, `_validate/query` third, real data
+last.
+
+## Critical Rules (MUST follow)
+
+1. **Preflight-check first** — run `preflight-check` before any cluster
+   operation. No exceptions.
+2. **Lint before apply** — never run `blueprint-apply` without reading the lint
+   output first. Never pass `--force` to silence errors without telling the user
+   exactly which error you are overriding and why.
+3. **Never invent a model dimension** — if the embedding model's vector width is
+   not known, look it up before mapping the `knn_vector` field. A mismatch is
+   silent until ingest fails.
+4. **Probe analyzers before loading data** — every custom analyzer needs at
+   least one `probes` entry. An analyzer that looks right and tokenizes wrong is
+   the single most common cause of "search returns nothing".
+
+## Key Rules
+
+- Ask **one** question per message.
+- Show the rendered dense spec to the user for approval before applying.
+- Hard numbers only — never "a few shards", always `3 shards`.
+- When a step fails, present the error and wait for guidance.
+- Never write a mapping the user did not ask for. Extra fields cost storage and
+  confuse relevance tuning.
+
+## Commands
+
+```bash
+uv run python scripts/opensearch_ops.py preflight-check
+
+# Static checks — no cluster needed
+uv run python scripts/opensearch_ops.py blueprint-lint --bundle blueprint.json
+uv run python scripts/opensearch_ops.py blueprint-render --bundle blueprint.json
+
+# Apply and verify against a cluster
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --dry-run
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace
+
+# Reverse direction — read an existing index back into a blueprint
+uv run python scripts/opensearch_ops.py blueprint-extract --index movies_v1 --out blueprint.json --lint
+```
+
+See [cli-reference.md](../../cli-reference.md) for the full CLI.
+
+## Workflow — design mode (requirement → running index)
+
+### Phase 1 — Establish the corpus
+
+Ask what is being searched. You need, at minimum:
+
+- Document count (order of magnitude is fine: `1.2m`, `50k`)
+- Average document size
+- The fields, and for each: is it **matched**, **filtered**, **sorted**,
+  **aggregated**, or **returned only**? This single question determines almost
+  every mapping decision.
+
+Do not proceed without field roles. A field that is only ever filtered should be
+`keyword`, not `text` — getting this wrong doubles the index size.
+
+### Phase 2 — Choose the retrieval strategy
+
+| Strategy | Use when | Cost |
+|---|---|---|
+| `bm25` | Keyword-dominant, exact terms matter, no GPU budget | Cheapest |
+| `dense_vector` | Semantic similarity, paraphrase tolerance | Embedding model + HNSW memory |
+| `neural_sparse` | Semantic recall with keyword-like interpretability | Model, no vector memory |
+| `hybrid` | Both exact terms and semantics matter | Both, plus a search pipeline |
+
+Read [opensearch-vocabulary.md](opensearch-vocabulary.md) for the parameter
+space of each. For deeper model selection, read the launchpad guides:
+[dense_vector_models.md](../opensearch-launchpad/dense_vector_models.md) and
+[sparse_vector_models.md](../opensearch-launchpad/sparse_vector_models.md).
+
+### Phase 3 — Compile the bundle
+
+Write `blueprint.json` following the schema in
+[blueprint-format.md](blueprint-format.md). Apply the five density techniques
+described there — they are what make the rendered spec reviewable.
+
+Start from [example-bundle.json](example-bundle.json), a complete hybrid
+movie-search blueprint with analyzers, a k-NN field, both pipelines, an ISM
+policy, and probes.
+
+### Phase 4 — Lint and render
+
+```bash
+uv run python scripts/opensearch_ops.py blueprint-lint --bundle blueprint.json
+uv run python scripts/opensearch_ops.py blueprint-render --bundle blueprint.json
+```
+
+Fix every error. Explain every warning you choose to accept. Then show the
+rendered dense spec to the user and get approval.
+
+### Phase 5 — Apply and verify
+
+```bash
+uv run python scripts/opensearch_ops.py blueprint-apply --bundle blueprint.json --replace
+```
+
+This creates the ingest pipeline, search pipeline, index, and ISM policy, then:
+
+- Runs every `probes` entry through `_analyze` and reports the token stream
+- Runs every named query through `_validate/query?explain=true`
+
+Read the token streams. If `title_autocomplete` produces 40 edge n-grams for a
+three-word title, that is the design working; if it produces one token, the
+filter chain is wrong.
+
+### Phase 6 — Load and hand off
+
+The blueprint stops at a verified, empty index. To load data and get a search
+UI, hand off to
+[opensearch-launchpad](../opensearch-launchpad/SKILL.md) — pass along the index
+name and strategy so it does not re-ask. To deploy the same blueprint to AWS,
+hand off to [aws-setup](../../cloud/aws-setup/SKILL.md).
+
+## Workflow — audit mode (existing index → blueprint)
+
+Use when the user asks what an index is doing, wants to review a mapping someone
+else wrote, or needs to port an index between clusters.
+
+```bash
+uv run python scripts/opensearch_ops.py blueprint-extract --index <name> --out blueprint.json --lint
+```
+
+This reads `_settings`, `_mapping`, and the attached ingest and search pipelines,
+strips cluster-assigned metadata (`uuid`, `creation_date`, `provided_name`), and
+emits a portable bundle plus the dense spec.
+
+Then report findings to the user in this order:
+
+1. **Errors** the lint found in the live index — these are live bugs.
+2. **Storage waste** — `text` fields never matched on, missing `ignore_above`
+   on high-cardinality keywords, `_source` enabled on a pure-aggregation index.
+3. **Relevance risk** — no `search_analyzer` split where one is needed,
+   `keyword` fields with no `normalizer` producing case-sensitive filters.
+
+The extracted bundle is directly re-appliable to another cluster, which is the
+supported migration path.
+
+## What the linter catches
+
+These are checked offline, before any cluster call:
+
+| Code | Failure |
+|---|---|
+| `knn.plugin_disabled` | `knn_vector` mapped but `index.knn` is not true |
+| `knn.missing_dimension` | `knn_vector` with no `dimension` |
+| `knn.unsupported_space_type` | e.g. `hamming` on the `lucene` engine |
+| `knn.ef_below_m` | `ef_construction` below `m` — recall collapse |
+| `ingest.dimension_mismatch` | Model emits 768-dim, field mapped 384 |
+| `ingest.wrong_target_type` | `sparse_encoding` writing to a `knn_vector` |
+| `hybrid.weights_sum` | Combination weights do not sum to 1.0 |
+| `hybrid.weight_count` | 2 weights declared, 3 sub-queries present |
+| `hybrid.missing_normalization` | Hybrid query with no normalization-processor |
+| `analysis.dangling_analyzer` | Field references an undefined analyzer |
+| `analysis.dangling_filter` | Analyzer references an undefined token filter |
+| `analysis.normalizer_on_non_keyword` | Normalizer on a `text` field |
+| `query.unmapped_field` | Named query references a field that isn't mapped |
+| `ism.unknown_transition` | ISM state transitions to a state that isn't defined |
+
+## Handoff table
+
+| User now wants | Go to |
+|---|---|
+| Load data and get a search UI | [opensearch-launchpad](../opensearch-launchpad/SKILL.md) |
+| Deploy this index to AWS | [aws-setup](../../cloud/aws-setup/SKILL.md) |
+| Chunk PDFs before indexing | [document-processing](../../ingest/document-processing/SKILL.md) |
+| Measure relevance after loading | [evaluation_guide.md](../opensearch-launchpad/evaluation_guide.md) |

--- a/skills/opensearch-skills/search/opensearch-blueprint/blueprint-format.md
+++ b/skills/opensearch-skills/search/opensearch-blueprint/blueprint-format.md
@@ -1,0 +1,176 @@
+# Blueprint Format
+
+A blueprint has two representations generated from one source.
+
+1. **The bundle** — `blueprint.json`, executable, fed to the cluster.
+2. **The dense spec** — one continuous line, rendered by `blueprint-render`.
+
+You author the bundle. The dense spec is derived, never hand-written — that is
+what keeps documentation from drifting away from configuration.
+
+---
+
+## The bundle schema
+
+```json
+{
+  "name": "MOVIE-SEARCH",
+  "pitch": "hybrid movie discovery over 1.2m titles",
+  "opensearch_version": "3.x",
+  "index": "movies_v1",
+  "settings": { "index": { "number_of_shards": 3, "knn": true, "analysis": {} } },
+  "mappings": { "properties": {} },
+  "ingest_pipeline": { "name": "movies_embed", "body": { "processors": [] } },
+  "search_pipeline": { "name": "movies_hybrid", "body": { "phase_results_processors": [] } },
+  "ism_policy": { "name": "movies_lifecycle", "body": { "policy": {} } },
+  "queries": [ { "name": "hybrid_semantic", "body": { "query": {} } } ],
+  "probes": [ { "analyzer": "title_en", "text": "The Lord of the Rings", "expect_tokens": [] } ]
+}
+```
+
+| Key | Required | Purpose |
+|---|---|---|
+| `index` | yes | Index name. Version-suffix it (`movies_v1`) so reindexing is an alias swap. |
+| `mappings.properties` | yes | Explicit field map. Dynamic mapping is not a design. |
+| `settings` | no | Accepts both `{"index": {...}}` and flat form. |
+| `ingest_pipeline` | no | Applied before the index is created. |
+| `search_pipeline` | no | Required if any query uses a `hybrid` clause. |
+| `ism_policy` | no | Lifecycle states and transitions. |
+| `queries` | no | Named queries, each validated via `_validate/query`. |
+| `probes` | no | Analyzer assertions run through `_analyze`. |
+
+### Probes
+
+A probe is an executable claim about tokenization:
+
+```json
+{ "analyzer": "title_en", "text": "The Lord of the Rings",
+  "expect_tokens": ["lord", "ring"] }
+```
+
+With `expect_tokens`, the probe passes only on an exact match and
+`blueprint-apply` exits non-zero on failure. Without it, the probe just reports
+the token stream for you to read. Always include at least one probe per custom
+analyzer.
+
+---
+
+## The five density techniques
+
+These carry over from general dense-spec writing, but every slot is filled with
+OpenSearch's own vocabulary. The point is that the rendered spec stays scannable
+as the design grows past what a mapping JSON can show on one screen.
+
+### 1. Slash-stack the option space
+
+Never name one setting where the alternatives matter. Stack them so the reader
+sees the decision, not just the outcome.
+
+- Weak: `an hnsw index`
+- Dense: `hnsw/lucene/l2, ef_construction 256, m 16`
+
+The engine, space type, and parameters are the decision. Show all three.
+
+### 2. OpenSearch-native jargon, never generic words
+
+The whole point of the format is that the reader — human or agent — recognizes
+a term and pulls in everything associated with it.
+
+- Weak: `a filter to make search case-insensitive`
+- Dense: `normalizer keyword_lc (lowercase/asciifolding)`
+- Weak: `combine keyword and vector results`
+- Dense: `normalization min_max, combination arithmetic_mean, weights 0.3/0.7`
+
+See [opensearch-vocabulary.md](opensearch-vocabulary.md) for the term inventory.
+If you do not know the correct term for something, look it up with
+`search-docs` — do not fall back to a generic phrase.
+
+### 3. CAPS sections, em-dash separated
+
+Em-dashes separate top-level sections **only**. Inside a section, use commas.
+
+```
+INDEX — ANALYSIS — MAPPINGS — INGEST PIPELINE — SEARCH PIPELINE — ISM — QUERIES
+```
+
+`blueprint-render` emits exactly this structure, so you get it for free.
+
+### 4. Hard numbers everywhere
+
+Every quantity is a number. This is the highest-leverage rule, because in
+OpenSearch a vague quantity is usually an unmade decision.
+
+- Weak: `several shards` → Dense: `3 shards`
+- Weak: `a large vector` → Dense: `dim 768`
+- Weak: `keep logs a while` → Dense: `hot 7d → warm 30d → delete 90d`
+- Weak: `long titles get truncated` → Dense: `ignore_above 256`
+
+Shard count should follow from corpus size: target 10–50 GB per shard, so
+`1.2m docs × 2 KB ≈ 2.4 GB` is **one** shard, not three. If you cannot justify
+the number from the corpus, you have not finished Phase 1.
+
+### 5. Ranges in parentheses
+
+Ranges communicate the shape of a parameter without spending words.
+
+- `ef_construction (128-512)` — recall/build-time tradeoff
+- `m (16-48)` — graph degree, memory-linear
+- `edge_ngram (2-20)` — autocomplete prefix window
+- `shingle (2-3)` — phrase-ish matching without positions
+- `refresh_interval (1s-30s)` — freshness vs indexing throughput
+- `scaling_factor (10-100)` — `scaled_float` precision
+
+---
+
+## The no-list
+
+Inside the rendered spec:
+
+- No prose sentences. It is a manifest, not documentation.
+- No vague quantifiers — always a hard number.
+- No generic words where an OpenSearch term exists.
+- No em-dashes inside a section — those separate sections only.
+- No line breaks. One continuous block.
+
+Inside the bundle:
+
+- No `dynamic: true` on a designed index.
+- No `text` field that is never matched on — make it `keyword`.
+- No `keyword` field without `ignore_above` if values can be unbounded.
+- No `knn_vector` without a probe-verified embedding path.
+
+---
+
+## Rendered output shape
+
+`blueprint-render` produces:
+
+```
+3.x, MOVIE-SEARCH — hybrid movie discovery over 1.2m titles — INDEX movies_v1
+(1 shards, 0 replicas, refresh_interval 30s, knn True) — ANALYSIS analyzer
+title_en (standard tokenizer, lowercase/asciifolding/english_stop/english_stemmer),
+normalizer keyword_lc (lowercase/asciifolding) — MAPPINGS title (text, analyzer
+title_en), title.raw (keyword, ignore_above 256), embedding (knn_vector, dim 384,
+hnsw/lucene/l2, ef_construction 256, m 16) — INGEST PIPELINE movies_embed
+(text_embedding: title→embedding) — SEARCH PIPELINE movies_hybrid (normalization
+min_max, combination arithmetic_mean, weights 0.3/0.7) — ISM movies_lifecycle
+(hot → warm → delete) — QUERIES bm25_title, hybrid_semantic — validated against
+_analyze / _validate/query / _search
+```
+
+Wrapped here for readability; the real output is one line. Paste it into a PR
+description or a design doc — it is the whole index in one paragraph.
+
+---
+
+## Offering tuning knobs
+
+After showing the rendered spec, offer 2–3 concrete adjustments, each with its
+tradeoff stated as a number:
+
+- drop `m` to 16 and `ef_construction` to 128 — roughly halves HNSW memory, costs
+  a few points of recall@10
+- shift hybrid weights 0.3/0.7 → 0.5/0.5 — favors exact terms, hurts paraphrase
+- add `refresh_interval 30s` — better bulk throughput, 30s search lag
+
+Keep it to four lines. The user iterates from there.

--- a/skills/opensearch-skills/search/opensearch-blueprint/example-bundle.json
+++ b/skills/opensearch-skills/search/opensearch-blueprint/example-bundle.json
@@ -1,0 +1,188 @@
+{
+  "name": "MOVIE-SEARCH",
+  "pitch": "hybrid movie discovery over 1.2m titles",
+  "opensearch_version": "3.x",
+  "index": "movies_v1",
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "refresh_interval": "30s",
+      "codec": "best_compression",
+      "knn": true,
+      "default_pipeline": "movies_embed",
+      "analysis": {
+        "filter": {
+          "english_stop": { "type": "stop", "stopwords": "_english_" },
+          "english_stemmer": { "type": "stemmer", "language": "english" },
+          "title_edge_ngram": { "type": "edge_ngram", "min_gram": 2, "max_gram": 20 }
+        },
+        "analyzer": {
+          "title_en": {
+            "type": "custom",
+            "tokenizer": "standard",
+            "filter": ["lowercase", "asciifolding", "english_stop", "english_stemmer"]
+          },
+          "title_autocomplete": {
+            "type": "custom",
+            "tokenizer": "standard",
+            "filter": ["lowercase", "asciifolding", "title_edge_ngram"]
+          }
+        },
+        "normalizer": {
+          "keyword_lc": { "type": "custom", "filter": ["lowercase", "asciifolding"] }
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text",
+        "analyzer": "title_en",
+        "fields": {
+          "raw": { "type": "keyword", "ignore_above": 256 },
+          "ac": {
+            "type": "text",
+            "analyzer": "title_autocomplete",
+            "search_analyzer": "standard"
+          }
+        }
+      },
+      "plot": { "type": "text", "analyzer": "title_en" },
+      "genres": { "type": "keyword", "normalizer": "keyword_lc" },
+      "year": { "type": "integer" },
+      "rating": { "type": "scaled_float", "scaling_factor": 10 },
+      "popularity": { "type": "rank_feature" },
+      "released": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_millis"
+      },
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 384,
+        "method": {
+          "name": "hnsw",
+          "engine": "lucene",
+          "space_type": "l2",
+          "parameters": { "ef_construction": 256, "m": 16 }
+        }
+      }
+    }
+  },
+  "ingest_pipeline": {
+    "name": "movies_embed",
+    "body": {
+      "description": "Embed the title into a 384-dim vector on write",
+      "processors": [
+        {
+          "text_embedding": {
+            "model_id": "huggingface/sentence-transformers/all-MiniLM-L6-v2",
+            "field_map": { "title": "embedding" }
+          }
+        }
+      ]
+    }
+  },
+  "search_pipeline": {
+    "name": "movies_hybrid",
+    "body": {
+      "description": "Normalize and blend BM25 with vector scores",
+      "phase_results_processors": [
+        {
+          "normalization-processor": {
+            "normalization": { "technique": "min_max" },
+            "combination": {
+              "technique": "arithmetic_mean",
+              "parameters": { "weights": [0.3, 0.7] }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "ism_policy": {
+    "name": "movies_lifecycle",
+    "body": {
+      "policy": {
+        "description": "Roll over weekly, force-merge warm, delete at 90d",
+        "default_state": "hot",
+        "states": [
+          {
+            "name": "hot",
+            "actions": [{ "rollover": { "min_index_age": "7d", "min_size": "20gb" } }],
+            "transitions": [
+              { "state_name": "warm", "conditions": { "min_index_age": "7d" } }
+            ]
+          },
+          {
+            "name": "warm",
+            "actions": [{ "force_merge": { "max_num_segments": 1 } }],
+            "transitions": [
+              { "state_name": "delete", "conditions": { "min_index_age": "90d" } }
+            ]
+          },
+          {
+            "name": "delete",
+            "actions": [{ "delete": {} }],
+            "transitions": []
+          }
+        ]
+      }
+    }
+  },
+  "queries": [
+    {
+      "name": "bm25_title",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [
+              {
+                "multi_match": {
+                  "query": "space opera",
+                  "fields": ["title^3", "plot"],
+                  "type": "best_fields"
+                }
+              }
+            ],
+            "filter": [{ "range": { "year": { "gte": 1980 } } }],
+            "should": [{ "rank_feature": { "field": "popularity" } }]
+          }
+        }
+      }
+    },
+    {
+      "name": "hybrid_semantic",
+      "body": {
+        "query": {
+          "hybrid": {
+            "queries": [
+              { "match": { "title": { "query": "space opera" } } },
+              {
+                "neural": {
+                  "embedding": {
+                    "query_text": "space opera",
+                    "model_id": "huggingface/sentence-transformers/all-MiniLM-L6-v2",
+                    "k": 50
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "probes": [
+    {
+      "analyzer": "title_en",
+      "text": "The Lord of the Rings",
+      "expect_tokens": ["lord", "ring"]
+    },
+    {
+      "analyzer": "title_autocomplete",
+      "text": "Blade Runner"
+    }
+  ]
+}

--- a/skills/opensearch-skills/search/opensearch-blueprint/opensearch-vocabulary.md
+++ b/skills/opensearch-skills/search/opensearch-blueprint/opensearch-vocabulary.md
@@ -1,0 +1,228 @@
+# OpenSearch Vocabulary
+
+The term inventory a blueprint draws from. Use the real name; never paraphrase.
+
+---
+
+## Field types
+
+| Type | Use for | Watch out |
+|---|---|---|
+| `text` | Full-text matched fields | Not aggregatable or sortable without `fielddata` |
+| `keyword` | Filters, facets, sorts, IDs | Set `ignore_above` (typically 256) on unbounded values |
+| `wildcard` | Grep-like substring search on long strings | Larger than `keyword` |
+| `integer` / `long` | Counts, IDs | Use the smallest type that fits |
+| `scaled_float` | Ratings, prices | Needs `scaling_factor`; 10 gives one decimal place |
+| `half_float` | Scores where 3 significant digits suffice | Half the storage of `float` |
+| `date` | Timestamps | Pin `format`, e.g. `strict_date_optional_time\|\|epoch_millis` |
+| `boolean` | Flags | — |
+| `ip` | Addresses | Supports CIDR range queries |
+| `geo_point` / `geo_shape` | Coordinates, regions | `geo_shape` is far more expensive |
+| `nested` | Arrays of objects queried as units | Each element is a hidden doc; costs scale with array length |
+| `join` | Parent/child | Single shard routing required |
+| `knn_vector` | Dense embeddings | Needs `index.knn: true` and a `dimension` |
+| `rank_features` | Sparse/learned term weights | Target of `sparse_encoding` |
+| `rank_feature` | A single numeric relevance signal | Use `positive_score_impact: false` for "lower is better" |
+| `alias` | Rename without reindex | Query-time only |
+| `percolator` | Stored queries matched against documents | Reverse search |
+
+**Multi-fields** — index one source several ways:
+
+```json
+"title": {
+  "type": "text", "analyzer": "title_en",
+  "fields": {
+    "raw": { "type": "keyword", "ignore_above": 256 },
+    "ac":  { "type": "text", "analyzer": "title_autocomplete" }
+  }
+}
+```
+
+---
+
+## Analysis chain
+
+Order is always: `char_filter` → `tokenizer` → `filter`.
+
+**Char filters** — `html_strip`, `mapping`, `pattern_replace`
+
+**Tokenizers** — `standard`, `whitespace`, `keyword`, `pattern`, `uax_url_email`,
+`ngram`, `edge_ngram`, `path_hierarchy`, `char_group`, `classic`, `letter`,
+`simple_pattern`, `simple_pattern_split`, `thai`
+
+**Token filters** — `lowercase`, `uppercase`, `asciifolding`, `stop`, `stemmer`,
+`snowball`, `kstem`, `porter_stem`, `keyword_marker`, `keyword_repeat`,
+`remove_duplicates`, `shingle`, `ngram`, `edge_ngram`, `synonym`,
+`synonym_graph`, `word_delimiter_graph`, `flatten_graph`, `elision`,
+`common_grams`, `unique`, `length`, `limit`, `trim`, `truncate`, `reverse`,
+`pattern_capture`, `pattern_replace`, `phonetic`, `stemmer_override`,
+`decimal_digit`, `cjk_bigram`, `cjk_width`, `min_hash`, `multiplexer`,
+`condition`, `predicate_token_filter`, `delimited_payload`, `hunspell`
+
+**Normalizers** — keyword-only, no tokenizer. Filters limited to the
+character-level set (`lowercase`, `asciifolding`, `trim`, `pattern_replace`, …).
+This is how you get case-insensitive **filters** without making a field `text`.
+
+### Patterns worth knowing
+
+- **Autocomplete** — index with `edge_ngram (2-20)`, search with `standard`.
+  Always split `analyzer` and `search_analyzer`, or every query term is itself
+  n-grammed and precision collapses.
+- **Stemming with exceptions** — `keyword_marker` (protect terms) before
+  `stemmer`, or `stemmer_override` for specific mappings.
+- **Phrase-ish matching cheaply** — `shingle (2-3)` instead of positional phrase
+  queries.
+- **Search-time synonyms** — put `synonym_graph` in `search_analyzer` only.
+  Index-time synonyms cannot be changed without a reindex.
+
+---
+
+## k-NN / vector search
+
+```json
+"embedding": {
+  "type": "knn_vector", "dimension": 384,
+  "method": { "name": "hnsw", "engine": "lucene", "space_type": "l2",
+              "parameters": { "ef_construction": 256, "m": 16 } }
+}
+```
+
+| Engine | Space types | Notes |
+|---|---|---|
+| `lucene` | `l2`, `cosinesimil`, `innerproduct` | Native segment merge, filter-aware |
+| `faiss` | `l2`, `innerproduct`, `cosinesimil`, `hamming` | Supports PQ/SQ quantization |
+| `nmslib` | `l2`, `cosinesimil`, `innerproduct`, `l1`, `linf` | Legacy |
+
+Parameters:
+
+- `m (16-48)` — graph degree. Memory grows roughly linearly.
+- `ef_construction (128-512)` — build-time candidate list. Higher = better
+  recall, slower indexing. Must be ≥ `m`.
+- `ef_search` — query-time candidate list, set per search.
+
+Requires `"index": { "knn": true }` in settings.
+
+---
+
+## Pipelines
+
+### Ingest processors
+
+`text_embedding` (dense), `sparse_encoding` (learned sparse),
+`text_image_embedding` (multimodal), `text_chunking`, `set`, `script`, `rename`,
+`remove`, `split`, `trim`, `lowercase`, `date`, `grok`, `dissect`, `foreach`,
+`json`, `convert`, `fingerprint`
+
+```json
+{ "text_embedding": { "model_id": "<id>", "field_map": { "title": "embedding" } } }
+```
+
+Attach with `"index": { "default_pipeline": "movies_embed" }`.
+
+### Search pipeline processors
+
+- **Phase results** — `normalization-processor` (required for `hybrid`)
+- **Request** — `filter_query`, `neural_query_enricher`, `script`
+- **Response** — `rename_field`, `rerank`, `collapse`, `truncate_hits`,
+  `personalize_search_ranking`
+
+```json
+{ "normalization-processor": {
+    "normalization": { "technique": "min_max" },
+    "combination": { "technique": "arithmetic_mean",
+                     "parameters": { "weights": [0.3, 0.7] } } } }
+```
+
+Normalization: `min_max`, `l2`, `z_score`.
+Combination: `arithmetic_mean`, `geometric_mean`, `harmonic_mean`.
+
+**Weights must sum to 1.0 and their count must equal the number of `hybrid`
+sub-queries.** Both are linted.
+
+---
+
+## Query clauses
+
+**Full text** — `match`, `match_phrase`, `match_phrase_prefix`, `multi_match`
+(types: `best_fields`, `most_fields`, `cross_fields`, `phrase`, `bm25`),
+`query_string`, `simple_query_string`, `intervals`
+
+**Term-level** — `term`, `terms`, `terms_set`, `range`, `prefix`, `wildcard`,
+`regexp`, `fuzzy`, `ids`, `exists`
+
+**Compound** — `bool` (`must`/`filter`/`should`/`must_not`), `dis_max`,
+`function_score`, `boosting`, `constant_score`
+
+**Neural** — `knn`, `neural`, `neural_sparse`, `hybrid`
+
+**Relevance** — `rank_feature`, `distance_feature`, `script_score`
+
+Put anything non-scoring in `filter`, not `must` — filters are cached and skip
+scoring entirely.
+
+---
+
+## Aggregations
+
+**Bucket** — `terms`, `composite` (paginates, use for high cardinality),
+`date_histogram`, `histogram`, `range`, `date_range`, `filters`, `nested`,
+`significant_text`, `sampler`, `diversified_sampler`, `multi_terms`
+
+**Metric** — `avg`, `sum`, `min`, `max`, `stats`, `extended_stats`,
+`cardinality` (set `precision_threshold`), `percentiles`, `percentile_ranks`,
+`top_hits`, `scripted_metric`
+
+**Pipeline** — `derivative`, `moving_avg`, `moving_fn`, `cumulative_sum`,
+`bucket_script`, `bucket_selector`, `bucket_sort`, `serial_diff`
+
+`terms` on a high-cardinality field is a memory hazard — use `composite`.
+
+---
+
+## Index settings
+
+| Setting | Range | Effect |
+|---|---|---|
+| `number_of_shards` | 1–N | Fixed at creation. Target 10–50 GB per shard. |
+| `number_of_replicas` | 0–N | Use `0` on single-node dev clusters. |
+| `refresh_interval` | `1s`–`30s`, `-1` | Higher = faster bulk indexing, staler search. |
+| `codec` | `default`, `best_compression` | `best_compression` trades CPU for ~15–25% disk. |
+| `knn` | bool | Must be `true` for `knn_vector`. |
+| `max_result_window` | default `10000` | Raise only if you cannot use `search_after`. |
+| `default_pipeline` | pipeline name | Ingest pipeline applied to every write. |
+
+Deep pagination: use `search_after` with a Point-in-Time, never `from`/`size`
+past a few thousand.
+
+---
+
+## ISM lifecycle
+
+States and their actions:
+
+- **hot** — `rollover` (`min_size`, `min_doc_count`, `min_index_age`)
+- **warm** — `force_merge` (`max_num_segments: 1`), `replica_count`, `shrink`
+- **cold** — `close`, `snapshot`
+- **delete** — `delete`
+
+Transitions use `min_index_age`, `min_size`, `min_doc_count`. Every
+`state_name` in a transition must be a defined state — this is linted.
+
+---
+
+## Useful diagnostic APIs
+
+```
+GET  <index>/_analyze                 # prove tokenization
+GET  <index>/_validate/query?explain  # syntax + field resolution
+POST <index>/_search?explain=true     # per-document score breakdown
+GET  <index>/_mapping
+GET  <index>/_settings
+GET  _cat/indices?v&s=store.size:desc
+GET  _cat/shards/<index>?v
+GET  <index>/_stats
+GET  _plugins/_ism/explain/<index>
+```
+
+`_analyze` and `_validate/query` are the two cheapest ways to be sure a design
+is right before loading data. Use them.

--- a/tests/evals/fixtures/routing.json
+++ b/tests/evals/fixtures/routing.json
@@ -105,6 +105,30 @@
     "id": "routing-negative-01",
     "prompt": "Bulk index my product catalog JSON into OpenSearch using the _bulk API",
     "expected_skill": "opensearch-launchpad",
-    "rationale": "Structured bulk-indexing is NOT managed-ingestion-service — it's opensearch-launchpad"
+    "rationale": "Structured bulk-indexing is NOT managed-ingestion-service \u2014 it's opensearch-launchpad"
+  },
+  {
+    "id": "routing-blueprint-01",
+    "prompt": "Design the index mapping and analyzer chain for a movie catalog before I load any data",
+    "expected_skill": "opensearch-blueprint",
+    "rationale": "Mapping + analysis design as a reviewable artifact, no data loading yet"
+  },
+  {
+    "id": "routing-blueprint-02",
+    "prompt": "My hybrid search returns nothing useful - can you check the normalization weights on my search pipeline?",
+    "expected_skill": "opensearch-blueprint",
+    "rationale": "Hybrid weight/normalization auditing is a blueprint lint concern"
+  },
+  {
+    "id": "routing-blueprint-03",
+    "prompt": "Extract the mapping and settings from my existing products index so I can port it to another cluster",
+    "expected_skill": "opensearch-blueprint",
+    "rationale": "Audit/extract mode - reading a live index back into a portable design"
+  },
+  {
+    "id": "routing-negative-blueprint-01",
+    "prompt": "Load my CSV into OpenSearch and give me a running search UI",
+    "expected_skill": "opensearch-launchpad",
+    "rationale": "Data loading + running UI is launchpad, NOT blueprint (which stops at a verified empty index)"
   }
 ]

--- a/tests/evals/fixtures/skill_rules.json
+++ b/tests/evals/fixtures/skill_rules.json
@@ -426,5 +426,37 @@
     "rule": "Must hand off to managed-ingestion-service for cloud ingestion (not just aws-setup direct indexing) since data is unstructured",
     "criteria": "The response must route unstructured data deployment through managed-ingestion-service (OSIS with semantic_enrichment) for cloud ingestion \u2014 not just direct bulk-indexing via aws-setup. Chunks already exist locally so they should be uploaded to S3 and ingested via OSIS. Exit state: cloud index has ASE sparse enrichment AND a flow agent pipeline is configured for search. It must mention provisioning the AOSS collection, OSIS ingestion, and setting up the flow agent after ingestion.",
     "rationale": "Phase 6 unstructured: provision AOSS, managed-ingestion-service handles OSIS ingestion, then agentic setup"
+  },
+  {
+    "id": "blueprint-lint-before-apply",
+    "skill": "opensearch-blueprint",
+    "prompt": "Here is my blueprint.json for a hybrid product index. Apply it to my cluster.",
+    "rule": "Must lint the bundle and read the findings before applying it",
+    "criteria": "The response must run 'blueprint-lint' (or 'blueprint-apply --dry-run') and review the findings before running a real 'blueprint-apply'. It must not apply the bundle to the cluster as its first action, and must not pass --force without naming the specific error being overridden.",
+    "rationale": "Critical Rule 2 - lint before apply; --force must be justified explicitly"
+  },
+  {
+    "id": "blueprint-probe-analyzers",
+    "skill": "opensearch-blueprint",
+    "prompt": "Design an autocomplete analyzer using edge n-grams for my titles field",
+    "rule": "Every custom analyzer needs a probe verified through the _analyze API",
+    "criteria": "The response must include at least one 'probes' entry for the custom analyzer and state that it will be verified via the _analyze API before data is loaded. It must also split 'analyzer' and 'search_analyzer' rather than applying the edge_ngram analyzer at search time.",
+    "rationale": "Critical Rule 4 - unprobed analyzers are the top cause of empty result sets"
+  },
+  {
+    "id": "blueprint-no-invented-dimension",
+    "skill": "opensearch-blueprint",
+    "prompt": "Add a knn_vector field to my index for embeddings from some sentence-transformers model",
+    "rule": "Must not invent a vector dimension",
+    "criteria": "The response must ask which embedding model is being used, or look up the model's dimension, rather than assuming a dimension value. It must not silently pick a number like 384 or 768 without tying it to a named model.",
+    "rationale": "Critical Rule 3 - a dimension mismatch fails silently until ingest"
+  },
+  {
+    "id": "blueprint-field-roles-first",
+    "skill": "opensearch-blueprint",
+    "prompt": "Build me an index blueprint for a 2 million document support ticket archive",
+    "rule": "Must establish field roles before writing mappings",
+    "criteria": "The response must ask which fields are matched, filtered, sorted, aggregated, or returned only, before proposing concrete field types. It must not emit a full mapping without knowing the field roles.",
+    "rationale": "Phase 1 - field role determines text vs keyword, which drives index size"
   }
 ]

--- a/tests/test_agent_skills_blueprint.py
+++ b/tests/test_agent_skills_blueprint.py
@@ -1,0 +1,759 @@
+"""Tests for skills/opensearch-skills/scripts/lib/blueprint.py
+
+No cluster required — cluster interaction is exercised through fakes.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "skills" / "opensearch-skills" / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from lib.blueprint import (  # noqa: E402
+    apply_bundle,
+    extract_bundle,
+    format_findings,
+    has_errors,
+    iter_fields,
+    lint_bundle,
+    load_bundle,
+    probe_analyzers,
+    render_blueprint,
+    validate_queries,
+)
+
+_EXAMPLE_BUNDLE = (
+    _REPO_ROOT / "skills" / "opensearch-skills" / "search" / "opensearch-blueprint"
+    / "example-bundle.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def codes(findings, level=None):
+    return {f["code"] for f in findings if level is None or f["level"] == level}
+
+
+def minimal_bundle(**overrides):
+    bundle = {
+        "index": "things_v1",
+        "mappings": {"properties": {"title": {"type": "text"}}},
+    }
+    bundle.update(overrides)
+    return bundle
+
+
+class _FakeIndices:
+    def __init__(self, *, exists=False, settings=None, mappings=None, analyze=None):
+        self._exists = exists
+        self._settings = settings or {}
+        self._mappings = mappings or {}
+        self._analyze = analyze or {"tokens": []}
+        self.created = []
+        self.deleted = []
+        self.analyzed = []
+        self.validated = []
+        self.validate_response = {"valid": True, "explanations": []}
+
+    def exists(self, index):
+        return self._exists
+
+    def delete(self, index):
+        self.deleted.append(index)
+
+    def create(self, index, body):
+        self.created.append((index, body))
+
+    def analyze(self, body, index=None):
+        self.analyzed.append((body, index))
+        return self._analyze
+
+    def validate_query(self, index, body, explain=False):
+        self.validated.append((index, body, explain))
+        return self.validate_response
+
+    def get_settings(self, index):
+        return self._settings
+
+    def get_mapping(self, index):
+        return self._mappings
+
+
+class _FakeIngest:
+    def __init__(self, pipelines=None):
+        self.put = []
+        self._pipelines = pipelines or {}
+
+    def put_pipeline(self, id, body):  # noqa: A002 - matches opensearch-py signature
+        self.put.append((id, body))
+
+    def get_pipeline(self, id):  # noqa: A002
+        return self._pipelines
+
+
+class _FakeTransport:
+    def __init__(self, responses=None):
+        self.requests = []
+        self._responses = responses or {}
+
+    def perform_request(self, method, path, body=None):
+        self.requests.append((method, path, body))
+        return self._responses.get(path, {})
+
+
+class _FakeClient:
+    def __init__(self, **kwargs):
+        self.indices = _FakeIndices(**kwargs.pop("indices", {}))
+        self.ingest = _FakeIngest(kwargs.pop("pipelines", None))
+        self.transport = _FakeTransport(kwargs.pop("responses", None))
+
+
+# ---------------------------------------------------------------------------
+# iter_fields
+# ---------------------------------------------------------------------------
+
+class TestIterFields:
+    def test_walks_multi_fields_and_nested_objects(self):
+        properties = {
+            "title": {
+                "type": "text",
+                "fields": {"raw": {"type": "keyword"}},
+            },
+            "author": {
+                "properties": {"name": {"type": "keyword"}},
+            },
+        }
+        paths = dict(iter_fields(properties))
+        assert "title" in paths
+        assert "title.raw" in paths
+        assert "author.name" in paths
+        assert paths["title.raw"]["type"] == "keyword"
+
+    def test_tolerates_non_dict_input(self):
+        assert list(iter_fields(None)) == []
+        assert list(iter_fields({"bad": "not-a-dict"})) == []
+
+
+# ---------------------------------------------------------------------------
+# Bundle-level lint
+# ---------------------------------------------------------------------------
+
+class TestBundleLint:
+    def test_rejects_non_object_bundle(self):
+        assert codes(lint_bundle(["not", "a", "bundle"])) == {"bundle.type"}
+
+    def test_requires_index_name(self):
+        bundle = minimal_bundle()
+        del bundle["index"]
+        assert "index.missing" in codes(lint_bundle(bundle))
+
+    def test_requires_explicit_mappings(self):
+        bundle = {"index": "things_v1", "mappings": {"properties": {}}}
+        assert "mappings.empty" in codes(lint_bundle(bundle))
+
+    def test_clean_minimal_bundle_has_no_errors(self):
+        assert not has_errors(lint_bundle(minimal_bundle()))
+
+
+# ---------------------------------------------------------------------------
+# Analysis references
+# ---------------------------------------------------------------------------
+
+class TestAnalysisLint:
+    def test_flags_dangling_analyzer(self):
+        bundle = minimal_bundle(
+            mappings={"properties": {"title": {"type": "text", "analyzer": "nope_en"}}}
+        )
+        assert "analysis.dangling_analyzer" in codes(lint_bundle(bundle))
+
+    def test_accepts_builtin_analyzer(self):
+        bundle = minimal_bundle(
+            mappings={"properties": {"title": {"type": "text", "analyzer": "english"}}}
+        )
+        assert "analysis.dangling_analyzer" not in codes(lint_bundle(bundle))
+
+    def test_accepts_custom_analyzer_defined_in_settings(self):
+        bundle = minimal_bundle(
+            settings={
+                "index": {
+                    "analysis": {
+                        "analyzer": {"title_en": {"tokenizer": "standard", "filter": ["lowercase"]}}
+                    }
+                }
+            },
+            mappings={"properties": {"title": {"type": "text", "analyzer": "title_en"}}},
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_accepts_flat_analysis_settings_form(self):
+        """settings.analysis and settings.index.analysis are both valid input."""
+        bundle = minimal_bundle(
+            settings={
+                "analysis": {
+                    "analyzer": {"title_en": {"tokenizer": "standard", "filter": ["lowercase"]}}
+                }
+            },
+            mappings={"properties": {"title": {"type": "text", "analyzer": "title_en"}}},
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_flags_dangling_tokenizer_and_filter(self):
+        bundle = minimal_bundle(
+            settings={
+                "index": {
+                    "analysis": {
+                        "analyzer": {
+                            "title_en": {
+                                "tokenizer": "made_up_tokenizer",
+                                "filter": ["made_up_filter"],
+                                "char_filter": ["made_up_char_filter"],
+                            }
+                        }
+                    }
+                }
+            },
+            mappings={"properties": {"title": {"type": "text", "analyzer": "title_en"}}},
+        )
+        found = codes(lint_bundle(bundle))
+        assert "analysis.dangling_tokenizer" in found
+        assert "analysis.dangling_filter" in found
+        assert "analysis.dangling_char_filter" in found
+
+    def test_flags_dangling_normalizer(self):
+        bundle = minimal_bundle(
+            mappings={"properties": {"genre": {"type": "keyword", "normalizer": "nope"}}}
+        )
+        assert "analysis.dangling_normalizer" in codes(lint_bundle(bundle))
+
+    def test_flags_normalizer_on_text_field(self):
+        bundle = minimal_bundle(
+            settings={"index": {"analysis": {"normalizer": {"lc": {"filter": ["lowercase"]}}}}},
+            mappings={"properties": {"title": {"type": "text", "normalizer": "lc"}}},
+        )
+        assert "analysis.normalizer_on_non_keyword" in codes(lint_bundle(bundle))
+
+
+# ---------------------------------------------------------------------------
+# k-NN
+# ---------------------------------------------------------------------------
+
+class TestKnnLint:
+    def _knn_bundle(self, field, index_settings=None):
+        return minimal_bundle(
+            settings={"index": index_settings if index_settings is not None else {"knn": True}},
+            mappings={"properties": {"embedding": field}},
+        )
+
+    def test_flags_knn_without_plugin_enabled(self):
+        bundle = self._knn_bundle({"type": "knn_vector", "dimension": 384}, index_settings={})
+        assert "knn.plugin_disabled" in codes(lint_bundle(bundle))
+
+    def test_accepts_string_true_for_knn_setting(self):
+        bundle = self._knn_bundle(
+            {"type": "knn_vector", "dimension": 384}, index_settings={"knn": "true"}
+        )
+        assert "knn.plugin_disabled" not in codes(lint_bundle(bundle))
+
+    def test_flags_missing_dimension(self):
+        bundle = self._knn_bundle({"type": "knn_vector"})
+        assert "knn.missing_dimension" in codes(lint_bundle(bundle))
+
+    def test_flags_non_positive_dimension(self):
+        bundle = self._knn_bundle({"type": "knn_vector", "dimension": 0})
+        assert "knn.invalid_dimension" in codes(lint_bundle(bundle))
+
+    def test_flags_unknown_engine(self):
+        bundle = self._knn_bundle({
+            "type": "knn_vector", "dimension": 384,
+            "method": {"name": "hnsw", "engine": "pinecone"},
+        })
+        assert "knn.unknown_engine" in codes(lint_bundle(bundle))
+
+    def test_flags_space_type_unsupported_by_engine(self):
+        bundle = self._knn_bundle({
+            "type": "knn_vector", "dimension": 384,
+            "method": {"name": "hnsw", "engine": "lucene", "space_type": "hamming"},
+        })
+        assert "knn.unsupported_space_type" in codes(lint_bundle(bundle))
+
+    def test_accepts_space_type_supported_by_engine(self):
+        bundle = self._knn_bundle({
+            "type": "knn_vector", "dimension": 384,
+            "method": {"name": "hnsw", "engine": "faiss", "space_type": "hamming"},
+        })
+        assert "knn.unsupported_space_type" not in codes(lint_bundle(bundle))
+
+    def test_warns_when_ef_construction_below_m(self):
+        bundle = self._knn_bundle({
+            "type": "knn_vector", "dimension": 384,
+            "method": {
+                "name": "hnsw", "engine": "lucene", "space_type": "l2",
+                "parameters": {"ef_construction": 8, "m": 16},
+            },
+        })
+        findings = lint_bundle(bundle)
+        assert "knn.ef_below_m" in codes(findings, level="warning")
+        assert not has_errors(findings)
+
+
+# ---------------------------------------------------------------------------
+# Ingest pipeline
+# ---------------------------------------------------------------------------
+
+class TestIngestLint:
+    def _bundle(self, processors, properties=None):
+        return minimal_bundle(
+            settings={"index": {"knn": True}},
+            mappings={"properties": properties or {
+                "title": {"type": "text"},
+                "embedding": {"type": "knn_vector", "dimension": 384},
+            }},
+            ingest_pipeline={"name": "embed", "body": {"processors": processors}},
+        )
+
+    def test_flags_dimension_mismatch_against_known_model(self):
+        bundle = self._bundle([{
+            "text_embedding": {
+                "model_id": "huggingface/sentence-transformers/all-mpnet-base-v2",
+                "field_map": {"title": "embedding"},
+            }
+        }])
+        assert "ingest.dimension_mismatch" in codes(lint_bundle(bundle))
+
+    def test_accepts_matching_dimension(self):
+        bundle = self._bundle([{
+            "text_embedding": {
+                "model_id": "huggingface/sentence-transformers/all-MiniLM-L6-v2",
+                "field_map": {"title": "embedding"},
+            }
+        }])
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_flags_unmapped_source_and_target(self):
+        bundle = self._bundle([{
+            "text_embedding": {"model_id": "x", "field_map": {"nope": "also_nope"}}
+        }])
+        found = codes(lint_bundle(bundle))
+        assert "ingest.unmapped_source" in found
+        assert "ingest.unmapped_target" in found
+
+    def test_flags_sparse_encoding_into_knn_vector(self):
+        bundle = self._bundle([{
+            "sparse_encoding": {"model_id": "x", "field_map": {"title": "embedding"}}
+        }])
+        assert "ingest.wrong_target_type" in codes(lint_bundle(bundle))
+
+    def test_sparse_encoding_into_rank_features_is_clean(self):
+        bundle = self._bundle(
+            [{"sparse_encoding": {"model_id": "x", "field_map": {"title": "tokens"}}}],
+            properties={"title": {"type": "text"}, "tokens": {"type": "rank_features"}},
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_flags_pipeline_without_name(self):
+        bundle = minimal_bundle(
+            ingest_pipeline={"body": {"processors": [{"set": {"field": "a", "value": 1}}]}}
+        )
+        assert "ingest.missing_name" in codes(lint_bundle(bundle))
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search pipeline
+# ---------------------------------------------------------------------------
+
+class TestHybridLint:
+    def _bundle(self, weights=None, subqueries=2, with_pipeline=True):
+        queries = [{"match": {"title": {"query": "x"}}} for _ in range(subqueries)]
+        bundle = minimal_bundle(
+            queries=[{"name": "hybrid_q", "body": {"query": {"hybrid": {"queries": queries}}}}]
+        )
+        if with_pipeline:
+            combination = {"technique": "arithmetic_mean"}
+            if weights is not None:
+                combination["parameters"] = {"weights": weights}
+            bundle["search_pipeline"] = {
+                "name": "hp",
+                "body": {"phase_results_processors": [{
+                    "normalization-processor": {
+                        "normalization": {"technique": "min_max"},
+                        "combination": combination,
+                    }
+                }]},
+            }
+        return bundle
+
+    def test_flags_hybrid_without_normalization_processor(self):
+        assert "hybrid.missing_normalization" in codes(
+            lint_bundle(self._bundle(with_pipeline=False))
+        )
+
+    def test_warns_on_normalization_without_hybrid_query(self):
+        bundle = minimal_bundle(search_pipeline={
+            "name": "hp",
+            "body": {"phase_results_processors": [{
+                "normalization-processor": {"normalization": {"technique": "min_max"}}
+            }]},
+        })
+        findings = lint_bundle(bundle)
+        assert "hybrid.unused_normalization" in codes(findings, level="warning")
+        assert not has_errors(findings)
+
+    def test_flags_weights_that_do_not_sum_to_one(self):
+        assert "hybrid.weights_sum" in codes(lint_bundle(self._bundle(weights=[0.3, 0.9])))
+
+    def test_accepts_weights_summing_to_one(self):
+        assert not has_errors(lint_bundle(self._bundle(weights=[0.3, 0.7])))
+
+    def test_flags_weight_count_mismatch(self):
+        found = codes(lint_bundle(self._bundle(weights=[0.5, 0.5], subqueries=3)))
+        assert "hybrid.weight_count" in found
+
+    def test_flags_non_numeric_weights(self):
+        assert "hybrid.invalid_weights" in codes(lint_bundle(self._bundle(weights=["a", "b"])))
+
+    def test_flags_unknown_techniques(self):
+        bundle = self._bundle(weights=[0.5, 0.5])
+        proc = bundle["search_pipeline"]["body"]["phase_results_processors"][0]
+        proc["normalization-processor"]["normalization"]["technique"] = "softmax"
+        proc["normalization-processor"]["combination"]["technique"] = "median"
+        found = codes(lint_bundle(bundle))
+        assert "hybrid.unknown_normalization" in found
+        assert "hybrid.unknown_combination" in found
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+class TestQueryLint:
+    def test_flags_unmapped_field(self):
+        bundle = minimal_bundle(
+            queries=[{"name": "q", "body": {"query": {"term": {"nope": "x"}}}}]
+        )
+        assert "query.unmapped_field" in codes(lint_bundle(bundle))
+
+    def test_accepts_mapped_field(self):
+        bundle = minimal_bundle(
+            queries=[{"name": "q", "body": {"query": {"match": {"title": "x"}}}}]
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_multi_match_boost_syntax_is_stripped(self):
+        bundle = minimal_bundle(
+            mappings={"properties": {"title": {"type": "text"}, "plot": {"type": "text"}}},
+            queries=[{"name": "q", "body": {
+                "query": {"multi_match": {"query": "x", "fields": ["title^3", "plot"]}}
+            }}],
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_field_valued_clauses_read_the_field_key(self):
+        """rank_feature/exists name their field in a value, not a key."""
+        bundle = minimal_bundle(
+            mappings={"properties": {"popularity": {"type": "rank_feature"}}},
+            queries=[{"name": "q", "body": {"query": {"bool": {"should": [
+                {"rank_feature": {"field": "popularity"}},
+                {"exists": {"field": "popularity"}},
+            ]}}}}],
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_multi_field_subfield_resolves_via_base(self):
+        bundle = minimal_bundle(
+            mappings={"properties": {
+                "title": {"type": "text", "fields": {"raw": {"type": "keyword"}}}
+            }},
+            queries=[{"name": "q", "body": {"query": {"term": {"title.raw": "x"}}}}],
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_flags_malformed_query_body(self):
+        bundle = minimal_bundle(queries=[{"name": "q", "body": {"size": 10}}])
+        assert "query.malformed" in codes(lint_bundle(bundle))
+
+
+# ---------------------------------------------------------------------------
+# Settings and ISM
+# ---------------------------------------------------------------------------
+
+class TestSettingsLint:
+    def test_flags_zero_shards(self):
+        bundle = minimal_bundle(settings={"index": {"number_of_shards": 0}})
+        assert "settings.invalid_shards" in codes(lint_bundle(bundle))
+
+    def test_warns_on_replicas_for_single_node(self):
+        bundle = minimal_bundle(settings={"index": {"number_of_replicas": 1}})
+        findings = lint_bundle(bundle)
+        assert "settings.replicas_on_single_node" in codes(findings, level="warning")
+        assert not has_errors(findings)
+
+
+class TestIsmLint:
+    def test_flags_unknown_default_state(self):
+        bundle = minimal_bundle(ism_policy={"name": "p", "body": {"policy": {
+            "default_state": "blazing",
+            "states": [{"name": "hot", "actions": [], "transitions": []}],
+        }}})
+        assert "ism.unknown_default_state" in codes(lint_bundle(bundle))
+
+    def test_flags_unknown_transition_target(self):
+        bundle = minimal_bundle(ism_policy={"name": "p", "body": {"policy": {
+            "default_state": "hot",
+            "states": [{
+                "name": "hot", "actions": [],
+                "transitions": [{"state_name": "glacier"}],
+            }],
+        }}})
+        assert "ism.unknown_transition" in codes(lint_bundle(bundle))
+
+    def test_flags_policy_without_name(self):
+        bundle = minimal_bundle(ism_policy={"body": {"policy": {"states": []}}})
+        assert "ism.missing_name" in codes(lint_bundle(bundle))
+
+    def test_no_findings_when_policy_absent(self):
+        assert not lint_bundle(minimal_bundle())
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+class TestRenderBlueprint:
+    def test_renders_sections_separated_by_em_dashes(self):
+        rendered = render_blueprint(load_bundle(_EXAMPLE_BUNDLE))
+        for section in ("INDEX", "ANALYSIS", "MAPPINGS", "INGEST PIPELINE",
+                        "SEARCH PIPELINE", "ISM", "QUERIES"):
+            assert section in rendered
+        assert "—" in rendered
+
+    def test_render_is_a_single_line(self):
+        assert "\n" not in render_blueprint(load_bundle(_EXAMPLE_BUNDLE))
+
+    def test_renders_knn_parameters(self):
+        rendered = render_blueprint(load_bundle(_EXAMPLE_BUNDLE))
+        assert "dim 384" in rendered
+        assert "hnsw/lucene/l2" in rendered
+        assert "ef_construction 256" in rendered
+
+    def test_renders_hybrid_weights(self):
+        assert "weights 0.3/0.7" in render_blueprint(load_bundle(_EXAMPLE_BUNDLE))
+
+    def test_singularizes_shard_and_replica_counts(self):
+        rendered = render_blueprint(minimal_bundle(
+            settings={"index": {"number_of_shards": 1, "number_of_replicas": 2}}
+        ))
+        assert "1 shard," in rendered
+        assert "2 replicas" in rendered
+
+    def test_renders_booleans_lowercase(self):
+        rendered = render_blueprint(minimal_bundle(settings={"index": {"knn": True}}))
+        assert "knn true" in rendered
+
+    def test_handles_empty_bundle(self):
+        assert "UNNAMED" in render_blueprint({})
+
+
+# ---------------------------------------------------------------------------
+# The shipped example must stay valid
+# ---------------------------------------------------------------------------
+
+class TestExampleBundle:
+    def test_example_bundle_lints_clean(self):
+        findings = lint_bundle(load_bundle(_EXAMPLE_BUNDLE))
+        assert findings == [], format_findings(findings)
+
+    def test_example_bundle_is_valid_json(self):
+        assert json.loads(_EXAMPLE_BUNDLE.read_text(encoding="utf-8"))["index"] == "movies_v1"
+
+
+# ---------------------------------------------------------------------------
+# Cluster interaction (faked)
+# ---------------------------------------------------------------------------
+
+class TestProbeAnalyzers:
+    def test_probe_passes_when_tokens_match_expectation(self):
+        client = _FakeClient(indices={
+            "analyze": {"tokens": [{"token": "lord"}, {"token": "ring"}]}
+        })
+        bundle = minimal_bundle(
+            settings={"index": {"analysis": {"analyzer": {"title_en": {}}}}},
+            probes=[{"analyzer": "title_en", "text": "The Lord of the Rings",
+                     "expect_tokens": ["lord", "ring"]}],
+        )
+        result = probe_analyzers(client, bundle)
+        assert result[0]["ok"] is True
+        assert result[0]["tokens"] == ["lord", "ring"]
+
+    def test_probe_fails_when_tokens_differ(self):
+        client = _FakeClient(indices={"analyze": {"tokens": [{"token": "lords"}]}})
+        bundle = minimal_bundle(
+            settings={"index": {"analysis": {"analyzer": {"title_en": {}}}}},
+            probes=[{"analyzer": "title_en", "text": "Lords", "expect_tokens": ["lord"]}],
+        )
+        result = probe_analyzers(client, bundle)
+        assert result[0]["ok"] is False
+        assert result[0]["expected"] == ["lord"]
+
+    def test_probe_without_expectation_reports_tokens_and_passes(self):
+        client = _FakeClient(indices={"analyze": {"tokens": [{"token": "bl"}, {"token": "bla"}]}})
+        bundle = minimal_bundle(probes=[{"analyzer": "standard", "text": "Blade"}])
+        result = probe_analyzers(client, bundle)
+        assert result[0]["ok"] is True
+        assert result[0]["tokens"] == ["bl", "bla"]
+
+    def test_custom_analyzer_is_probed_against_the_index(self):
+        client = _FakeClient(indices={"analyze": {"tokens": []}})
+        bundle = minimal_bundle(
+            settings={"index": {"analysis": {"analyzer": {"title_en": {}}}}},
+            probes=[{"analyzer": "title_en", "text": "x"}],
+        )
+        probe_analyzers(client, bundle)
+        _, index = client.indices.analyzed[0]
+        assert index == "things_v1"
+
+    def test_analyze_error_is_captured_not_raised(self):
+        class _Boom(_FakeIndices):
+            def analyze(self, body, index=None):
+                raise RuntimeError("no such analyzer")
+
+        client = _FakeClient()
+        client.indices = _Boom()
+        bundle = minimal_bundle(probes=[{"analyzer": "ghost", "text": "x"}])
+        result = probe_analyzers(client, bundle)
+        assert result[0]["ok"] is False
+        assert "no such analyzer" in result[0]["error"]
+
+
+class TestValidateQueries:
+    def test_reports_valid_queries(self):
+        client = _FakeClient()
+        bundle = minimal_bundle(
+            queries=[{"name": "q", "body": {"query": {"match_all": {}}}}]
+        )
+        result = validate_queries(client, "things_v1", bundle)
+        assert result == [{"name": "q", "valid": True, "explanations": []}]
+        assert client.indices.validated[0][2] is True
+
+    def test_captures_validation_errors(self):
+        class _Boom(_FakeIndices):
+            def validate_query(self, index, body, explain=False):
+                raise RuntimeError("parse_exception")
+
+        client = _FakeClient()
+        client.indices = _Boom()
+        bundle = minimal_bundle(queries=[{"name": "q", "body": {"query": {}}}])
+        result = validate_queries(client, "things_v1", bundle)
+        assert result[0]["valid"] is False
+        assert "parse_exception" in result[0]["error"]
+
+
+class TestApplyBundle:
+    def test_creates_pipelines_index_and_policy(self):
+        client = _FakeClient()
+        bundle = load_bundle(_EXAMPLE_BUNDLE)
+        applied = apply_bundle(client, bundle)
+
+        assert applied["ingest_pipeline"] == "movies_embed"
+        assert applied["search_pipeline"] == "movies_hybrid"
+        assert applied["index"] == "movies_v1"
+        assert applied["ism_policy"] == "movies_lifecycle"
+
+        assert client.ingest.put[0][0] == "movies_embed"
+        paths = [path for _, path, _ in client.transport.requests]
+        assert "/_search/pipeline/movies_hybrid" in paths
+        assert "/_plugins/_ism/policies/movies_lifecycle" in paths
+
+        index, body = client.indices.created[0]
+        assert index == "movies_v1"
+        assert "settings" in body and "mappings" in body
+
+    def test_replace_deletes_existing_index_first(self):
+        client = _FakeClient(indices={"exists": True})
+        applied = apply_bundle(client, minimal_bundle(), replace=True)
+        assert applied["deleted_existing"] is True
+        assert client.indices.deleted == ["things_v1"]
+
+    def test_without_replace_existing_index_is_untouched(self):
+        client = _FakeClient(indices={"exists": True})
+        apply_bundle(client, minimal_bundle(), replace=False)
+        assert client.indices.deleted == []
+
+
+class TestExtractBundle:
+    def _client(self):
+        return _FakeClient(
+            indices={
+                "settings": {"movies_v1": {"settings": {"index": {
+                    "number_of_shards": "1",
+                    "uuid": "abc123",
+                    "creation_date": "1700000000000",
+                    "provided_name": "movies_v1",
+                    "knn": "true",
+                    "default_pipeline": "movies_embed",
+                }}}},
+                "mappings": {"movies_v1": {"mappings": {
+                    "properties": {"title": {"type": "text"}}
+                }}},
+            },
+            pipelines={"movies_embed": {"processors": []}},
+        )
+
+    def test_strips_cluster_assigned_metadata(self):
+        bundle = extract_bundle(self._client(), "movies_v1")
+        index_settings = bundle["settings"]["index"]
+        for key in ("uuid", "creation_date", "provided_name"):
+            assert key not in index_settings
+        assert index_settings["number_of_shards"] == "1"
+
+    def test_carries_mappings_and_index_name(self):
+        bundle = extract_bundle(self._client(), "movies_v1")
+        assert bundle["index"] == "movies_v1"
+        assert bundle["mappings"]["properties"]["title"]["type"] == "text"
+
+    def test_pulls_attached_ingest_pipeline(self):
+        bundle = extract_bundle(self._client(), "movies_v1")
+        assert bundle["ingest_pipeline"]["name"] == "movies_embed"
+
+    def test_extracted_bundle_round_trips_through_render(self):
+        rendered = render_blueprint(extract_bundle(self._client(), "movies_v1"))
+        assert "movies_v1" in rendered
+        assert "MAPPINGS" in rendered
+
+    def test_missing_pipeline_does_not_raise(self):
+        class _Boom(_FakeIngest):
+            def get_pipeline(self, id):  # noqa: A002
+                raise RuntimeError("pipeline_missing")
+
+        client = self._client()
+        client.ingest = _Boom()
+        bundle = extract_bundle(client, "movies_v1")
+        assert "ingest_pipeline" not in bundle
+
+
+# ---------------------------------------------------------------------------
+# Reporting helpers
+# ---------------------------------------------------------------------------
+
+class TestFormatFindings:
+    def test_clean_message_when_no_findings(self):
+        assert "No findings" in format_findings([])
+
+    def test_counts_errors_and_warnings(self):
+        findings = lint_bundle(minimal_bundle(
+            settings={"index": {"number_of_replicas": 1, "number_of_shards": 0}}
+        ))
+        report = format_findings(findings)
+        assert "ERROR" in report
+        assert "WARN" in report
+        assert "1 error(s), 1 warning(s)." in report
+
+
+@pytest.mark.parametrize("bundle", [{}, {"index": "x"}, {"mappings": {}}])
+def test_lint_never_raises_on_partial_bundles(bundle):
+    assert isinstance(lint_bundle(bundle), list)

--- a/tests/test_agent_skills_blueprint.py
+++ b/tests/test_agent_skills_blueprint.py
@@ -14,6 +14,7 @@ _SCRIPTS_DIR = _REPO_ROOT / "skills" / "opensearch-skills" / "scripts"
 sys.path.insert(0, str(_SCRIPTS_DIR))
 
 from lib.blueprint import (  # noqa: E402
+    BlueprintApplyError,
     apply_bundle,
     extract_bundle,
     format_findings,
@@ -21,6 +22,7 @@ from lib.blueprint import (  # noqa: E402
     iter_fields,
     lint_bundle,
     load_bundle,
+    preflight_apply,
     probe_analyzers,
     render_blueprint,
     validate_queries,
@@ -50,11 +52,14 @@ def minimal_bundle(**overrides):
 
 
 class _FakeIndices:
-    def __init__(self, *, exists=False, settings=None, mappings=None, analyze=None):
+    def __init__(self, *, exists=False, settings=None, mappings=None, analyze=None,
+                 create_fails=False):
         self._exists = exists
         self._settings = settings or {}
         self._mappings = mappings or {}
         self._analyze = analyze or {"tokens": []}
+        # When set, the first create() raises; later creates (rollback) succeed.
+        self._create_fails = create_fails
         self.created = []
         self.deleted = []
         self.analyzed = []
@@ -68,6 +73,9 @@ class _FakeIndices:
         self.deleted.append(index)
 
     def create(self, index, body):
+        if self._create_fails:
+            self._create_fails = False
+            raise RuntimeError("mapper_parsing_exception: bad mapping")
         self.created.append((index, body))
 
     def analyze(self, body, index=None):
@@ -88,6 +96,7 @@ class _FakeIndices:
 class _FakeIngest:
     def __init__(self, pipelines=None):
         self.put = []
+        self.deleted = []
         self._pipelines = pipelines or {}
 
     def put_pipeline(self, id, body):  # noqa: A002 - matches opensearch-py signature
@@ -95,6 +104,9 @@ class _FakeIngest:
 
     def get_pipeline(self, id):  # noqa: A002
         return self._pipelines
+
+    def delete_pipeline(self, id):  # noqa: A002
+        self.deleted.append(id)
 
 
 class _FakeTransport:
@@ -112,6 +124,13 @@ class _FakeClient:
         self.indices = _FakeIndices(**kwargs.pop("indices", {}))
         self.ingest = _FakeIngest(kwargs.pop("pipelines", None))
         self.transport = _FakeTransport(kwargs.pop("responses", None))
+        # None models a count API that cannot be reached.
+        self._count = kwargs.pop("doc_count", 0)
+
+    def count(self, index):
+        if self._count is None:
+            raise RuntimeError("cluster_block_exception")
+        return {"count": self._count}
 
 
 # ---------------------------------------------------------------------------
@@ -741,14 +760,136 @@ class TestApplyBundle:
 
     def test_replace_deletes_existing_index_first(self):
         client = _FakeClient(indices={"exists": True})
-        applied = apply_bundle(client, minimal_bundle(), replace=True)
+        applied = apply_bundle(client, minimal_bundle(), replace=True, confirm=True)
         assert applied["deleted_existing"] is True
         assert client.indices.deleted == ["things_v1"]
 
-    def test_without_replace_existing_index_is_untouched(self):
+
+class TestApplySafetyGates:
+    """Every refusal must happen before the first mutation."""
+
+    def test_existing_index_without_replace_is_refused_not_silently_skipped(self):
         client = _FakeClient(indices={"exists": True})
-        apply_bundle(client, minimal_bundle(), replace=False)
+        with pytest.raises(BlueprintApplyError) as excinfo:
+            apply_bundle(client, minimal_bundle(), replace=False)
+        assert excinfo.value.code == "index_exists"
         assert client.indices.deleted == []
+        assert client.indices.created == []
+        assert client.ingest.put == []
+
+    def test_replace_without_confirmation_refuses_and_mutates_nothing(self):
+        client = _FakeClient(indices={"exists": True})
+        with pytest.raises(BlueprintApplyError) as excinfo:
+            apply_bundle(client, minimal_bundle(), replace=True, confirm=False)
+        assert excinfo.value.code == "confirmation_required"
+        assert client.indices.deleted == []
+        assert client.ingest.put == []
+
+    def test_nonempty_index_is_refused_even_with_confirmation(self):
+        client = _FakeClient(indices={"exists": True}, doc_count=4200)
+        with pytest.raises(BlueprintApplyError) as excinfo:
+            apply_bundle(client, minimal_bundle(), replace=True, confirm=True)
+        assert excinfo.value.code == "index_not_empty"
+        assert "4200" in str(excinfo.value)
+        assert client.indices.deleted == []
+
+    def test_nonempty_index_deletable_with_explicit_opt_in(self):
+        client = _FakeClient(indices={"exists": True}, doc_count=4200)
+        applied = apply_bundle(
+            client, minimal_bundle(), replace=True, confirm=True, allow_nonempty=True
+        )
+        assert applied["deleted_existing"] is True
+
+    def test_unknown_doc_count_fails_closed(self):
+        """An unreachable count API must never be read as 'empty, safe to delete'."""
+        client = _FakeClient(indices={"exists": True}, doc_count=None)
+        with pytest.raises(BlueprintApplyError) as excinfo:
+            apply_bundle(client, minimal_bundle(), replace=True, confirm=True)
+        assert excinfo.value.code == "index_not_empty"
+        assert client.indices.deleted == []
+
+
+class TestPreflightApply:
+    def test_reports_the_delete_without_performing_it(self):
+        client = _FakeClient(indices={"exists": True}, doc_count=7)
+        plan = preflight_apply(client, minimal_bundle(), replace=True)
+        assert plan["will_delete"] is True
+        assert plan["doc_count"] == 7
+        assert {h["code"] for h in plan["hazards"]} == {"destructive.delete_index"}
+        assert client.indices.deleted == []
+
+    def test_flags_conflict_when_replace_not_requested(self):
+        client = _FakeClient(indices={"exists": True})
+        plan = preflight_apply(client, minimal_bundle(), replace=False)
+        assert plan["will_delete"] is False
+        assert {h["code"] for h in plan["hazards"]} == {"conflict.index_exists"}
+
+    def test_clean_create_has_no_hazards(self):
+        plan = preflight_apply(_FakeClient(), load_bundle(_EXAMPLE_BUNDLE))
+        assert plan["hazards"] == []
+        kinds = {c["kind"] for c in plan["creates"]}
+        assert {"index", "ingest_pipeline", "search_pipeline", "ism_policy"} <= kinds
+
+    def test_separates_overwrites_from_creates(self):
+        client = _FakeClient(pipelines={"movies_embed": {"processors": []}})
+        plan = preflight_apply(client, load_bundle(_EXAMPLE_BUNDLE))
+        assert {o["name"] for o in plan["overwrites"]} == {"movies_embed"}
+        assert "movies_embed" not in {c["name"] for c in plan["creates"]}
+
+
+class TestApplyRollback:
+    def test_failed_index_create_unwinds_the_pipelines_it_made(self):
+        client = _FakeClient(indices={"create_fails": True})
+        with pytest.raises(BlueprintApplyError) as excinfo:
+            apply_bundle(client, load_bundle(_EXAMPLE_BUNDLE))
+
+        assert excinfo.value.code == "apply_failed"
+        # The ingest pipeline it created is deleted again, not left orphaned.
+        assert client.ingest.deleted == ["movies_embed"]
+        assert ("DELETE", "/_search/pipeline/movies_hybrid", None) in client.transport.requests
+        assert excinfo.value.details["rollback_failed"] == []
+
+    def test_preexisting_pipeline_is_restored_not_deleted(self):
+        prior = {"description": "the original", "processors": []}
+        client = _FakeClient(
+            indices={"create_fails": True},
+            pipelines={"movies_embed": prior},
+        )
+        with pytest.raises(BlueprintApplyError):
+            apply_bundle(client, load_bundle(_EXAMPLE_BUNDLE))
+
+        assert client.ingest.deleted == []
+        assert client.ingest.put[-1] == ("movies_embed", prior)
+
+    def test_replaced_index_shell_is_recreated_after_a_failure(self):
+        client = _FakeClient(
+            indices={
+                "exists": True,
+                "create_fails": True,
+                "settings": {"things_v1": {"settings": {"index": {
+                    "number_of_shards": "3", "uuid": "abc",
+                }}}},
+                "mappings": {"things_v1": {"mappings": {
+                    "properties": {"title": {"type": "text"}}
+                }}},
+            },
+        )
+        with pytest.raises(BlueprintApplyError) as excinfo:
+            apply_bundle(client, minimal_bundle(), replace=True, confirm=True)
+
+        restored = dict(client.indices.created)["things_v1"]
+        assert restored["settings"]["index"]["number_of_shards"] == "3"
+        assert "uuid" not in restored["settings"]["index"]
+        assert restored["mappings"]["properties"]["title"]["type"] == "text"
+        # Data loss is reported plainly rather than implied by a restored shell.
+        assert excinfo.value.details["irreversible"]
+
+    def test_no_rollback_flag_leaves_partial_state_and_reraises_cause(self):
+        client = _FakeClient(indices={"create_fails": True})
+        with pytest.raises(RuntimeError) as excinfo:
+            apply_bundle(client, load_bundle(_EXAMPLE_BUNDLE), rollback=False)
+        assert not isinstance(excinfo.value, BlueprintApplyError)
+        assert client.ingest.deleted == []
 
 
 class TestExtractBundle:

--- a/tests/test_agent_skills_blueprint.py
+++ b/tests/test_agent_skills_blueprint.py
@@ -238,6 +238,14 @@ class TestAnalysisLint:
         )
         assert "analysis.normalizer_on_non_keyword" in codes(lint_bundle(bundle))
 
+    def test_reports_one_normalizer_problem_per_field(self):
+        """A dangling normalizer on a text field reports the type error only."""
+        bundle = minimal_bundle(
+            mappings={"properties": {"title": {"type": "text", "normalizer": "ghost"}}}
+        )
+        found = codes(lint_bundle(bundle))
+        assert found == {"analysis.normalizer_on_non_keyword"}
+
 
 # ---------------------------------------------------------------------------
 # k-NN
@@ -356,6 +364,43 @@ class TestIngestLint:
         )
         assert not has_errors(lint_bundle(bundle))
 
+    def test_text_image_embedding_field_map_is_modality_keyed(self):
+        """field_map is {modality: source} and the target lives in 'embedding'."""
+        bundle = self._bundle(
+            [{
+                "text_image_embedding": {
+                    "model_id": "x",
+                    "embedding": "embedding",
+                    "field_map": {"text": "title", "image": "poster"},
+                }
+            }],
+            properties={
+                "title": {"type": "text"},
+                "poster": {"type": "binary"},
+                "embedding": {"type": "knn_vector", "dimension": 384},
+            },
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_text_image_embedding_flags_unmapped_source(self):
+        bundle = self._bundle(
+            [{
+                "text_image_embedding": {
+                    "model_id": "x",
+                    "embedding": "embedding",
+                    "field_map": {"text": "ghost_field"},
+                }
+            }],
+            properties={"embedding": {"type": "knn_vector", "dimension": 384}},
+        )
+        assert "ingest.unmapped_source" in codes(lint_bundle(bundle))
+
+    def test_text_image_embedding_requires_embedding_target(self):
+        bundle = self._bundle([{
+            "text_image_embedding": {"model_id": "x", "field_map": {"text": "title"}}
+        }])
+        assert "ingest.missing_embedding_target" in codes(lint_bundle(bundle))
+
     def test_flags_pipeline_without_name(self):
         bundle = minimal_bundle(
             ingest_pipeline={"body": {"processors": [{"set": {"field": "a", "value": 1}}]}}
@@ -470,6 +515,27 @@ class TestQueryLint:
                 "title": {"type": "text", "fields": {"raw": {"type": "keyword"}}}
             }},
             queries=[{"name": "q", "body": {"query": {"term": {"title.raw": "x"}}}}],
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_aggregations_are_not_read_as_query_fields(self):
+        """A terms agg is {"terms": {"field": ..., "size": ...}} — parameters, not fields."""
+        bundle = minimal_bundle(
+            mappings={"properties": {"genres": {"type": "keyword"}}},
+            queries=[{"name": "faceted", "body": {
+                "query": {"match_all": {}},
+                "aggs": {"by_genre": {"terms": {"field": "genres", "size": 10}}},
+            }}],
+        )
+        assert not has_errors(lint_bundle(bundle))
+
+    def test_terms_lookup_reads_the_field_key_not_lookup_params(self):
+        """Terms lookup nests index/id/path under the field name."""
+        bundle = minimal_bundle(
+            mappings={"properties": {"color": {"type": "keyword"}}},
+            queries=[{"name": "q", "body": {"query": {"terms": {
+                "color": {"index": "palettes", "id": "2", "path": "colors"}
+            }}}}],
         )
         assert not has_errors(lint_bundle(bundle))
 
@@ -724,6 +790,32 @@ class TestExtractBundle:
         rendered = render_blueprint(extract_bundle(self._client(), "movies_v1"))
         assert "movies_v1" in rendered
         assert "MAPPINGS" in rendered
+
+    def test_resolves_settings_and_mappings_keys_independently(self):
+        """An alias resolves to a concrete name; the two responses may differ in order."""
+        client = _FakeClient(
+            indices={
+                "settings": {"movies_v1": {"settings": {"index": {"number_of_shards": "2"}}}},
+                # Deliberately different insertion order and an extra sibling index.
+                "mappings": {
+                    "other_index": {"mappings": {"properties": {"wrong": {"type": "text"}}}},
+                    "movies_v1": {"mappings": {"properties": {"title": {"type": "text"}}}},
+                },
+            },
+        )
+        bundle = extract_bundle(client, "movies_v1")
+        assert bundle["mappings"]["properties"] == {"title": {"type": "text"}}
+        assert bundle["settings"]["index"]["number_of_shards"] == "2"
+
+    def test_falls_back_to_first_key_for_alias_lookups(self):
+        client = _FakeClient(
+            indices={
+                "settings": {"movies_v1": {"settings": {"index": {}}}},
+                "mappings": {"movies_v1": {"mappings": {"properties": {"a": {"type": "text"}}}}},
+            },
+        )
+        bundle = extract_bundle(client, "movies-alias")
+        assert bundle["mappings"]["properties"] == {"a": {"type": "text"}}
 
     def test_missing_pipeline_does_not_raise(self):
         class _Boom(_FakeIngest):


### PR DESCRIPTION
### Description

Adds `opensearch-blueprint`, a leaf skill under `search/` that compiles a search requirement into a **blueprint bundle** — one JSON document specifying index settings, the analysis chain, mappings, k-NN parameters, ingest and search pipelines, an ISM policy, and named queries — then verifies that design against a live cluster before any data is loaded.

This is a rework of the submission in #90 after review feedback that the original was a general-purpose prompt generator with no OpenSearch surface area. That was accurate. This version only makes sense inside OpenSearch.

### Commands added

Four new subcommands on the existing `opensearch_ops.py` CLI:

| Command | What it does |
|---|---|
| `blueprint-lint` | 14 static correctness checks, no cluster required, exits non-zero on errors |
| `blueprint-render` | Bundle → dense single-block spec for PR review and design docs |
| `blueprint-apply` | Creates pipelines/index/ISM policy, probes analyzers via `_analyze`, validates queries via `_validate/query?explain=true` |
| `blueprint-extract` | Reads `_settings`, `_mapping`, and attached pipelines from a live index back into a portable bundle |

### What the linter catches

OpenSearch-specific failures that are silent until ingest or query time. Seeding four realistic bugs into the bundled example:

```
ERROR  analysis.dangling_analyzer [mappings.properties.plot.analyzer]: Field 'plot' references
       analyzer 'plot_en_typo', which is neither built-in nor defined in settings.analysis.analyzer.
ERROR  knn.plugin_disabled [settings.index.knn]: Index maps 1 knn_vector field(s) but
       settings.index.knn is not true; the index will reject them.
ERROR  ingest.dimension_mismatch [mappings.properties.embedding.dimension]: Model
       'all-mpnet-base-v2' emits 768-dim vectors but 'embedding' is mapped with dimension 384.
ERROR  hybrid.weights_sum [search_pipeline.combination.parameters.weights]: Combination weights
       [0.4, 0.9] sum to 1.3; OpenSearch requires them to sum to 1.0.

4 error(s), 0 warning(s).
```

Full rule set: hybrid weight sum and weight-count-vs-subquery-count, embedding model dimension vs. mapped `knn_vector` dimension, `knn_vector` without `index.knn`, `space_type` unsupported by the chosen engine, `ef_construction` below `m`, dangling analyzer/tokenizer/filter/char_filter/normalizer references, normalizers on non-keyword fields, `sparse_encoding` writing into a `knn_vector`, queries referencing unmapped fields, ISM transitions to undefined states, and invalid shard counts.

### Audit / migration direction

`blueprint-extract` points at an index someone else built and emits a linted, portable bundle that re-applies to another cluster. Cluster-assigned metadata (`uuid`, `creation_date`, `provided_name`) is stripped so the result is portable.

### Relationship to `opensearch-launchpad`

Deliberately complementary, not overlapping:

- **launchpad** is the guided build — sample data in, running search UI out.
- **blueprint** is the design artifact — stops at a verified *empty* index, then hands off to launchpad to load data.

A negative routing eval case (`routing-negative-blueprint-01`) was added specifically to keep the two from being confused.

### Example prompts that trigger it

> "Design the index mapping and analyzer chain for a movie catalog before I load any data"

> "My hybrid search returns nothing useful — can you check the normalization weights on my search pipeline?"

> "Extract the mapping and settings from my existing products index so I can port it to another cluster"

### Files

```
skills/opensearch-skills/search/opensearch-blueprint/
  SKILL.md                    # workflow: design mode + audit mode
  blueprint-format.md         # bundle schema, density rules
  opensearch-vocabulary.md    # field types, analysis, k-NN, pipelines, ISM
  example-bundle.json         # runnable hybrid movie-search blueprint
skills/opensearch-skills/scripts/lib/blueprint.py
tests/test_agent_skills_blueprint.py
```

Plus router updates (`search/SKILL.md`, `opensearch-skills/SKILL.md`, `README.md`, `cli-reference.md`) and eval fixtures.

### Testing

```bash
uv run pytest tests/test_agent_skills_blueprint.py -v   # 75 passed
uv run pytest tests/ -q                                  # see note below
```

75 new tests, none requiring a cluster — faked clients throughout. Every lint rule, the renderer, and all four cluster-interaction paths are covered. Spec-compliance tests pass for the new `SKILL.md`.

Routing and skill-rule eval fixtures added: 4 routing cases (3 positive, 1 negative) and 4 rule-compliance cases.

### Note on an unrelated pre-existing failure

`tests/test_agent_skills_ingest.py` fails 11 tests on a clean checkout of `main` with `ModuleNotFoundError: No module named 'psutil'` — `psutil` doesn't appear to be declared in `pyproject.toml`. Verified pre-existing via `git stash`; unrelated to this PR. Happy to open a separate issue or fix it here if you'd prefer.

`AGENTS.md` asks contributors to update `CHANGELOG.md`, but the repo doesn't currently have one. I left it alone rather than creating it unilaterally — glad to add it if wanted.

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

Related to #90 (hackathon submission — left open for tracking; close it whenever suits your process).
