### PR TITLE
Add vector search tuning skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Skills are organized in a tree — install the whole collection or pick individu
 | Category | Skill | Description |
 |----------|-------|-------------|
 | **Search** | [opensearch-launchpad](skills/opensearch-skills/search/opensearch-launchpad/) | Build search apps from scratch — BM25, semantic, hybrid, agentic search |
+| **Search** | [opensearch-vector-search](skills/opensearch-skills/search/opensearch-vector-search/) | Tune and operate vector search — k-NN, HNSW, quantization, sizing, latency, cost |
 | **Observability** | [log-analytics](skills/opensearch-skills/observability/log-analytics/) | Query and analyze logs with PPL — error patterns, anomaly detection |
 | **Observability** | [trace-analytics](skills/opensearch-skills/observability/trace-analytics/) | Investigate distributed traces — slow spans, service maps, agent invocations |
 | **Cloud** | [aws-setup](skills/opensearch-skills/cloud/aws-setup/) | Deploy to Amazon OpenSearch Service or Serverless |
@@ -30,6 +31,7 @@ npx skills add opensearch-project/opensearch-agent-skills
 
 # Install a specific skill
 npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth
+npx skills add opensearch-project/opensearch-agent-skills@opensearch-vector-search --full-depth
 npx skills add opensearch-project/opensearch-agent-skills@log-analytics --full-depth
 npx skills add opensearch-project/opensearch-agent-skills@trace-analytics --full-depth
 npx skills add opensearch-project/opensearch-agent-skills@aws-setup --full-depth
@@ -69,6 +71,10 @@ After installing, try:
 
 > *"I want to build a semantic search app with OpenSearch"*
 
+For vector search operations, try:
+
+> *"My OpenSearch k-NN queries over 100M vectors are slow. Help me tune HNSW, shard count, and memory usage."*
+
 Your agent reads the skill instructions and runs the scripts directly — no MCP server required.
 
 ---
@@ -94,6 +100,10 @@ skills/
       opensearch-launchpad/           # Search app builder
         SKILL.md
         *.md                          # Model guides, evaluation, strategies
+      opensearch-vector-search/       # Vector search tuning and operations
+        SKILL.md
+        references/                    # k-NN, HNSW, quantization, sizing, query tuning
+        scripts/                       # Read-only analyzer and optional pricing lookup
     observability/                    # Category: Observability
       SKILL.md
       log-analytics/                  # Log querying & analysis

--- a/skills/opensearch-skills/SKILL.md
+++ b/skills/opensearch-skills/SKILL.md
@@ -24,6 +24,7 @@ This is the top-level skill for OpenSearch. It contains four category skills tha
 | Category | Skill | Install individually |
 |---|---|---|
 | [search](search/SKILL.md) | [opensearch-launchpad](search/opensearch-launchpad/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@opensearch-launchpad --full-depth` |
+| [search](search/SKILL.md) | [opensearch-vector-search](search/opensearch-vector-search/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@opensearch-vector-search --full-depth` |
 | [observability](observability/SKILL.md) | [log-analytics](observability/log-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@log-analytics --full-depth` |
 | [observability](observability/SKILL.md) | [trace-analytics](observability/trace-analytics/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@trace-analytics --full-depth` |
 | [cloud](cloud/SKILL.md) | [aws-setup](cloud/aws-setup/SKILL.md) | `npx skills add opensearch-project/opensearch-agent-skills@aws-setup --full-depth` |
@@ -37,6 +38,7 @@ Route to the right skill based on user intent:
 | User Intent | Skill |
 |---|---|
 | Build a search app, set up an index, choose a search strategy | [opensearch-launchpad](search/opensearch-launchpad/SKILL.md) |
+| Tune vector search, k-NN, HNSW, quantization, disk mode, capacity, latency, recall, or vector cost | [opensearch-vector-search](search/opensearch-vector-search/SKILL.md) |
 | Analyze logs, query with PPL, discover error patterns | [log-analytics](observability/log-analytics/SKILL.md) |
 | Investigate traces, debug spans, analyze service maps | [trace-analytics](observability/trace-analytics/SKILL.md) |
 | Deploy to AWS, provision a domain or collection | [aws-setup](cloud/aws-setup/SKILL.md) |
@@ -48,7 +50,7 @@ If the user's intent spans multiple skills (e.g., "build a search app and deploy
 
 ## Feedback Collection (Required Behavior)
 
-**This applies to ALL skills in this collection** — opensearch-launchpad, log-analytics, trace-analytics, and aws-setup. Regardless of which skill is active, you MUST follow these rules.
+**This applies to ALL skills in this collection** — opensearch-launchpad, opensearch-vector-search, log-analytics, trace-analytics, aws-setup, managed-ingestion-service, and document-processing. Regardless of which skill is active, you MUST follow these rules.
 
 You MUST proactively collect feedback during every interaction. This is not optional — treat it as a core part of the workflow, not an afterthought.
 

--- a/skills/opensearch-skills/search/SKILL.md
+++ b/skills/opensearch-skills/search/SKILL.md
@@ -21,6 +21,7 @@ Category skill for building search applications with OpenSearch.
 | Skill | Description |
 |---|---|
 | [opensearch-launchpad](opensearch-launchpad/SKILL.md) | End-to-end search application builder — from sample data to a running search UI with BM25, semantic, hybrid, or agentic search |
+| [opensearch-vector-search](opensearch-vector-search/SKILL.md) | Vector search tuning and operations — k-NN, HNSW, quantization, disk mode, sizing, cost, and read-only cluster analysis |
 
 ## When to Use
 
@@ -30,3 +31,10 @@ Read [opensearch-launchpad/SKILL.md](opensearch-launchpad/SKILL.md) when the use
 - Deploy ML models for semantic or hybrid search
 - Evaluate and tune search quality
 - Process documents (PDF, DOCX) for search ingestion
+
+Read [opensearch-vector-search/SKILL.md](opensearch-vector-search/SKILL.md) when the user wants to:
+- Tune an existing vector search or k-NN workload
+- Size vector memory, shards, replicas, or instances
+- Choose HNSW parameters, quantization, or disk mode
+- Optimize vector queries, filters, recall, latency, or cost
+- Analyze an existing vector search cluster in read-only mode

--- a/skills/opensearch-skills/search/opensearch-vector-search/SKILL.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: opensearch-vector-search
+description: >
+  Tune and operate OpenSearch vector search workloads. Use this skill for
+  k-NN, knn_vector, HNSW parameter tuning, vector query optimization,
+  quantization, disk mode, shard planning, vector memory sizing, capacity
+  planning, performance troubleshooting, cost optimization, or read-only
+  analysis of an existing vector search cluster. Prefer opensearch-launchpad
+  when the user wants to build a new end-to-end search app.
+compatibility: Requires Python 3.11+ and opensearch-py for live cluster analysis. Optional AWS pricing lookup requires boto3 and AWS credentials.
+metadata:
+  author: norrishuang
+  version: "1.0"
+---
+
+# OpenSearch Vector Search
+
+You are an OpenSearch vector search specialist. Help users design, tune, diagnose, and cost-optimize vector search workloads while keeping the workflow portable across self-managed OpenSearch, Docker, Kubernetes, Amazon OpenSearch Service, and OpenSearch Serverless unless the user asks for a provider-specific answer.
+
+## Key Rules
+
+- Keep live cluster work read-only. Never create, update, delete, or reconfigure indices or cluster settings from this skill.
+- Do not assume a cloud provider. Ask for the target distribution only when it affects the recommendation.
+- Prefer OpenSearch-native vector search features before proprietary dependencies.
+- For new search applications, route to [opensearch-launchpad](../opensearch-launchpad/SKILL.md). Use this skill for vector-specific tuning, sizing, diagnosis, and query optimization.
+- If using `scripts/get_opensearch_pricing.py`, tell the user it makes read-only AWS Pricing API calls and requires AWS credentials.
+- When exact syntax or version support matters, verify against the user's OpenSearch version or upstream OpenSearch documentation.
+
+## Reference Routing
+
+Read only the files needed for the user's question:
+
+| Need | File |
+|---|---|
+| k-NN mapping, HNSW, warmup, memory vs disk mode | [references/vector-search.md](references/vector-search.md) |
+| Binary, byte, FP16, product quantization | [references/quantization-techniques.md](references/quantization-techniques.md) |
+| Capacity planning, memory formulas, cost levers | [references/cost-optimization.md](references/cost-optimization.md) |
+| JVM, k-NN circuit breakers, thread pools, node roles | [references/cluster-tuning.md](references/cluster-tuning.md) |
+| Benchmark expectations, QPS, latency, recall tradeoffs | [references/performance-benchmarks.md](references/performance-benchmarks.md) |
+| Mappings, shards, replicas, lifecycle, indexing patterns | [references/indexing-strategies.md](references/indexing-strategies.md) |
+| Query DSL, filters, pagination, caches, aggregations | [references/query-optimization.md](references/query-optimization.md) |
+| Optimized instance families and OpenSearch-optimized storage tiers | [references/optimized-instances.md](references/optimized-instances.md) |
+
+## Workflows
+
+Run script commands from this skill directory so `scripts/...` resolves to the bundled leaf-skill scripts:
+
+```bash
+cd skills/opensearch-skills/search/opensearch-vector-search
+```
+
+If the skill is installed independently, the installed skill root is already the directory containing this `SKILL.md`. If the full OpenSearch skill tree is installed, resolve this directory from `search/opensearch-vector-search`.
+
+### Vector Configuration
+
+1. Collect version, vector count, dimension, similarity target, latency goal, recall goal, QPS, update rate, and deployment target.
+2. Read [references/vector-search.md](references/vector-search.md) and any relevant routing file.
+3. Recommend a mapping and query pattern with explicit tradeoffs for recall, memory, latency, and indexing throughput.
+4. Provide JSON examples for the user to apply; do not apply them automatically.
+
+### Capacity Planning
+
+1. Ask for vector count, dimensions, replicas, target latency, target recall, and whether compression or disk mode is acceptable.
+2. Read [references/cost-optimization.md](references/cost-optimization.md) and [references/quantization-techniques.md](references/quantization-techniques.md) if compression is in scope.
+3. Estimate memory with HNSW graph overhead, replicas, and safety headroom.
+4. Compare at least two options: an in-memory low-latency design and a compressed or disk-mode lower-cost design.
+5. Keep the primary recommendation vendor-neutral. Add provider-specific instance or pricing details only when the user asks or gives a cloud target.
+
+### Query Optimization
+
+1. Ask for the mapping, query body, target latency, and whether filters are pre-filter or post-filter.
+2. Read [references/query-optimization.md](references/query-optimization.md).
+3. Recommend changes to `k`, `ef_search`, filters, shard count, caching, pagination, and result reranking as applicable.
+4. If the user provides an endpoint, offer to validate read-only with `_search` or the analyzer script before making strong claims.
+
+### Read-Only Cluster Analysis
+
+Run the analyzer only after the user provides an endpoint and confirms that read-only inspection is acceptable.
+
+```bash
+uv run python scripts/analyze_cluster.py --url <url> --username <user> --password <pass> --action cluster-overview --format pretty
+uv run python scripts/analyze_cluster.py --url <url> --username <user> --password <pass> --action index-detail --index <index> --format pretty
+uv run python scripts/analyze_cluster.py --url <url> --username <user> --password <pass> --action shard-analysis --index <index> --format pretty
+```
+
+For unauthenticated local clusters:
+
+```bash
+uv run python scripts/analyze_cluster.py --url http://localhost:9200 --no-auth --action all --format pretty
+```
+
+Interpret the JSON output for the user:
+
+- Cluster health, version, and node resource pressure
+- k-NN stats, cache behavior, and circuit breaker signals
+- Vector field mappings, dimensions, engine, method, and compression
+- Estimated memory requirements vs available capacity
+- Shard distribution and sizing risks
+
+## Optional AWS Pricing Lookup
+
+Use this only for Amazon OpenSearch Service cost questions:
+
+```bash
+uv run python scripts/get_opensearch_pricing.py --region us-east-1 --instance-type r7g.xlarge --format json
+```
+
+If `boto3` or AWS credentials are missing, give the user the sizing math and explain what pricing input is still needed.
+
+## Response Shape
+
+For recommendations, keep the answer actionable:
+
+1. Requirements and assumptions
+2. Memory or latency calculation
+3. Recommended configuration
+4. Tradeoffs and alternatives
+5. Validation steps the user can run safely

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/cluster-tuning.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/cluster-tuning.md
@@ -1,0 +1,455 @@
+# Cluster Configuration and Tuning
+
+## Core Concepts
+
+OpenSearch cluster performance depends on hardware resource configuration, JVM settings, node role assignment, and operating system optimization. Proper cluster architecture and resource allocation are the foundation for ensuring high availability and high performance.
+
+## Common Issues
+
+### Issue 1: JVM Heap Memory Configuration
+
+**Symptoms**:
+- Frequent GC (garbage collection)
+- OutOfMemoryError
+- Degraded query and indexing performance
+- Node instability
+
+**Cause**:
+Improper JVM heap memory configuration leads to frequent GC or out-of-memory conditions.
+
+**Solution**:
+
+1. Set heap memory size (jvm.options):
+```bash
+# Set to 50% of physical memory, but no more than 32GB
+-Xms16g
+-Xmx16g
+```
+
+2. Configure GC parameters:
+```bash
+# Use G1GC (recommended)
+-XX:+UseG1GC
+-XX:G1ReservePercent=25
+-XX:InitiatingHeapOccupancyPercent=30
+```
+
+3. Monitor GC logs:
+```bash
+-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/opensearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+```
+
+**Best Practices**:
+- Set heap memory to 50% of physical memory
+- Do not exceed 32GB (compressed oops limit)
+- Set Xms and Xmx to the same value (avoid dynamic resizing)
+- Reserve 50% of memory for the OS page cache
+- Use the G1GC garbage collector
+- Monitor GC frequency and pause times
+
+### Issue 2: Node Role Assignment
+
+**Symptoms**:
+- Unbalanced cluster load
+- Some nodes overloaded
+- Queries and indexing interfering with each other
+
+**Cause**:
+Having all nodes serve all roles leads to resource contention.
+
+**Solution**:
+
+1. Dedicated master node:
+```yaml
+# opensearch.yml
+node.roles: [cluster_manager]
+node.name: master-node-1
+```
+
+2. Dedicated data node:
+```yaml
+# opensearch.yml
+node.roles: [data, ingest]
+node.name: data-node-1
+```
+
+3. Dedicated coordinating node:
+```yaml
+# opensearch.yml
+node.roles: []
+node.name: coordinating-node-1
+```
+
+4. Recommended cluster architectures:
+```
+Small cluster (< 10 nodes):
+- 3 master nodes
+- N data nodes (data + ingest)
+
+Medium cluster (10-50 nodes):
+- 3 dedicated master nodes
+- N data nodes
+- 2-3 coordinating nodes
+
+Large cluster (> 50 nodes):
+- 3 dedicated master nodes
+- N hot data nodes
+- M warm data nodes
+- 3-5 coordinating nodes
+```
+
+**Best Practices**:
+- Use an odd number of master nodes (3, 5, 7)
+- Master nodes should not handle data or query tasks
+- Data nodes should focus on storage and queries
+- Coordinating nodes handle client requests and aggregations
+- Use node labels to implement data tiering (hot/warm/cold)
+
+### Issue 3: Shard Allocation and Balancing
+
+**Symptoms**:
+- Uneven disk usage across nodes
+- Some nodes under excessive load
+- Shard allocation failures
+
+**Cause**:
+Improper shard allocation strategies or disk watermark thresholds being triggered.
+
+**Solution**:
+
+1. Configure disk watermarks:
+```yaml
+# opensearch.yml
+cluster.routing.allocation.disk.threshold_enabled: true
+cluster.routing.allocation.disk.watermark.low: 85%
+cluster.routing.allocation.disk.watermark.high: 90%
+cluster.routing.allocation.disk.watermark.flood_stage: 95%
+```
+
+2. Manually allocate shards:
+```bash
+POST /_cluster/reroute
+{
+  "commands": [
+    {
+      "move": {
+        "index": "my_index",
+        "shard": 0,
+        "from_node": "node1",
+        "to_node": "node2"
+      }
+    }
+  ]
+}
+```
+
+3. Configure shard allocation strategy:
+```yaml
+# opensearch.yml
+cluster.routing.allocation.awareness.attributes: zone
+cluster.routing.allocation.awareness.force.zone.values: zone1,zone2
+```
+
+4. Rebalance shards:
+```bash
+PUT /_cluster/settings
+{
+  "transient": {
+    "cluster.routing.rebalance.enable": "all"
+  }
+}
+```
+
+**Best Practices**:
+- Set reasonable disk watermarks (85%/90%/95%)
+- Use shard allocation awareness (zone awareness)
+- Avoid too many shards on a single node (< 1000)
+- Regularly monitor shard distribution
+- Use allocation filtering to control shard placement
+
+### Issue 4: Thread Pool Configuration
+
+**Symptoms**:
+- Requests being rejected
+- Thread pool queues full
+- High query or indexing latency
+
+**Cause**:
+Thread pool sizes insufficient to handle concurrent requests.
+
+**Solution**:
+
+1. Check thread pool status:
+```bash
+GET /_cat/thread_pool?v&h=node_name,name,active,queue,rejected
+```
+
+2. Adjust thread pool sizes:
+```yaml
+# opensearch.yml
+thread_pool:
+  search:
+    size: 30
+    queue_size: 1000
+  write:
+    size: 30
+    queue_size: 1000
+```
+
+3. Dynamic adjustment (temporary):
+```bash
+PUT /_cluster/settings
+{
+  "transient": {
+    "thread_pool.search.queue_size": 2000
+  }
+}
+```
+
+**Thread Pool Types**:
+- `search`: Search requests
+- `write`: Index, update, and delete requests
+- `get`: Get requests
+- `analyze`: Analyze requests
+- `snapshot`: Snapshot operations
+
+**Best Practices**:
+- search thread pool: CPU cores × 1.5
+- write thread pool: CPU cores
+- Queue size: 1000-2000
+- Monitor the rejected metric
+- Avoid unlimited queues (may cause OOM)
+
+### Issue 5: Network and Transport Configuration
+
+**Symptoms**:
+- Slow inter-node communication
+- Delayed cluster state updates
+- Network timeouts
+
+**Cause**:
+Improper network configuration or insufficient bandwidth.
+
+**Solution**:
+
+1. Configure network settings:
+```yaml
+# opensearch.yml
+network.host: 0.0.0.0
+http.port: 9200
+transport.port: 9300
+
+# Compress transport data
+transport.compress: true
+
+# Timeout settings
+cluster.publish.timeout: 30s
+discovery.request_peers_timeout: 10s
+```
+
+2. Configure TCP parameters:
+```yaml
+# opensearch.yml
+transport.tcp.keep_alive: true
+transport.tcp.reuse_address: true
+```
+
+3. Operating system optimization:
+```bash
+# /etc/sysctl.conf
+net.core.somaxconn = 65535
+net.ipv4.tcp_max_syn_backlog = 8192
+net.ipv4.tcp_tw_reuse = 1
+```
+
+**Best Practices**:
+- Use a dedicated network for inter-node communication
+- Enable transport compression (transport.compress)
+- Configure reasonable timeout values
+- Monitor network latency and bandwidth usage
+- Use high-speed networking (10Gbps+)
+
+## Configuration Examples
+
+### Production Environment Configuration (opensearch.yml)
+
+```yaml
+# Cluster configuration
+cluster.name: production-cluster
+node.name: data-node-1
+node.roles: [data, ingest]
+
+# Network configuration
+network.host: 0.0.0.0
+http.port: 9200
+transport.port: 9300
+transport.compress: true
+
+# Discovery configuration
+discovery.seed_hosts: ["master-1:9300", "master-2:9300", "master-3:9300"]
+cluster.initial_cluster_manager_nodes: ["master-1", "master-2", "master-3"]
+
+# Path configuration
+path.data: /var/lib/opensearch
+path.logs: /var/log/opensearch
+
+# Memory configuration
+bootstrap.memory_lock: true
+
+# Shard allocation
+cluster.routing.allocation.disk.threshold_enabled: true
+cluster.routing.allocation.disk.watermark.low: 85%
+cluster.routing.allocation.disk.watermark.high: 90%
+cluster.routing.allocation.disk.watermark.flood_stage: 95%
+
+# Thread pools
+thread_pool:
+  search:
+    size: 30
+    queue_size: 1000
+  write:
+    size: 30
+    queue_size: 1000
+
+# Security configuration
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.transport.enabled: true
+```
+
+### JVM Configuration (jvm.options)
+
+```bash
+# Heap memory (set to 50% of physical memory, no more than 32GB)
+-Xms16g
+-Xmx16g
+
+# GC configuration
+-XX:+UseG1GC
+-XX:G1ReservePercent=25
+-XX:InitiatingHeapOccupancyPercent=30
+
+# GC logging
+-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/opensearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+
+# Heap dump (on OOM)
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:HeapDumpPath=/var/log/opensearch/heapdump.hprof
+
+# Performance optimization
+-XX:+AlwaysPreTouch
+-Djava.io.tmpdir=/tmp
+```
+
+### Operating System Configuration
+
+```bash
+# /etc/security/limits.conf
+opensearch soft nofile 65535
+opensearch hard nofile 65535
+opensearch soft memlock unlimited
+opensearch hard memlock unlimited
+
+# /etc/sysctl.conf
+vm.max_map_count=262144
+vm.swappiness=1
+net.core.somaxconn=65535
+net.ipv4.tcp_max_syn_backlog=8192
+```
+
+## Performance Monitoring
+
+### Key Metrics
+
+1. **Cluster Health**:
+```bash
+GET /_cluster/health
+```
+
+2. **Node Statistics**:
+```bash
+GET /_nodes/stats
+```
+
+3. **Thread Pool Status**:
+```bash
+GET /_cat/thread_pool?v
+```
+
+4. **Shard Allocation**:
+```bash
+GET /_cat/shards?v
+```
+
+5. **JVM Memory**:
+```bash
+GET /_nodes/stats/jvm
+```
+
+### Alert Thresholds
+
+- Cluster status: not green
+- JVM heap usage: > 85%
+- GC time ratio: > 10%
+- Disk usage: > 85%
+- Thread pool rejection rate: > 1%
+- Query latency: > 500ms
+- Indexing latency: > 1s
+
+## Capacity Planning
+
+### Hardware Recommendations
+
+**Data Nodes**:
+- CPU: 16-32 cores
+- Memory: 64-128 GB
+- Disk: SSD, 1-4 TB
+- Network: 10 Gbps
+
+**Master Nodes**:
+- CPU: 4-8 cores
+- Memory: 8-16 GB
+- Disk: SSD, 100-200 GB
+- Network: 1-10 Gbps
+
+**Coordinating Nodes**:
+- CPU: 8-16 cores
+- Memory: 32-64 GB
+- Disk: SSD, 100-200 GB
+- Network: 10 Gbps
+
+### Capacity Calculation
+
+```
+Number of data nodes = (total data size × (1 + replica count)) / (per-node disk capacity × 0.7)
+Number of master nodes = 3 (fixed)
+Number of coordinating nodes = max(2, number of data nodes / 10)
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Cluster status yellow**:
+   - Check if replica shards are unassigned
+   - Check if there are enough nodes
+
+2. **Cluster status red**:
+   - Check if primary shards are missing
+   - Check if nodes are offline
+   - Review shard allocation failure reasons
+
+3. **Nodes frequently restarting**:
+   - Check for JVM OOM
+   - Check disk space
+   - Review system logs
+
+4. **Slow queries**:
+   - Check slow query logs
+   - Analyze query structure
+   - Check cache hit rates
+
+## Reference Resources
+
+- [OpenSearch Cluster Configuration](https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/)
+- [Performance Tuning Guide](https://opensearch.org/docs/latest/tuning-your-cluster/)
+- [Capacity Planning](https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/cluster-manager/)

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/cost-optimization.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/cost-optimization.md
@@ -1,0 +1,1754 @@
+---
+name: vector-search-cost-optimization
+description: OpenSearch vector search cost optimization guide
+metadata:
+  short-description: OpenSearch Vector Search Technical Expert
+  compatibility: claude-4
+  license: Apache-2.0
+---
+
+# OpenSearch Vector Search Cost Optimization Guide
+
+## Core Concepts
+
+The cost of OpenSearch vector search mainly consists of compute resources, storage resources, and data transfer. On Amazon OpenSearch Service these map to domain instances, EBS or local storage, and network transfer; on self-managed OpenSearch or Kubernetes they map to node CPU, memory, disk, and network capacity. Through proper architecture design and configuration optimization, you can significantly reduce operational cost while maintaining good performance.
+
+**Portable Baseline Configuration**:
+- **Vector Engine**: FAISS for most production workloads; keep nmslib only for legacy compatibility.
+- **Similarity Algorithm**: cosine for normalized embeddings and common semantic-search workloads; choose L2 or inner product when the embedding model requires it.
+- **Node Shape**: Prefer current-generation CPU, enough RAM for k-NN graph/cache headroom, and storage with predictable IOPS. For Amazon OpenSearch Service examples in this guide, r7g/r8g/r8gd and OpenSearch-optimized families are used as concrete reference points; for self-managed or Kubernetes deployments, map the same resource profile to your platform.
+
+<!-- FALLBACK: aws-pricing, priority=1, condition="cost-related" -->
+
+## Cost Optimization Techniques Overview
+
+### 1. Disk-Based Vector Search
+
+#### 1.1 Technical Principles
+
+Disk mode is a revolutionary feature introduced in OpenSearch 2.17. By storing full-precision vectors on disk while using compressed vectors in memory for searching, it achieves the optimal balance between cost and performance. This approach combines real-time native quantization with a two-stage search mechanism.
+
+**Core Mechanism**:
+1. **Storage Separation**: Full-precision vectors stored on disk, compressed vectors loaded into memory
+2. **Real-time Quantization**: Automatic scalar quantization during indexing, no preprocessing required
+3. **Two-stage Search**:
+   - Stage 1: Fast filtering using compressed vectors in memory
+   - Stage 2: Loading full-precision vectors from disk for precise computation
+
+**Cost Advantages**:
+- Memory requirements reduced by 32× (using 32× compression)
+- Allows use of smaller instance types
+- Overall cost reduction of 50-80%
+- Supports larger-scale vector datasets
+
+#### 1.2 Configuration Options Explained
+
+**Basic Configuration**:
+```json
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "my_vector_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "innerproduct",
+        "data_type": "float",
+        "mode": "on_disk"  // Enable disk mode
+      }
+    }
+  }
+}
+```
+
+**Advanced Configuration**:
+```json
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "my_vector_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "innerproduct",
+        "data_type": "float",
+        "mode": "on_disk",
+        "compression_level": "16x",  // Options: 2x, 4x, 8x, 16x, 32x
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "cosine",
+          "parameters": {
+            "ef_construction": 512  // Index build parameter
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### 1.3 Compression Level Selection
+
+Disk mode supports multiple compression levels, each corresponding to a different scalar quantization method:
+
+| Compression Level | Quantization Method | Bits | Recall Impact | Recommended Scenario |
+|----------|----------|------|------------|----------|
+| 2x | FP16 | 16-bit | < 2% | High precision requirements |
+| 4x | Byte/Int8 | 8-bit | < 5% | Recommended for production |
+| 8x | 4-bit | 4-bit | 5-10% | Balanced performance and cost |
+| 16x | 2-bit | 2-bit | 10-15% | Cost-first |
+| 32x | Binary | 1-bit | 15-20% | Maximum cost optimization |
+
+**Default Configuration**: If only `mode: "on_disk"` is set, the system will use:
+- Engine: FAISS (recommended)
+- Method: HNSW
+- Similarity Algorithm: cosine (recommended)
+- Compression Level: 32x (1-bit binary quantization)
+- ef_construction: 100
+
+#### 1.4 Two-Stage Search Optimization
+
+To compensate for recall loss caused by quantization, disk mode supports two-stage search:
+
+**Search Configuration**:
+```json
+{
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [1.5, 2.5, 3.5, ...],
+        "k": 5,
+        "method_parameters": {
+          "ef_search": 512  // Stage 1 search depth
+        },
+        "rescore": {
+          "oversample_factor": 10.0  // Rescoring factor
+        }
+      }
+    }
+  }
+}
+```
+
+**How oversample_factor Works**:
+1. Stage 1: Retrieve `oversample_factor × k` results (using compressed vectors)
+2. Stage 2: Load full-precision vectors from disk for these results
+3. Recompute exact scores and return top-k results
+
+**Default oversample_factor Settings**:
+
+| Vector Dimension | Compression Level | Default Factor | Notes |
+|----------|----------|----------|------|
+| < 1000 | All levels | 5 | Fixed value |
+| ≥ 1000 | 32x | 3 | High compression needs more rescoring |
+| ≥ 1000 | 16x, 8x | 2 | Medium compression |
+| ≥ 1000 | 4x, 2x | No default | Low compression doesn't need rescoring |
+
+#### 1.5 Performance Characteristics Analysis
+
+**Latency Breakdown**:
+```
+Total Latency = Stage 1 Latency + Disk I/O Latency + Stage 2 Computation Latency
+
+Stage 1 Latency: 10-30ms (compressed vector search in memory)
+Disk I/O Latency: 50-150ms (depends on EBS performance and oversample_factor)
+Stage 2 Latency: 5-20ms (full-precision vector recomputation)
+```
+
+**QPS Impact Factors**:
+1. **EBS IOPS**: Directly affects disk read performance
+2. **oversample_factor**: Higher factor requires more disk I/O
+3. **Compression Level**: Higher compression needs more rescoring
+4. **Concurrent Queries**: Disk I/O is the bottleneck
+
+#### 1.6 EBS Configuration Optimization
+
+**Recommended EBS Configuration**:
+```json
+{
+  "ebs_options": {
+    "ebs_enabled": true,
+    "volume_type": "gp3",
+    "volume_size": 1000,      // Adjust based on data volume
+    "iops": 16000,            // Maximum IOPS
+    "throughput": 1000        // Maximum throughput MB/s
+  }
+}
+```
+
+**IOPS Requirement Estimation**:
+```
+Required IOPS = QPS × oversample_factor × k × vector_size(KB) / 4KB
+
+Example:
+- QPS: 50
+- oversample_factor: 10
+- k: 10
+- Vector size: 768 × 4 bytes = 3KB
+- Required IOPS: 50 × 10 × 10 × 3/4 = 3,750 IOPS
+```
+
+**Amazon OpenSearch Service Storage Example** (gp3 vs gp2):
+- gp3: $0.08/GB/month + $0.005/IOPS/month (above 3000 IOPS)
+- gp2: $0.10/GB/month, performance tied to capacity
+- **Recommendation**: Prefer gp3 when using EBS-backed Amazon OpenSearch Service domains because it decouples capacity from IOPS and can reduce storage cost. For self-managed deployments, choose the storage class that provides the required IOPS and throughput with predictable latency.
+
+#### 1.7 Actual Performance Test Data
+
+**Test Environment**: 100M vectors, 768 dimensions, 5-node cluster
+
+| Configuration | Instance Type | Compression Level | QPS | P95 Latency | Recall | Monthly Cost |
+|------|----------|----------|-----|---------|--------|----------|
+| In-memory mode | 2×r8g.16xlarge | None | 2,500+ | 10ms | 0.99+ | $4,934 |
+| Disk mode | 5×r8g.xlarge | 8x | 120 | 85ms | 0.95+ | $1,540 |
+| Disk mode | 5×r8g.xlarge | 16x | 95 | 95ms | 0.92+ | $1,540 |
+| Disk mode | 5×r8g.xlarge | 32x | 73 | 114ms | 0.90+ | $1,540 |
+
+**Note**: All tests used the FAISS engine and cosine similarity algorithm. Instance families shown here are Amazon OpenSearch Service examples; use the CPU, memory, and IO profile rather than the brand name as the portable sizing signal.
+
+**Cost Savings**: 68-69% (disk mode vs in-memory mode)
+
+#### 1.8 Use Case Analysis
+
+**Best-fit Scenarios**:
+- Batch processing and offline analytics
+- Applications that can tolerate 100-200ms latency
+- Large-scale vector datasets (> 50M vectors)
+- Cost-sensitive MVPs and development environments
+- Low query frequency applications (< 100 QPS)
+
+**Not Suitable For**:
+- Real-time recommendation systems (requiring < 20ms latency)
+- High-frequency query applications (> 500 QPS)
+- Applications extremely sensitive to recall
+- User-facing scenarios requiring ultra-low latency
+
+#### 1.9 Deployment Best Practices
+
+**Cluster Configuration Recommendations**:
+```json
+{
+  "cluster_config": {
+    "instance_type": "r8g.xlarge",     // Memory-optimized instances
+    "instance_count": 5,               // Increase nodes for better concurrency
+    "dedicated_master_enabled": true,
+    "master_instance_type": "r8g.medium",
+    "master_instance_count": 3
+  },
+  "ebs_options": {
+    "volume_type": "gp3",
+    "volume_size": 500,                // 500GB per node
+    "iops": 9000,                      // High IOPS configuration
+    "throughput": 500
+  }
+}
+```
+
+**Index Configuration Recommendations**:
+```json
+{
+  "settings": {
+    "number_of_shards": 10,            // Increase shard count for better concurrency
+    "number_of_replicas": 1,
+    "index.knn": true,
+    "index.refresh_interval": "30s"    // Reduce refresh frequency
+  }
+}
+```
+
+**Monitoring Metrics**:
+- EBS IOPS utilization: < 80%
+- EBS throughput utilization: < 80%
+- Query latency P95: < 200ms
+- Recall: > 90%
+- Disk utilization: < 85%
+
+### 2. Quantization Compression Techniques Explained
+
+OpenSearch supports four main quantization techniques, each with different compression ratios, performance characteristics, and applicable scenarios. Quantization is a lossy compression technique that reduces memory usage and computational requirements by mapping high-precision values to smaller discrete values.
+
+#### 2.1 Binary Quantization
+
+**Technical Principles**:
+Binary quantization is a type of scalar quantization that compresses 32-bit floating-point numbers to 1-4 bit binary representations. OpenSearch uses FAISS engine's binary quantization, performing native training during indexing without requiring additional preprocessing steps.
+
+**Compression Ratio**: Up to 32× (1-bit)
+**Memory Savings**: 96.9%
+**Recall Impact**: 15-20% decrease
+
+**Configuration Options**:
+- 1-bit: 32× compression, maximum memory savings
+- 2-bit: 16× compression, balanced compression and precision
+- 4-bit: 8× compression, better precision retention
+
+**Configuration Example**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "cosine",
+          "parameters": {
+            "m": 16,
+            "ef_construction": 512,
+            "encoder": {
+              "name": "binary",
+              "parameters": {
+                "bits": 1  // 1, 2, or 4
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Memory Requirement Formula**:
+```
+Memory = 1.1 × (bits × (d/8) + 8 × m) × num_vectors bytes × replica_num
+```
+
+**Performance Comparison Table** (1 billion vectors, 384 dimensions, m=16):
+
+| Encoding Bits | Compression Ratio | Memory Required (GB) | Use Case |
+|----------|--------|---------------|----------|
+| 1-bit | 32× | 193.6 | Maximum cost optimization |
+| 2-bit | 16× | 246.4 | Balanced compression and precision |
+| 4-bit | 8× | 352.0 | Recommended for production |
+
+**Applicable Scenarios**:
+- Extremely memory-constrained environments
+- Applications that can accept some recall loss
+- Scenarios requiring maximum cost savings
+- High-dimensional vectors (≥768 dimensions) perform better
+
+#### 2.2 Byte Quantization
+
+**Technical Principles**:
+Compresses 32-bit floating-point numbers to 8-bit integers (-128 to +127), reducing memory usage by 75%. Requires vector conversion before data import, or uses the built-in quantization in disk mode.
+
+**Compression Ratio**: 4×
+**Memory Savings**: 75%
+**Recall Impact**: < 5%
+
+**Configuration Example**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "data_type": "byte",  // Key configuration
+        "space_type": "cosine",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 512,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Memory Requirement Formula**:
+```
+Memory = 1.1 × (1 × d + 8 × m) × num_vectors bytes × replica_num
+```
+
+**Applicable Scenarios**:
+- Production environments requiring high precision
+- Applications with strict recall requirements
+- Medium-scale vector datasets
+
+#### 2.3 FP16 Quantization (Half-Precision Floating Point)
+
+**Technical Principles**:
+Uses 16-bit floating-point numbers instead of 32-bit floating-point numbers, cutting memory usage in half. Vector dimension values must be within the range [-65504.0, 65504.0].
+
+**Compression Ratio**: 2×
+**Memory Savings**: 50%
+**Recall Impact**: < 2% (nearly lossless)
+
+**Configuration Example**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "cosine",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "encoder": {
+              "name": "sq",
+              "parameters": {
+                "type": "fp16",
+                "clip": true  // Automatically clip values outside range
+              }
+            },
+            "ef_construction": 256,
+            "m": 8
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Memory Requirement Formula**:
+```
+Memory = 1.1 × (2 × d + 8 × m) × num_vectors bytes × replica_num
+```
+
+**Applicable Scenarios**:
+- Applications with extremely high precision requirements
+- Conservative cost optimization strategies
+- Datasets with vector values within the supported range
+
+#### 2.4 Product Quantization
+
+**Technical Principles**:
+Divides vectors into m sub-vectors, each encoded with code_size bits. This is the most complex but highest compression ratio technique, achieving up to 64× compression. Requires a training process to build the quantizer model.
+
+**Compression Ratio**: Up to 64×
+**Memory Savings**: Up to 98.4%
+**Recall Impact**: Depends on training data quality
+
+**Implementation Steps**:
+
+1. **Create Training Index**:
+```json
+PUT /train-index
+{
+  "mappings": {
+    "properties": {
+      "train-field": {
+        "type": "knn_vector",
+        "dimension": 768
+      }
+    }
+  }
+}
+```
+
+2. **Train Quantizer Model**:
+```json
+POST /_plugins/_knn/models/my-pq-model/_train
+{
+  "training_index": "train-index",
+  "training_field": "train-field",
+  "dimension": 768,
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "code_size": 8,  // Encoding bits per sub-vector
+          "m": 96          // Number of sub-vectors (768/8 = 96)
+        }
+      },
+      "ef_construction": 256,
+      "m": 8
+    }
+  }
+}
+```
+
+3. **Create Production Index**:
+```json
+PUT /my-vector-index
+{
+  "mappings": {
+    "properties": {
+      "target-field": {
+        "type": "knn_vector",
+        "model_id": "my-pq-model"
+      }
+    }
+  }
+}
+```
+
+**Memory Requirement Formula**:
+```
+Memory = 1.1 × ((code_size/8) × m + 24 + 8 × m) × num_vectors bytes × replica_num
+```
+
+**Configuration Parameter Notes**:
+- `code_size`: Encoding bits per sub-vector (typically 8)
+- `m`: Number of sub-vectors (typically dimension/8)
+- Training dataset requires at least 256 documents (2^code_size)
+
+**Applicable Scenarios**:
+- Ultra-large-scale vector datasets (> 100 million vectors)
+- Maximum cost optimization requirements
+- Scenarios with sufficient training data
+- Environments that can accept complex deployment processes
+
+#### 2.5 Quantization Technique Performance Comparison
+
+**Comprehensive Performance Comparison Table** (1 billion vectors, 384 dimensions):
+
+| Quantization Technique | Compression Ratio | Memory (GB) | Recall | Latency | Preprocessing | Complexity |
+|----------|--------|-----------|--------|------|--------|--------|
+| No compression | 1× | 1830.4 | 0.99+ | < 50ms | None | Low |
+| FP16 | 2× | 985.6 | 0.95+ | < 50ms | None | Low |
+| Byte | 4× | 563.2 | 0.95+ | < 50ms | None | Low |
+| Binary (1-bit) | 32× | 193.6 | 0.90+ | < 200ms | None | Medium |
+| Product | 64× | 184.8 | 0.70+ | < 50ms | Required | High |
+
+**Cost-Effectiveness Analysis** (based on $X baseline cost):
+
+| Quantization Technique | Monthly Cost | Cost Savings | Recommended Scenario |
+|----------|----------|----------|----------|
+| No compression | $X | 0% | Performance-first |
+| FP16 | $0.5X | 50% | Conservative optimization |
+| Byte | $0.25X | 75% | Production recommended |
+| Binary | $0.15X | 85% | Cost-first |
+| Product | $0.1X | 90% | Maximum optimization |
+
+#### 2.6 Quantization Technique Selection Guide
+
+**Decision Flow Chart**:
+```
+Need maximum cost optimization?
+├─ Yes → Have sufficient training data?
+│   ├─ Yes → Product Quantization (90% savings)
+│   └─ No → Binary Quantization (85% savings)
+└─ No → Can accept 5% recall loss?
+    ├─ Yes → Byte Quantization (75% savings)
+    └─ No → FP16 Quantization (50% savings)
+```
+
+**Best Practice Recommendations**:
+
+1. **Production Environment First Choice**: Byte Quantization (4×)
+   - Minimal recall loss (< 5%)
+   - Simple implementation, no preprocessing required
+   - Significant cost savings (75%)
+
+2. **Maximum Cost Optimization**: Binary Quantization (32×)
+   - Suitable for batch processing scenarios
+   - Need to evaluate recall impact
+   - Works better when combined with disk mode
+
+3. **Conservative Optimization**: FP16 Quantization (2×)
+   - Nearly zero recall loss
+   - Suitable for scenarios with extremely high precision requirements
+   - Simplest implementation
+
+4. **Ultra-Large Scale**: Product Quantization (64×)
+   - Requires a specialized team to implement
+   - Suitable for > 1 billion vector scenarios
+   - Requires sufficient training data
+
+### 3. Node and Instance Selection Strategy
+
+#### Memory-Optimized Nodes - Low-Latency Vector Search
+
+**Characteristics**:
+- High memory capacity for in-memory HNSW graphs and k-NN cache
+- Suitable for in-memory mode vector search
+- Current-generation CPUs usually provide the best latency and price-performance
+- Amazon OpenSearch Service examples include r7g/r8g/r8gd; self-managed examples include any equivalent memory-optimized node class
+
+**Recommended Scenarios**:
+- Low latency requirements (< 10ms)
+- High QPS requirements (> 1000)
+- Production environment critical services
+
+**Amazon OpenSearch Service Cost Examples**:
+- r8g.xlarge: $154/month (16GB memory)
+- r8g.2xlarge: $308/month (32GB memory)
+- r8g.4xlarge: $617/month (64GB memory)
+- r8g.16xlarge: $2,467/month (256GB memory)
+- Treat these as example price points; verify current regional pricing before committing to a design
+
+#### OpenSearch-Optimized Instances (OR2/OM2/OI2) - AWS-Specific Examples
+
+**Characteristics**:
+- Instance types optimized specifically for Amazon OpenSearch Service
+- Higher network performance and storage throughput
+- Useful for some large-scale OpenSearch workloads, with vector-specific caveats
+
+**Recommended Scenarios**:
+- Large-scale production environments (> 50M vectors)
+- Indexing-heavy or mixed workloads that benefit from managed storage behavior
+- Workloads where the refresh interval and storage architecture match the latency target
+
+**Recommendation**: Start from workload requirements: memory for the graph, CPU for query concurrency, storage IOPS for disk mode, and refresh/ingest requirements. Then map those requirements to the best available node or instance family on the target platform.
+
+### 4. Storage Layer Optimization
+
+#### EBS Volume Type Selection
+
+**gp3 (General Purpose SSD)**:
+- Baseline performance: 3,000 IOPS, 125 MB/s
+- Scalable to: 16,000 IOPS, 1,000 MB/s
+- Cost: $0.08/GB/month + additional IOPS/throughput charges
+- **Recommended for**: Disk-mode vector search
+
+**gp2 (General Purpose SSD - Legacy)**:
+- Performance tied to capacity: 3 IOPS/GB
+- Cost: $0.10/GB/month
+- **Not recommended**: Superseded by gp3
+
+**io2 (High-Performance SSD)**:
+- Up to 64,000 IOPS
+- Cost: $0.125/GB/month + $0.065/IOPS/month
+- **Recommended for**: Ultra-high performance requirement scenarios
+
+**Cost Optimization Recommendations**:
+- Use gp3 instead of gp2 (saves 20%)
+- Increase IOPS only when needed (pay-as-you-go)
+- Monitor IOPS utilization to avoid over-provisioning
+
+#### UltraWarm Storage Tier
+
+**Characteristics**:
+- S3-based low-cost storage
+- Suitable for cold data and archiving
+- 90% cost reduction
+
+**Applicable Scenarios**:
+- Historical vector data archiving
+- Infrequently accessed vector indices
+- Long-term data retention
+
+**Cost Comparison**:
+- Hot storage (gp3): $0.08/GB/month
+- UltraWarm: $0.024/GB/month
+- Savings: **70%**
+
+**Limitations**:
+- Higher query latency
+- Does not support real-time writes
+- Requires data migration process
+
+### 5. Shard and Replica Strategy
+
+#### Shard Count Optimization
+
+**Principles**:
+- Too few shards: Cannot fully utilize cluster resources
+- Too many shards: Increases management overhead and memory usage
+
+**Recommended Formula**:
+```
+Number of shards = Number of data nodes × 1.5 to 2
+```
+
+**Examples**:
+- 3-node cluster: 4-6 shards
+- 5-node cluster: 7-10 shards
+
+**Cost Impact**:
+- Each shard consumes approximately 10-50MB of memory
+- Too many shards may require larger instances
+
+#### Replica Count Optimization
+
+**Development Environment**:
+- Replicas: 0
+- Cost savings: 50%
+- Risk: No high availability
+
+**Production Environment**:
+- Replicas: 1 (recommended)
+- Cost increase: 100%
+- Benefits: High availability + improved read performance
+
+**High-Availability Environment**:
+- Replicas: 2
+- Cost increase: 200%
+- Benefits: Fault tolerance across 3 AZs
+
+**Cost Optimization Recommendations**:
+- Use 0 replicas for development/test environments
+- Use 1 replica for production environments
+- Use 2 replicas only for critical services
+
+## Quantization Technique Performance Benchmarks
+
+### Benchmark Environment
+
+**Test Dataset**:
+- Vector count: 1 million
+- Vector dimensions: 1024
+- Data type: sentence-transformers/all-MiniLM-L12-v2 embeddings
+- Query set: 1000 random query vectors
+- Ground truth: Top-100 nearest neighbors for each query
+
+**Test Cluster**:
+- Instance type: r8g.2xlarge (8 vCPU, 64GB RAM)
+- Node count: 3
+- OpenSearch version: 2.17
+- Shard configuration: 8 shards, 0 replicas
+
+### Detailed Performance Comparison
+
+#### No Compression Baseline
+
+**Configuration**:
+```json
+{
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "space_type": "cosine",
+    "parameters": {
+      "ef_construction": 512,
+      "m": 16
+    }
+  }
+}
+```
+
+**Performance Metrics**:
+- Index size: 8.7 MB
+- Memory usage: 13.1 MB (including graph structure)
+- Indexing time: 45 seconds
+- QPS: 4,889
+- P95 latency: 6.5ms
+- Recall@100: 0.970
+
+#### Binary Quantization (1-bit)
+
+**Configuration**:
+```json
+{
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "binary",
+        "parameters": {
+          "bits": 1
+        }
+      },
+      "ef_construction": 512,
+      "m": 16
+    }
+  }
+}
+```
+
+**Performance Metrics**:
+- Index size: 273 KB (compression ratio: 32×)
+- Memory usage: 0.4 MB
+- Indexing time: 52 seconds (+15%)
+- QPS: 3,097 (-37%)
+- P95 latency: 7.9ms (+21%)
+- Recall@100: 0.766 (-21%)
+
+**Cost Impact**:
+- Memory savings: 96.9%
+- Instance type: Can downgrade from r8g.2xlarge to r8g.large
+- Cost savings: 75%
+
+#### Byte Quantization (8-bit)
+
+**Configuration**:
+```json
+{
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "sq",
+        "parameters": {
+          "type": "int8"
+        }
+      },
+      "ef_construction": 512,
+      "m": 16
+    }
+  }
+}
+```
+
+**Performance Metrics**:
+- Index size: 2.2 MB (compression ratio: 4×)
+- Memory usage: 3.3 MB
+- Indexing time: 48 seconds (+7%)
+- QPS: 4,156 (-15%)
+- P95 latency: 7.1ms (+9%)
+- Recall@100: 0.960 (-1%)
+
+**Cost Impact**:
+- Memory savings: 75%
+- Instance type: Can downgrade from r8g.2xlarge to r8g.xlarge
+- Cost savings: 50%
+
+#### FP16 Quantization (16-bit)
+
+**Configuration**:
+```json
+{
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "sq",
+        "parameters": {
+          "type": "fp16",
+          "clip": true
+        }
+      },
+      "ef_construction": 512,
+      "m": 16
+    }
+  }
+}
+```
+
+**Performance Metrics**:
+- Index size: 4.4 MB (compression ratio: 2×)
+- Memory usage: 6.6 MB
+- Indexing time: 46 seconds (+2%)
+- QPS: 4,623 (-5%)
+- P95 latency: 6.8ms (+5%)
+- Recall@100: 0.965 (-0.5%)
+
+**Cost Impact**:
+- Memory savings: 50%
+- Instance type: Keep r8g.2xlarge but can support more indices
+- Cost savings: 25-30% through higher density
+
+#### Product Quantization
+
+**Training Configuration**:
+```json
+{
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "code_size": 8,
+          "m": 128  // 1024/8 = 128 sub-vectors
+        }
+      },
+      "ef_construction": 512,
+      "m": 16
+    }
+  }
+}
+```
+
+**Performance Metrics**:
+- Index size: 136 KB (compression ratio: 64×)
+- Memory usage: 0.2 MB
+- Training time: 120 seconds
+- Indexing time: 65 seconds (+44%)
+- QPS: 3,845 (-21%)
+- P95 latency: 8.2ms (+26%)
+- Recall@100: 0.723 (-25%)
+
+**Cost Impact**:
+- Memory savings: 98.5%
+- Instance type: Can downgrade from r8g.2xlarge to r8g.medium
+- Cost savings: 87%
+- **Note**: Requires additional training steps and data
+
+### Disk Mode Performance Tests
+
+#### Test Configuration
+
+**EBS Configuration**:
+- Volume type: gp3
+- Capacity: 100GB
+- IOPS: 9000
+- Throughput: 500 MB/s
+
+**Index Configuration**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "vector": {
+        "type": "knn_vector",
+        "dimension": 1024,
+        "mode": "on_disk",
+        "compression_level": "8x",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 512,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Disk Mode Performance at Different Compression Levels
+
+| Compression Level | Memory Usage | QPS | P95 Latency | Recall@100 | IOPS Utilization |
+|----------|----------|-----|---------|------------|------------|
+| 2x (FP16) | 6.6 MB | 85 | 95ms | 0.965 | 45% |
+| 4x (Byte) | 3.3 MB | 92 | 88ms | 0.960 | 42% |
+| 8x (4-bit) | 1.7 MB | 98 | 82ms | 0.945 | 38% |
+| 16x (2-bit) | 0.8 MB | 76 | 105ms | 0.920 | 52% |
+| 32x (1-bit) | 0.4 MB | 65 | 125ms | 0.890 | 58% |
+
+#### Rescoring Effect Tests
+
+**Test Query**:
+```json
+{
+  "query": {
+    "knn": {
+      "vector": {
+        "vector": [...],
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 5.0
+        }
+      }
+    }
+  }
+}
+```
+
+**Impact of Different oversample_factor Values** (32x compression):
+
+| oversample_factor | Recall@10 | P95 Latency | IOPS Utilization |
+|-------------------|-----------|---------|------------|
+| 1.0 (no rescoring) | 0.845 | 65ms | 35% |
+| 2.0 | 0.872 | 78ms | 42% |
+| 5.0 | 0.890 | 125ms | 58% |
+| 10.0 | 0.905 | 185ms | 78% |
+| 20.0 | 0.915 | 285ms | 95% |
+
+**Best Practice Recommendations**:
+- For 32x compression, recommend oversample_factor = 5-10
+- For 8x compression, recommend oversample_factor = 2-3
+- Monitor IOPS utilization, avoid exceeding 80%
+
+### Large-Scale Dataset Tests
+
+#### 1 Billion Vectors Test (384 Dimensions)
+
+**Test Environment**:
+- Cluster: 10 × r8g.4xlarge
+- Dataset: 1 billion vectors, 384 dimensions
+- Shards: 20 shards, 1 replica
+
+**In-Memory Mode vs Disk Mode Comparison**:
+
+| Mode | Compression Level | Total Memory Required | Instance Config | Monthly Cost | QPS | P95 Latency |
+|------|----------|------------|----------|----------|-----|---------|
+| In-memory | None | 1830 GB | 10×r8g.4xlarge | $12,340 | 8,500+ | 12ms |
+| In-memory | 8x | 458 GB | 5×r8g.2xlarge | $3,080 | 6,200+ | 15ms |
+| Disk | 8x | 115 GB | 10×r8g.xlarge | $3,080 | 450 | 95ms |
+| Disk | 32x | 58 GB | 10×r8g.xlarge | $3,080 | 280 | 145ms |
+
+**Key Findings**:
+1. Disk mode can support larger-scale datasets at the same cost
+2. In-memory mode + 8x compression provides the best price-performance ratio
+3. Disk mode is suitable for batch processing and low-frequency query scenarios
+
+### In-Depth Recall Analysis
+
+#### Recall Performance at Different k Values
+
+**Test Conditions**: 1M vectors, 1024 dimensions, 1000 queries
+
+| Quantization Method | k=1 | k=10 | k=50 | k=100 |
+|----------|-----|------|------|-------|
+| No compression | 0.995 | 0.970 | 0.965 | 0.960 |
+| FP16 (2x) | 0.992 | 0.965 | 0.960 | 0.955 |
+| Byte (4x) | 0.988 | 0.960 | 0.955 | 0.950 |
+| Binary (32x) | 0.845 | 0.766 | 0.745 | 0.730 |
+| Product (64x) | 0.798 | 0.723 | 0.705 | 0.695 |
+
+**Observations**:
+- Recall slightly decreases as k value increases
+- Binary and Product quantization perform relatively better at k=1
+- Byte quantization maintains consistently high recall across all k values
+
+#### Impact of Vector Dimensions on Quantization Effectiveness
+
+**Test Results** (Binary quantization, k=10):
+
+| Vector Dimension | Recall@10 | Relative Baseline Loss |
+|----------|-----------|-------------|
+| 128 | 0.645 | -33.5% |
+| 256 | 0.698 | -28.1% |
+| 384 | 0.732 | -24.5% |
+| 512 | 0.751 | -22.6% |
+| 768 | 0.766 | -21.0% |
+| 1024 | 0.778 | -19.8% |
+| 1536 | 0.795 | -18.0% |
+
+**Conclusion**: Higher-dimensional vectors (≥768) are better suited for Binary quantization, with relatively smaller recall loss.
+
+## Real-World Cost Case Studies
+
+### Case 1: Small-Scale Application (1M Vectors, 768 Dimensions)
+
+**Requirements**:
+- Vector count: 1 million
+- Vector dimensions: 768
+- QPS requirement: 500
+- Latency requirement: < 20ms
+
+**Option A: Standard In-Memory Mode**
+- Instances: 2 × r8g.xlarge
+- Configuration: 2 shards, 1 replica, no compression
+- Monthly cost: $308
+- Performance: QPS 1,327, latency 8.4ms
+
+**Option B: Compression Optimized**
+- Instances: 1 × r8g.xlarge
+- Configuration: 1 shard, 0 replicas, 8x compression
+- Monthly cost: $154
+- Performance: QPS 730, latency 7.1ms
+- **Cost savings: 50%**
+
+**Recommendation**: Option B (meets requirements with optimal cost)
+
+### Case 2: Medium-Scale Application (10M Vectors, 1024 Dimensions)
+
+**Requirements**:
+- Vector count: 10 million
+- Vector dimensions: 1024
+- QPS requirement: 1,000
+- Latency requirement: < 15ms
+
+**Option A: Standard Configuration**
+- Instances: 3 × r7g.2xlarge
+- Configuration: 3 shards, 0 replicas, no compression
+- Monthly cost: $924
+- Performance: QPS 2,435, latency 9.0ms
+
+**Option B: Compression Optimized**
+- Instances: 2 × r8g.2xlarge
+- Configuration: 4 shards, 0 replicas, 8x compression
+- Monthly cost: $616
+- Performance: QPS 1,200, latency 11ms
+- **Cost savings: 33%**
+
+**Recommendation**: Option B (slightly reduced performance but significantly lower cost)
+
+### Case 3: Large-Scale Application (100M Vectors, 768 Dimensions)
+
+**Requirements**:
+- Vector count: 100 million
+- Vector dimensions: 768
+- QPS requirement: 100 (batch processing scenario)
+- Latency requirement: < 200ms
+
+**Option A: In-Memory Mode**
+- Instances: 2 × r8g.16xlarge
+- Configuration: 17 shards, 1 replica
+- Monthly cost: $4,934
+- Performance: QPS 2,982, latency 9.6ms
+
+**Option B: Disk Mode + Compression**
+- Instances: 5 × r8g.xlarge
+- Configuration: 10 shards, 1 replica, 32x compression, disk mode
+- EBS: gp3 500GB × 5, 9000 IOPS
+- Monthly cost: $770 (instances) + $200 (EBS) = $970
+- Performance: QPS 73, latency 114ms
+- **Cost savings: 80%**
+
+**Recommendation**: Option B (optimal cost for batch processing scenarios)
+
+## Cost Calculation Formulas
+
+### Basic Cost Calculation
+
+```
+Monthly Total Cost = Instance Cost + Storage Cost + Data Transfer Cost
+
+Instance Cost = Instance Unit Price × Instance Count × (1 + Replica Count)
+Storage Cost = EBS Capacity Cost + IOPS Cost + Throughput Cost
+Data Transfer Cost = Cross-AZ Transfer + Cross-Region Transfer + Internet Outbound
+```
+
+### Vector Index Size Estimation
+
+```
+Index Size (GB) = Vector Count × Dimensions × 4 bytes / (1024^3) / Compression Ratio
+
+Example:
+- 100M vectors × 768 dimensions × 4 bytes = 307.2 GB (no compression)
+- With 8x compression: 307.2 / 8 = 38.4 GB
+- With 32x compression: 307.2 / 32 = 9.6 GB
+```
+
+### Instance Memory Requirement Estimation
+
+```
+Required Memory (GB) = Index Size + JVM Heap + System Overhead
+
+JVM Heap = Index Size × 0.5 (recommended)
+System Overhead = 2-4 GB
+
+Example (10M vectors, 1024 dimensions, 8x compression):
+- Index size: 5 GB
+- JVM Heap: 2.5 GB
+- System overhead: 3 GB
+- Total requirement: 10.5 GB → Choose 16GB instance (r8g.xlarge)
+```
+
+## Quantization Technique Implementation Guide
+
+### Pre-Implementation Assessment
+
+#### 1. Data Characteristics Analysis
+
+**Vector Dimension Assessment**:
+```python
+# Check vector dimension distribution
+import numpy as np
+
+def analyze_vector_dimensions(vectors):
+    dimensions = [len(v) for v in vectors]
+    print(f"Dimension range: {min(dimensions)} - {max(dimensions)}")
+    print(f"Average dimension: {np.mean(dimensions):.1f}")
+    print(f"Dimension consistency: {len(set(dimensions)) == 1}")
+
+    # Quantization suitability assessment
+    avg_dim = np.mean(dimensions)
+    if avg_dim >= 768:
+        print("Recommendation: Binary quantization works well")
+    elif avg_dim >= 384:
+        print("Recommendation: Byte quantization balances performance and cost")
+    else:
+        print("Recommendation: FP16 quantization maintains high precision")
+```
+
+**Vector Value Range Check**:
+```python
+def check_vector_ranges(vectors):
+    all_values = np.concatenate(vectors)
+    min_val, max_val = np.min(all_values), np.max(all_values)
+
+    print(f"Value range: [{min_val:.4f}, {max_val:.4f}]")
+
+    # FP16 compatibility check
+    if min_val >= -65504.0 and max_val <= 65504.0:
+        print("✓ Compatible with FP16 quantization")
+    else:
+        print("✗ Clipping required for FP16")
+
+    # Byte quantization preprocessing requirement
+    if min_val >= -128 and max_val <= 127:
+        print("✓ Can directly use Byte quantization")
+    else:
+        print("✗ Normalization required")
+```
+
+#### 2. Performance Requirement Assessment
+
+**Latency Requirement Analysis**:
+```
+Real-time applications (< 20ms):
+├─ High precision needs → FP16 quantization + in-memory mode
+└─ Cost-first → Byte quantization + in-memory mode
+
+Near-real-time applications (20-100ms):
+├─ Balanced choice → Byte quantization + in-memory mode
+└─ Cost-first → 8x compression + disk mode
+
+Batch processing applications (> 100ms):
+├─ Standard choice → 8x-16x compression + disk mode
+└─ Maximum optimization → 32x compression + disk mode
+```
+
+**QPS Requirement Assessment**:
+```
+High-frequency queries (> 1000 QPS): In-memory mode + light compression (2x-4x)
+Medium-frequency queries (100-1000 QPS): In-memory mode + medium compression (4x-8x)
+Low-frequency queries (< 100 QPS): Disk mode + high compression (16x-32x)
+```
+
+### Phased Implementation Strategy
+
+#### Phase 1: Conservative Optimization (Lowest Risk)
+
+**Goal**: Reduce costs by 30-50% without impacting performance
+
+**Implementation Steps**:
+1. **FP16 Quantization Test**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "encoder": {
+              "name": "sq",
+              "parameters": {
+                "type": "fp16",
+                "clip": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+2. **A/B Testing Validation**:
+```bash
+# Create test index
+curl -X PUT "localhost:9200/test-fp16" -H 'Content-Type: application/json' -d'...'
+
+# Import test data (10% of production data)
+# Run recall tests
+# Compare performance metrics
+```
+
+3. **Production Environment Deployment**:
+   - Create new index during off-peak hours
+   - Gradually switch traffic
+   - Monitor key metrics
+
+#### Phase 2: Aggressive Optimization (Balanced Risk-Reward)
+
+**Goal**: Reduce costs by 50-75%, accepting minor performance impact
+
+**Implementation Steps**:
+1. **Byte Quantization Deployment**:
+```json
+{
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "sq",
+        "parameters": {
+          "type": "int8"
+        }
+      }
+    }
+  }
+}
+```
+
+2. **Disk Mode Pilot**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "vector": {
+        "type": "knn_vector",
+        "mode": "on_disk",
+        "compression_level": "8x"
+      }
+    }
+  }
+}
+```
+
+#### Phase 3: Maximum Optimization (High Risk, High Reward)
+
+**Goal**: Reduce costs by 75-90%, suitable for specific scenarios
+
+**Implementation Steps**:
+1. **Binary Quantization Evaluation**
+2. **Product Quantization Implementation** (if sufficient training data is available)
+3. **32x Disk Mode Deployment**
+
+### Migration Implementation Plan
+
+#### Zero-Downtime Migration Strategy
+
+**Option A: Dual-Write Strategy**
+```python
+def dual_write_migration():
+    # 1. Create new quantized index
+    create_quantized_index()
+
+    # 2. Dual-write new data to both indices
+    for new_data in data_stream:
+        write_to_old_index(new_data)
+        write_to_new_index(new_data)
+
+    # 3. Migrate historical data
+    migrate_historical_data()
+
+    # 4. Switch read traffic
+    switch_read_traffic()
+
+    # 5. Stop writing to old index
+    stop_old_index_writes()
+```
+
+**Option B: Alias Switch Strategy**
+```bash
+# 1. Create new index
+PUT /vectors-quantized-v2
+{
+  "mappings": { ... }  # Quantization configuration
+}
+
+# 2. Reindex data
+POST /_reindex
+{
+  "source": { "index": "vectors-v1" },
+  "dest": { "index": "vectors-quantized-v2" }
+}
+
+# 3. Atomic alias switch
+POST /_aliases
+{
+  "actions": [
+    { "remove": { "index": "vectors-v1", "alias": "vectors" }},
+    { "add": { "index": "vectors-quantized-v2", "alias": "vectors" }}
+  ]
+}
+```
+
+#### Rollback Plan
+
+**Quick Rollback Steps**:
+1. Retain the original index for 24-48 hours
+2. Monitor key business metrics
+3. If issues arise, immediately switch alias back for rollback
+4. Analyze the root cause and retry with adjusted configuration
+
+### Troubleshooting Guide
+
+#### Common Issue 1: Significant Recall Drop
+
+**Symptoms**: Post-quantization recall drops more than expected (> 10%)
+
+**Possible Causes**:
+- Vector dimensions too low (< 384)
+- Uneven vector value distribution
+- Compression level too high
+
+**Solutions**:
+```python
+# 1. Check vector quality
+def diagnose_recall_drop(original_vectors, quantized_vectors):
+    # Compute vector similarity distribution
+    similarities = cosine_similarity(original_vectors, quantized_vectors)
+
+    print(f"Average similarity: {np.mean(similarities):.3f}")
+    print(f"Minimum similarity: {np.min(similarities):.3f}")
+
+    # If average similarity < 0.9, consider reducing compression level
+    if np.mean(similarities) < 0.9:
+        print("Suggestion: Reduce compression level or enable rescoring")
+
+# 2. Enable rescoring
+{
+  "query": {
+    "knn": {
+      "vector": {...},
+      "rescore": {
+        "oversample_factor": 5.0  # Increase rescoring factor
+      }
+    }
+  }
+}
+```
+
+#### Common Issue 2: Poor Disk Mode Performance
+
+**Symptoms**: Disk mode latency too high (> 300ms)
+
+**Possible Causes**:
+- Insufficient EBS IOPS
+- oversample_factor too high
+- Too many concurrent queries
+
+**Solutions**:
+```bash
+# 1. Check EBS performance
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/EBS \
+  --metric-name VolumeReadOps \
+  --dimensions Name=VolumeId,Value=vol-xxx \
+  --start-time 2024-01-01T00:00:00Z \
+  --end-time 2024-01-01T01:00:00Z \
+  --period 300 \
+  --statistics Average
+
+# 2. Optimize EBS configuration
+{
+  "ebs_options": {
+    "volume_type": "gp3",
+    "iops": 16000,        # Increase IOPS
+    "throughput": 1000    # Increase throughput
+  }
+}
+
+# 3. Adjust query parameters
+{
+  "rescore": {
+    "oversample_factor": 3.0  # Reduce rescoring factor
+  }
+}
+```
+
+#### Common Issue 3: Index Build Failure
+
+**Symptoms**: Quantized index creation or data import fails
+
+**Possible Causes**:
+- Vector values exceed quantization range
+- Insufficient memory
+- Incorrect configuration parameters
+
+**Solutions**:
+```python
+# 1. Vector preprocessing
+def preprocess_vectors_for_quantization(vectors, target_type="fp16"):
+    if target_type == "fp16":
+        # Clip to FP16 range
+        vectors = np.clip(vectors, -65504.0, 65504.0)
+    elif target_type == "int8":
+        # Normalize to [-128, 127]
+        vectors = vectors / np.max(np.abs(vectors)) * 127
+        vectors = np.round(vectors).astype(np.int8)
+
+    return vectors
+
+# 2. Batch import
+def batch_import_vectors(vectors, batch_size=1000):
+    for i in range(0, len(vectors), batch_size):
+        batch = vectors[i:i+batch_size]
+        try:
+            import_batch(batch)
+        except Exception as e:
+            print(f"Batch {i//batch_size} failed: {e}")
+            # Retry or skip
+```
+
+### Monitoring and Maintenance
+
+#### Key Monitoring Metrics
+
+**Performance Metrics**:
+```python
+# 1. Query latency monitoring
+{
+  "query_latency_p95": "< target latency",
+  "query_latency_p99": "< target latency × 1.5",
+  "qps": "> minimum requirement"
+}
+
+# 2. Recall monitoring
+{
+  "recall_at_k": "> 0.90",  # Adjust based on business requirements
+  "precision_at_k": "> 0.85"
+}
+
+# 3. Resource usage monitoring
+{
+  "memory_usage": "< 85%",
+  "cpu_usage": "< 80%",
+  "disk_iops_usage": "< 80%"
+}
+```
+
+**Business Metrics**:
+```python
+# 4. Business impact monitoring
+{
+  "user_satisfaction": "remain stable",
+  "conversion_rate": "no significant decline",
+  "search_success_rate": "> 95%"
+}
+```
+
+#### Automated Monitoring Script
+
+```python
+import boto3
+import requests
+from datetime import datetime, timedelta
+
+def monitor_quantized_index():
+    # 1. Check cluster health
+    health = requests.get("http://localhost:9200/_cluster/health").json()
+    if health["status"] != "green":
+        alert("Cluster status abnormal")
+
+    # 2. Check query performance
+    stats = requests.get("http://localhost:9200/_nodes/stats/indices/search").json()
+    avg_latency = calculate_average_latency(stats)
+    if avg_latency > LATENCY_THRESHOLD:
+        alert(f"Query latency too high: {avg_latency}ms")
+
+    # 3. Check recall (requires periodic testing)
+    recall = run_recall_test()
+    if recall < RECALL_THRESHOLD:
+        alert(f"Recall dropped: {recall}")
+
+    # 4. Check EBS performance (disk mode)
+    if DISK_MODE_ENABLED:
+        iops_usage = get_ebs_iops_usage()
+        if iops_usage > 0.8:
+            alert(f"IOPS utilization too high: {iops_usage*100}%")
+
+# Run monitoring periodically
+schedule.every(5).minutes.do(monitor_quantized_index)
+```
+
+## Cost Optimization Best Practices
+
+### 1. Choose the Right Compression Level
+
+**Decision Tree**:
+```
+Can you accept 5% recall loss?
+├─ Yes → Use 8x compression (recommended)
+└─ No → Can you accept 20% recall loss?
+    ├─ Yes → Use 32x compression (maximum cost optimization)
+    └─ No → Don't use compression (performance-first)
+```
+
+### 2. Choose Mode Based on Latency Requirements
+
+**Decision Tree**:
+```
+Latency requirement < 20ms?
+├─ Yes → Use in-memory mode
+└─ No → Latency requirement < 200ms?
+    ├─ Yes → Use disk mode + high IOPS
+    └─ No → Use disk mode + standard IOPS
+```
+
+### 3. Optimize Shard and Replica Configuration
+
+**Development Environment**:
+- Shards: 1-2
+- Replicas: 0
+- Lowest cost
+
+**Production Environment**:
+- Shards: Node count × 1.5
+- Replicas: 1
+- Balanced cost and availability
+
+**Critical Services**:
+- Shards: Node count × 2
+- Replicas: 2
+- Maximum availability
+
+### 4. Use Reserved Instances
+
+**1-Year Reserved Instances**:
+- Discount: 30-40%
+- Suitable for: Stable production environments
+
+**3-Year Reserved Instances**:
+- Discount: 50-60%
+- Suitable for: Long-running core services
+
+**Cost Comparison** (r8g.2xlarge):
+- On-demand: $308/month
+- 1-year reserved: $215/month (30% savings)
+- 3-year reserved: $154/month (50% savings)
+
+### 5. Monitor and Continuously Optimize
+
+**Key Metrics**:
+- CPU utilization: Target 60-80%
+- Memory utilization: Target 70-85%
+- IOPS utilization: Target 60-80%
+- Cache hit rate: Target > 95%
+
+**Optimization Recommendations**:
+- CPU < 40%: Consider downgrading instances
+- Memory > 90%: Consider upgrading instances or increasing compression
+- IOPS < 50%: Consider reducing IOPS configuration
+- Cache hit rate < 90%: Increase memory or optimize queries
+
+## Frequently Asked Questions
+
+### Question 1: How to choose the most cost-effective instance type?
+
+**Answer**:
+1. Calculate index size (considering compression)
+2. Estimate memory requirements (index × 1.5 + 3GB)
+3. Choose the smallest instance that meets memory requirements
+4. Consider Reserved Instances to further reduce costs
+
+**Example**:
+- 10M vectors, 768 dimensions, 8x compression
+- Index size: 3.8 GB
+- Memory requirement: 3.8 × 1.5 + 3 = 8.7 GB
+- Recommendation: r8g.xlarge (16GB, $154/month)
+
+### Question 2: Can disk mode really save 67% on costs?
+
+**Answer**:
+Yes, but with prerequisites:
+1. Can accept 100-200ms latency
+2. QPS requirement < 100
+3. Using 32x compression
+4. Configured with high IOPS EBS (9000+)
+
+**Scenarios not suitable for disk mode**:
+- Real-time recommendation systems
+- Low-latency search services
+- High QPS requirements (> 500)
+
+### Question 3: Does quantization compression affect search accuracy?
+
+**Answer**:
+- 8x compression (4-bit): Recall loss < 5%, nearly imperceptible
+- 32x compression (1-bit): Recall loss 15-20%, need to evaluate business impact
+
+**Recommendations**:
+- Prioritize 8x compression for production environments
+- Validate recall impact through A/B testing
+- Can compensate recall through increased oversample-factor
+
+### Question 4: How to reduce costs without impacting performance?
+
+**Answer**:
+1. Use 8x compression (nearly lossless recall)
+2. Use 0 replicas for development environments
+3. Optimize shard count (avoid over-sharding)
+4. Use Reserved Instances (save 30-50%)
+5. Monitor resource utilization, right-size instances
+
+**Quick Optimization Checklist**:
+- [ ] Using quantization compression?
+- [ ] Using 0 replicas in development environments?
+- [ ] Is shard count reasonable?
+- [ ] Considered Reserved Instances?
+- [ ] Is resource utilization in the 60-80% range?
+
+## Cost Optimization Tools and Resources
+
+### AWS Cost Calculator
+- [AWS Pricing Calculator](https://calculator.aws/)
+- Can estimate OpenSearch Service costs
+- Supports multiple instance types and configurations
+
+### Monitoring Tools
+- CloudWatch: Instance and EBS metrics
+- OpenSearch Dashboards: Cluster health and performance
+- Cost Explorer: Cost trend analysis
+
+### Reference Resources
+- [OpenSearch Official Pricing](https://aws.amazon.com/opensearch-service/pricing/)
+- [EC2 Instance Pricing](https://aws.amazon.com/ec2/pricing/)
+- [EBS Pricing](https://aws.amazon.com/ebs/pricing/)
+- [OpenSearch Cost Optimization Blog](https://aws.amazon.com/blogs/big-data/)
+
+## Summary
+
+Cost optimization for OpenSearch vector search is a multi-dimensional problem that requires finding the right balance between performance, cost, and availability. Through proper use of quantization compression techniques, disk mode, instance selection, and storage optimization, you can significantly reduce costs while maintaining good performance.
+
+### Core Optimization Strategies
+
+**1. Quantization Technique Selection**:
+- **Byte Quantization (4×)**: First choice for production, recall loss < 5%, 75% cost savings
+- **Binary Quantization (32×)**: Maximum cost optimization, suitable for high-dimensional vectors (≥768), 85% cost savings
+- **FP16 Quantization (2×)**: Conservative optimization, nearly zero precision loss, 50% cost savings
+- **Product Quantization (64×)**: Ultra-large-scale datasets, requires training data, 90% cost savings
+
+**2. Disk Mode Application**:
+- Suitable for batch processing and low-frequency query scenarios (< 100 QPS)
+- Combined with quantization techniques can achieve 50-80% cost savings
+- Requires high-performance EBS configuration (gp3, 9000+ IOPS)
+- Compensates recall loss through rescoring mechanism
+
+**3. Implementation Best Practices**:
+- Phased implementation: Conservative optimization → Aggressive optimization → Maximum optimization
+- Thorough A/B testing to validate recall and performance impact
+- Establish comprehensive monitoring and rollback mechanisms
+- Choose appropriate compression level based on business scenarios
+
+### Key Decision Guide
+
+**Performance-First Scenarios**:
+- Real-time recommendation systems: FP16 quantization + in-memory mode
+- Low-latency search: Byte quantization + in-memory mode
+- High QPS applications: Light compression (2x-4x) + in-memory mode
+
+**Cost-First Scenarios**:
+- Batch processing analytics: 32x compression + disk mode
+- Development/test environments: Binary quantization + 0 replicas
+- Large-scale datasets: Product quantization + disk mode
+
+**Balanced Scenarios**:
+- General production environments: 8x compression + in-memory mode
+- Near-real-time applications: 8x compression + disk mode
+- Medium-scale data: Byte quantization + 1 replica
+
+### Cost Savings Potential
+
+**Quantization Technique Cost Savings**:
+- FP16: 50% cost savings, < 2% recall loss
+- Byte: 75% cost savings, < 5% recall loss
+- Binary: 85% cost savings, 15-20% recall loss
+- Product: 90% cost savings, requires training investment
+
+**Additional Disk Mode Savings**:
+- Combined with quantization techniques can achieve 50-80% total cost savings
+- Suitable for applications with higher latency tolerance (100-200ms)
+- Further improve price-performance through EBS optimization
+
+### Implementation Recommendations
+
+**Immediately Actionable Optimizations**:
+1. Use 0 replica configuration for development environments (save 50%)
+2. Implement FP16 quantization (lowest risk, save 50%)
+3. Optimize shard configuration (avoid over-sharding)
+4. Consider Reserved Instances (additional 30-60% savings)
+
+**Medium-Term Optimization Plan**:
+1. Evaluate Byte quantization applicability
+2. Pilot disk mode in non-critical scenarios
+3. Establish quantization effectiveness monitoring system
+4. Optimize EBS configuration and costs
+
+**Long-Term Strategic Planning**:
+1. Choose quantization strategy based on data growth trends
+2. Establish automated cost optimization workflows
+3. Continuously monitor and adjust compression parameters
+4. Evaluate emerging quantization techniques for potential adoption
+
+By systematically applying these quantization techniques and optimization strategies, organizations can achieve significant cost savings while maintaining search quality, laying the foundation for sustainable development of large-scale vector search applications.

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/cost-optimization.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/cost-optimization.md
@@ -18,8 +18,6 @@ The cost of OpenSearch vector search mainly consists of compute resources, stora
 - **Similarity Algorithm**: cosine for normalized embeddings and common semantic-search workloads; choose L2 or inner product when the embedding model requires it.
 - **Node Shape**: Prefer current-generation CPU, enough RAM for k-NN graph/cache headroom, and storage with predictable IOPS. For Amazon OpenSearch Service examples in this guide, r7g/r8g/r8gd and OpenSearch-optimized families are used as concrete reference points; for self-managed or Kubernetes deployments, map the same resource profile to your platform.
 
-<!-- FALLBACK: aws-pricing, priority=1, condition="cost-related" -->
-
 ## Cost Optimization Techniques Overview
 
 ### 1. Disk-Based Vector Search

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/indexing-strategies.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/indexing-strategies.md
@@ -1,0 +1,494 @@
+# Indexing Strategies and Best Practices
+
+## Core Concepts
+
+OpenSearch index design directly impacts query performance, storage efficiency, and cluster stability. Proper mapping configuration, sharding strategy, and index lifecycle management form the foundation of building a high-performance search system.
+
+## Common Issues
+
+### Issue 1: How to Choose the Right Number of Shards
+
+**Symptoms**:
+- Poor query performance
+- Unbalanced cluster load
+- Cannot modify shard count after index creation
+
+**Cause**:
+The number of shards affects parallelism, resource allocation, and cluster scalability.
+
+**Solution**:
+
+Rule-of-thumb formula for calculating shard count:
+```
+Number of shards = Total data size (GB) / Target shard size (GB)
+Recommended shard size: 10-50 GB
+```
+
+Set shards when creating an index:
+```json
+{
+  "settings": {
+    "number_of_shards": 3,
+    "number_of_replicas": 1
+  }
+}
+```
+
+**Best Practices**:
+- Small indexes (< 50GB): 1-3 shards
+- Medium indexes (50-500GB): 3-10 shards
+- Large indexes (> 500GB): 10+ shards
+- Keep each shard size between 10-50GB
+- Shard count should be a multiple of the number of data nodes (for even distribution)
+- Avoid over-sharding which wastes resources
+
+### Issue 2: Choosing Mapping Field Types
+
+**Symptoms**:
+- Inaccurate query results
+- Wasted storage space
+- Unable to perform certain types of queries
+
+**Cause**:
+Field types determine how data is stored and indexed.
+
+**Solution**:
+
+Common field type configurations:
+```json
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text",
+        "analyzer": "standard",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "price": {
+        "type": "float"
+      },
+      "quantity": {
+        "type": "integer"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||epoch_millis"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "standard"
+      },
+      "metadata": {
+        "type": "object",
+        "enabled": false
+      }
+    }
+  }
+}
+```
+
+**Field Type Selection Guide**:
+- `text`: Full-text search fields (tokenized)
+- `keyword`: Exact match, aggregation, sorting (not tokenized)
+- `integer/long`: Integers
+- `float/double`: Floating-point numbers
+- `date`: Date and time
+- `boolean`: Boolean values
+- `object`: Nested objects
+- `nested`: Independently indexed nested objects (for complex queries)
+
+**Best Practices**:
+- Use `text` for fields that require full-text search
+- Use `keyword` for fields that require exact matching, aggregation, or sorting
+- Use multi-field to support both full-text search and exact matching simultaneously
+- Set `enabled: false` for fields that don't need to be searched to save space
+- Specify explicit formats for date fields
+- Avoid using the `_all` field (deprecated)
+
+### Issue 3: Dynamic Mapping vs Explicit Mapping
+
+**Symptoms**:
+- Field types don't match expectations
+- Index bloat (field explosion)
+- Unable to control field behavior
+
+**Cause**:
+Dynamic mapping automatically infers field types, which may not match actual requirements.
+
+**Solution**:
+
+1. Disable dynamic mapping (recommended for production):
+```json
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "known_field": {
+        "type": "text"
+      }
+    }
+  }
+}
+```
+
+2. Use dynamic templates:
+```json
+{
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "strings_as_keywords": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "integers": {
+          "match_mapping_type": "long",
+          "mapping": {
+            "type": "integer"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+**Best Practices**:
+- Use `dynamic: "strict"` in production to prevent field explosion
+- Use `dynamic: true` in development for rapid iteration
+- Use dynamic templates to uniformly handle unknown fields
+- Regularly review mappings and remove unnecessary fields
+
+### Issue 4: Index Aliases and Zero-Downtime Reindexing
+
+**Symptoms**:
+- Need to modify mapping but cannot do so online
+- Reindexing causes service interruption
+- Unable to smoothly switch indexes
+
+**Cause**:
+OpenSearch does not support modifying the type of existing fields; reindexing is required.
+
+**Solution**:
+
+Use index aliases for zero-downtime reindexing:
+
+1. Create a new index:
+```bash
+PUT /my_index_v2
+{
+  "mappings": {
+    "properties": {
+      "field": {
+        "type": "keyword"  // 新的类型
+      }
+    }
+  }
+}
+```
+
+2. Reindex the data:
+```bash
+POST /_reindex
+{
+  "source": {
+    "index": "my_index_v1"
+  },
+  "dest": {
+    "index": "my_index_v2"
+  }
+}
+```
+
+3. Switch the alias:
+```bash
+POST /_aliases
+{
+  "actions": [
+    {
+      "remove": {
+        "index": "my_index_v1",
+        "alias": "my_index"
+      }
+    },
+    {
+      "add": {
+        "index": "my_index_v2",
+        "alias": "my_index"
+      }
+    }
+  ]
+}
+```
+
+4. Delete the old index:
+```bash
+DELETE /my_index_v1
+```
+
+**Best Practices**:
+- Always use aliases instead of directly using index names
+- Use version numbers in index naming (e.g., my_index_v1)
+- Use the `_reindex` API when rebuilding indexes
+- Verify data integrity in the new index before switching the alias
+- Keep the old index for a period of time to allow rollback
+
+### Issue 5: Index Template Management
+
+**Symptoms**:
+- Inconsistent configuration across multiple indexes
+- Tedious creation of time-series indexes
+- Difficult to manage index settings uniformly
+
+**Cause**:
+Manually creating each index is error-prone and inefficient.
+
+**Solution**:
+
+Create an index template:
+```json
+{
+  "index_patterns": ["logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 1,
+      "refresh_interval": "30s"
+    },
+    "mappings": {
+      "properties": {
+        "timestamp": {
+          "type": "date"
+        },
+        "level": {
+          "type": "keyword"
+        },
+        "message": {
+          "type": "text"
+        },
+        "host": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "priority": 100
+}
+```
+
+Apply the template:
+```bash
+PUT /_index_template/logs_template
+{
+  // Template configuration
+}
+```
+
+**Best Practices**:
+- Create templates for similar indexes
+- Use wildcards to match index names
+- Set a reasonable priority
+- Use index templates + rollover strategy for time-series data
+- Regularly review and update templates
+
+## Configuration Examples
+
+### Production Environment Index Configuration
+
+```json
+{
+  "settings": {
+    "number_of_shards": 5,
+    "number_of_replicas": 1,
+    "refresh_interval": "30s",
+    "max_result_window": 10000,
+    "index": {
+      "codec": "best_compression",
+      "mapping": {
+        "total_fields": {
+          "limit": 2000
+        }
+      }
+    }
+  },
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "id": {
+        "type": "keyword"
+      },
+      "title": {
+        "type": "text",
+        "analyzer": "standard",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "content": {
+        "type": "text",
+        "analyzer": "standard"
+      },
+      "category": {
+        "type": "keyword"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "price": {
+        "type": "float"
+      },
+      "stock": {
+        "type": "integer"
+      },
+      "created_at": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      },
+      "updated_at": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      },
+      "metadata": {
+        "type": "object",
+        "enabled": false
+      }
+    }
+  }
+}
+```
+
+### Time-Series Index Template
+
+```json
+{
+  "index_patterns": ["metrics-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 1,
+      "refresh_interval": "5s",
+      "index": {
+        "lifecycle": {
+          "name": "metrics_policy",
+          "rollover_alias": "metrics"
+        }
+      }
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "metric_name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "double"
+        },
+        "host": {
+          "type": "keyword"
+        },
+        "tags": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}
+```
+
+## Index Lifecycle Management
+
+### ISM Policy Example
+
+```json
+{
+  "policy": {
+    "description": "Hot-Warm-Delete policy",
+    "default_state": "hot",
+    "states": [
+      {
+        "name": "hot",
+        "actions": [
+          {
+            "rollover": {
+              "min_index_age": "1d",
+              "min_primary_shard_size": "50gb"
+            }
+          }
+        ],
+        "transitions": [
+          {
+            "state_name": "warm",
+            "conditions": {
+              "min_index_age": "7d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "warm",
+        "actions": [
+          {
+            "replica_count": {
+              "number_of_replicas": 0
+            }
+          },
+          {
+            "force_merge": {
+              "max_num_segments": 1
+            }
+          }
+        ],
+        "transitions": [
+          {
+            "state_name": "delete",
+            "conditions": {
+              "min_index_age": "30d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "delete",
+        "actions": [
+          {
+            "delete": {}
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Performance Optimization Tips
+
+1. **Bulk Indexing**: Use the bulk API with batch sizes of 5-15MB
+2. **Disable Refresh**: Set `refresh_interval: -1` during bulk imports
+3. **Add Replicas Later**: Increase replica count after import is complete
+4. **Use Compression**: Set `codec: best_compression` to save space
+5. **Limit Field Count**: Set `mapping.total_fields.limit` to prevent field explosion
+
+## Reference Resources
+
+- [OpenSearch Mapping Documentation](https://opensearch.org/docs/latest/field-types/)
+- [Index Settings Reference](https://opensearch.org/docs/latest/api-reference/index-apis/create-index/)
+- [Index Lifecycle Management](https://opensearch.org/docs/latest/im-plugin/)

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/indexing-strategies.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/indexing-strategies.md
@@ -194,7 +194,7 @@ PUT /my_index_v2
   "mappings": {
     "properties": {
       "field": {
-        "type": "keyword"  // 新的类型
+        "type": "keyword"
       }
     }
   }

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/optimized-instances.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/optimized-instances.md
@@ -1,0 +1,143 @@
+# OpenSearch Optimized Instances Guide
+
+## Overview
+
+OpenSearch Optimized instances are Amazon OpenSearch Service-specific instance families that provide improved price-performance for selected managed-service workloads. They use a storage architecture where local EBS/NVMe storage is used for caching and data is synchronously copied to Amazon S3 for durability. Treat this file as an AWS-specific reference; for self-managed OpenSearch or Kubernetes, translate the guidance into CPU, memory, storage, and refresh-latency requirements.
+
+**Instance Families:**
+
+| Family | Focus | Storage | Best For |
+|--------|-------|---------|----------|
+| **OR1** | Memory-optimized | EBS (gp3/io1) + S3 | Indexing-heavy workloads, log analytics |
+| **OR2** | Memory-optimized (next-gen) | EBS (gp3/io1) + S3 | Same as OR1 with better price-performance |
+| **OM2** | Compute-optimized | EBS (gp3/io1) + S3 | Higher indexing throughput, 15% faster than OR1 |
+| **OI2** | Storage-optimized | Local NVMe + S3 | Large datasets, no EBS needed |
+
+## Instance Specifications
+
+### OR1 (Memory-Optimized, 1st Gen)
+
+| Instance | vCPU | Memory (GiB) | $/month (us-east-1) |
+|----------|------|-------------|---------------------|
+| or1.medium.search | 1 | 8 | $76.65 |
+| or1.large.search | 2 | 16 | $152.57 |
+| or1.xlarge.search | 4 | 32 | $305.87 |
+| or1.2xlarge.search | 8 | 64 | $610.28 |
+| or1.4xlarge.search | 16 | 128 | $1,222.02 |
+| or1.8xlarge.search | 32 | 256 | $2,442.58 |
+| or1.12xlarge.search | 48 | 384 | $3,664.60 |
+| or1.16xlarge.search | 64 | 512 | $4,878.59 |
+
+### OR2 (Memory-Optimized, 2nd Gen)
+
+| Instance | vCPU | Memory (GiB) | $/month (us-east-1) |
+|----------|------|-------------|---------------------|
+| or2.medium.search | 1 | 8 | $73.00 |
+| or2.large.search | 2 | 16 | $146.00 |
+| or2.xlarge.search | 4 | 32 | $292.73 |
+| or2.2xlarge.search | 8 | 64 | $584.00 |
+| or2.4xlarge.search | 16 | 128 | $1,168.00 |
+| or2.8xlarge.search | 32 | 256 | $2,336.00 |
+| or2.12xlarge.search | 48 | 384 | $3,504.00 |
+| or2.16xlarge.search | 64 | 512 | $4,672.00 |
+
+### OM2 (Compute-Optimized)
+
+| Instance | vCPU | Memory (GiB) | $/month (us-east-1) |
+|----------|------|-------------|---------------------|
+| om2.large.search | 2 | 8 | $111.69 |
+| om2.xlarge.search | 4 | 16 | $222.65 |
+| om2.2xlarge.search | 8 | 32 | $445.30 |
+| om2.4xlarge.search | 16 | 64 | $891.33 |
+| om2.8xlarge.search | 32 | 128 | $1,781.93 |
+| om2.12xlarge.search | 48 | 192 | $2,673.26 |
+| om2.16xlarge.search | 64 | 256 | $3,564.59 |
+
+### OI2 (Storage-Optimized, NVMe)
+
+| Instance | vCPU | Memory (GiB) | $/month (us-east-1) |
+|----------|------|-------------|---------------------|
+| oi2.large.search | 2 | 16 | $212.96 |
+| oi2.xlarge.search | 4 | 32 | $425.91 |
+| oi2.2xlarge.search | 8 | 64 | $851.82 |
+| oi2.4xlarge.search | 16 | 128 | $1,703.64 |
+| oi2.8xlarge.search | 32 | 256 | $3,407.29 |
+| oi2.12xlarge.search | 48 | 384 | $5,110.93 |
+| oi2.16xlarge.search | 64 | 512 | $6,814.58 |
+| oi2.24xlarge.search | 96 | 768 | $10,221.87 |
+
+## Key Characteristics
+
+### Architecture
+- **Dual storage**: Data is written locally (EBS for OR1/OR2/OM2, NVMe for OI2) and synchronously replicated to S3
+- **Automatic recovery**: In case of node failure, missing shards are automatically restored from S3
+- **Indexing on primary only**: Indexing is only performed on primary shards, replicas are synced from S3
+
+### Performance Characteristics
+- **OM2**: Up to 15% higher indexing throughput compared to OR1, 66% higher than M7g
+- **OR2**: Better price-performance than OR1 (3-5% cheaper at same specs)
+- **Refresh interval**: Minimum 10 seconds (default 10s, vs 1s for standard instances)
+- **Higher ingestion latency**: Buffer operations before S3 sync add latency
+
+### When to Use Optimized Instances
+
+**Good fit:**
+- Indexing-heavy operational analytics (log analytics, observability, security analytics)
+- Workloads that prioritize indexing throughput over search latency
+- Large-scale data ingestion pipelines
+- Write-heavy workloads where refresh interval of 10s+ is acceptable
+
+**Not ideal for:**
+- **Latency-sensitive vector search / k-NN workloads**: The 10-second minimum refresh interval and S3-sync architecture add latency. For Amazon OpenSearch Service, standard memory-optimized instances such as r7g/r8g are often a better fit for pure low-latency vector search
+- Real-time search with sub-second refresh requirements
+- Read-heavy workloads with minimal indexing
+
+### Vector Search Considerations
+
+For vector search workloads, optimized instances can be used but with caveats:
+- The 10-second refresh interval means newly indexed vectors won't be searchable immediately
+- S3 sync adds write latency, which can impact bulk vector indexing throughput
+- For pure low-latency vector search clusters on Amazon OpenSearch Service, standard memory-optimized instances such as **r7g/r8g** usually provide better search latency
+- For mixed workloads (logs + vectors), OR2/OM2 can be cost-effective for the log portion
+
+## Requirements & Limitations
+
+- **OpenSearch version**: 2.11+ for new domains, 2.15+ for existing domains
+- **Encryption at rest**: Must be enabled
+- **Master nodes**: Must use Graviton instances (c6g, m6g, r6g, or newer)
+- **Refresh interval**: Minimum 10 seconds
+- **Replica behavior**: Replicas may lag primary shards by a few seconds (monitor via `ReplicationLagMaxTime` metric)
+
+## Provisioning Example
+
+```bash
+# Create domain with OR2 instances
+aws opensearch create-domain \
+  --domain-name my-domain \
+  --engine-version OpenSearch_2.17 \
+  --cluster-config "InstanceType=or2.2xlarge.search,InstanceCount=3,DedicatedMasterEnabled=true,DedicatedMasterType=r7g.large.search,DedicatedMasterCount=3" \
+  --ebs-options "EBSEnabled=true,VolumeType=gp3,VolumeSize=200" \
+  --encryption-at-rest-options Enabled=true \
+  --node-to-node-encryption-options Enabled=true \
+  --domain-endpoint-options EnforceHTTPS=true
+```
+
+## Cost Comparison (us-east-1, 256 GiB memory tier)
+
+| Instance | Type | Memory | $/month | Notes |
+|----------|------|--------|---------|-------|
+| r7g.8xlarge | Standard | 256 GiB | $2,076.85 | Strong fit for vector search |
+| r8g.8xlarge | Standard | 256 GiB | $2,284.90 | Current-generation performance example |
+| or2.8xlarge | Optimized | 256 GiB | $2,336.00 | Best for indexing-heavy + S3 durability |
+| or1.8xlarge | Optimized | 256 GiB | $2,442.58 | Previous gen optimized |
+| oi2.8xlarge | Optimized | 256 GiB | $3,407.29 | NVMe, highest IOPS |
+
+**Key insight**: For the same memory, optimized instances cost ~10-15% more than standard instances, but include S3-based durability and automatic recovery. Choose based on workload type, not just price.
+
+## Tuning Tips
+
+For best indexing throughput on optimized instances:
+1. Use large bulk sizes (recommended: 10 MB per bulk request)
+2. Use multiple ingestion clients for parallel processing
+3. Set primary shard count = data node count for maximum utilization
+4. Monitor `ReplicationLagMaxTime` to ensure replicas stay in sync

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/performance-benchmarks.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/performance-benchmarks.md
@@ -1,0 +1,515 @@
+# OpenSearch Vector Search Performance Benchmarks
+
+## Core Concepts
+
+This document provides performance benchmark data for OpenSearch vector search across different node shapes, dataset sizes, and vector dimensions. Many concrete examples use Amazon OpenSearch Service instance names because they are easy to compare, but the portable sizing signals are CPU generation, memory per node, storage IOPS/throughput, shard count, compression, and target latency.
+
+<!-- FALLBACK: opensearch, priority=1 -->
+<!-- FALLBACK: aws-pricing, priority=2, condition="cost-related" -->
+
+## Key Performance Metrics
+
+- **QPS (Queries Per Second)**: Queries per second, higher is better
+- **Latency (p95/p99)**: Latency percentiles, lower is better
+- **Recall@10/100**: Recall rate, higher is better (typically > 0.9 is excellent)
+- **ef_search**: HNSW search parameter, affects the balance between recall and performance
+- **Load Time**: Index build time (seconds)
+
+## Dataset Size and Instance Selection
+
+### Small-Scale Dataset (1M Vectors)
+
+#### 1M Vectors, 1024 Dimensions
+
+**Example Configuration**: 2 × r7g.xlarge or equivalent memory-optimized nodes (2 shards, 1 replica)
+
+| ef_search | QPS | Latency (p95) | Recall@100 | Notes |
+|-----------|-----|---------------|------------|-------|
+| 40 | 1327.56 | 8.4ms | 0.8388 | Low-latency scenario |
+| 100 | 1145.40 | 9.2ms | 0.9143 | Balanced configuration |
+| 200 | 931.13 | 10.5ms | 0.9502 | High-recall scenario |
+
+**Key Findings**:
+- Using fp16 can improve performance by approximately 5%
+- 2 shards + 1 replica provides good availability
+- Load Time: ~1062 seconds
+
+#### 1M Vectors, 1536 Dimensions
+
+**Example Configuration**: 3 × r7g.2xlarge or equivalent memory-optimized nodes (3 shards, 2 replica)
+
+| ef_search | QPS | Latency (p95) | Recall@100 | Notes |
+|-----------|-----|---------------|------------|-------|
+| 100 | 2356.32 | 11.9ms | 0.9746 | Recommended configuration |
+| 200 | 2044.13 | 12.9ms | 0.9915 | High recall |
+
+**Load Time**: ~852 seconds
+
+### Medium-Scale Dataset (10M Vectors)
+
+#### 10M Vectors, 768 Dimensions
+
+**Example Configuration**: 3 × r8g.2xlarge or equivalent memory-optimized nodes (3 shards, 0 replica)
+
+| ef_search | QPS | Latency (p95) | Recall@100 | Notes |
+|-----------|-----|---------------|------------|-------|
+| 40 | 2078.03 | 6.8ms | 0.8962 | Low latency |
+| 100 | 1741.79 | 7.3ms | 0.9389 | Balanced configuration |
+| 200 | 1333.02 | 8.1ms | 0.9699 | High recall |
+
+**Key Findings**:
+- 6 shards configuration can improve concurrent performance
+- ef_construction=400, m=20 can optimize index quality
+- GPU acceleration can improve index build speed by approximately 45%
+
+#### 10M Vectors, 1024 Dimensions
+
+**Example Configuration**: 3 × r7g.2xlarge or equivalent memory-optimized nodes (3 shards, 0 replica)
+
+| ef_search | QPS | Latency (p95) | Recall@100 | Notes |
+|-----------|-----|---------------|------------|-------|
+| 40 | 2788.63 | 7.9ms | 0.8082 | Low latency |
+| 100 | 2435.95 | 9.0ms | 0.8755 | Balanced configuration |
+| 200 | 1983.60 | 9.7ms | 0.9133 | High recall |
+
+**Load Time**: ~6078 seconds
+
+**High-Performance Example**: 2 × r7g.16xlarge or equivalent high-memory nodes (16 shards)
+- ef_search=100: QPS 1856, Latency 9.8ms, Recall@100 0.9245
+- Load Time: ~54979 seconds
+
+### Large-Scale Dataset (100M Vectors)
+
+#### 100M Vectors, 768 Dimensions
+
+**In-Memory Mode Example**: r8g.16xlarge.search × 2 or equivalent high-memory nodes (17 shards, 1 replica)
+
+| ef_search | QPS | Latency (p95) | Recall@100 | Memory Usage |
+|-----------|-----|---------------|------------|--------------|
+| 100 | 2982.79 | 9.6ms | 0.9343 | 315GB × 2 (86.2%) |
+| 200 | 2246.56 | 10.3ms | 0.9454 | High memory usage |
+| 400 | 1512.79 | 12.9ms | 0.9513 | Highest recall |
+
+**On-Disk Mode Example**: r8g.xlarge × 5 or equivalent IO-backed nodes (10 shards, 1 replica, on-disk 32x)
+
+| ef_search | QPS | Latency (p95) | IOPS | Throughput | Memory Usage |
+|-----------|-----|---------------|------|------------|--------------|
+| 100 | 32.83 | 132.9ms | 4500 | 250MB/s | 9.7GB/node (83.6%) |
+| 200 | 32.59 | 170.2ms | 4500 | 250MB/s | Low memory |
+
+**High IOPS Configuration**: IOPS 9000, Throughput 500MB/s
+- ef_search=100: QPS 73.48, Latency 114.9ms
+- Performance improvement of approximately 2.2×
+
+**Key Findings**:
+- On-disk mode significantly reduces QPS (approximately 1/100)
+- High IOPS can partially mitigate on-disk mode performance loss
+- In-memory mode is suitable for low-latency requirements
+- On-disk mode is suitable for cost-sensitive scenarios
+
+## Quantization Compression (Binary Quantization)
+
+### BQ Performance Comparison (1M Vectors, 1 × r8g.4xlarge)
+
+#### Standard Mode (No Compression)
+
+| Shards | ef_search | QPS | Latency (p95) | Recall@100 |
+|--------|-----------|-----|---------------|------------|
+| 1 | 100 | 4889.04 | 6.5ms | 0.9697 |
+| 1 | 200 | 4294.15 | 6.1ms | 0.9812 |
+
+#### BQ 1-bit (oversample-factor 20)
+
+| Shards | ef_search | QPS | Latency (p95) | Recall@100 | Performance Change |
+|--------|-----------|-----|---------------|------------|---------------------|
+| 1 | 100 | 3097.73 | 7.9ms | 0.7659 | -37% QPS, -21% Recall |
+| 8 | 100 | 570.04 | 11.4ms | 0.9243 | Multi-shard compensation |
+
+#### BQ 4-bit (oversample-factor 20)
+
+| Shards | ef_search | QPS | Latency (p95) | Recall@100 | Performance Change |
+|--------|-----------|-----|---------------|------------|---------------------|
+| 8 | 100 | 541.84 | 11.8ms | 0.9598 | High recall |
+| 8 | 200 | 461.32 | 13.1ms | 0.9838 | Near lossless |
+
+**Key Findings**:
+- BQ 1-bit: 32× memory savings, but noticeable recall degradation
+- BQ 4-bit: 8× memory savings, near-lossless recall
+- Reducing oversample-factor from 20 to 10 can improve QPS by approximately 54%
+- Multi-shard configuration can compensate for performance loss from quantization
+
+## On-Disk Mode Cost-Effectiveness Analysis
+
+### 10M Vectors, 1024 Dimensions Comparison
+
+#### In-Memory Mode (om2.2xlarge.search × 1)
+
+| Compression | ef_search | QPS | Latency (p95) | Recall@100 | Memory |
+|-------------|-----------|-----|---------------|------------|--------|
+| 8x | 100 | 2012.46 | 7.1ms | 0.9214 | Standard |
+| 32x | 100 | 1497.58 | 6.1ms | 0.9033 | 2.7MB |
+
+#### On-Disk Mode (om2.2xlarge.search × 1, 4 shards)
+
+| Compression | ef_search | QPS | Latency (p95) | Recall@100 | Cost |
+|-------------|-----------|-----|---------------|------------|------|
+| 8x | 100 | 43.58 | 148.4ms | 0.9214 | $760.51/month |
+| 32x | 100 | 41.61 | 101.8ms | 0.9033 | Lower cost |
+
+**Key Findings**:
+- On-disk mode reduces QPS by approximately 98%
+- Latency increases by approximately 20×
+- Suitable for batch processing or cost-sensitive scenarios
+- Unstable: QPS fluctuates between 40-1500, affected by EBS IOPS
+
+### 1M Vectors, 1024 Dimensions Comparison
+
+#### Memory-Optimized Instances (om2.2xlarge.search × 1)
+
+| Compression | ef_search | QPS | Latency (p95) | Recall@100 | Memory |
+|-------------|-----------|-----|---------------|------------|--------|
+| 32x | 100 | 1710.08 | 7.0ms | 0.8958 | 273KB |
+| 8x | 100 | 1384.60 | 7.3ms | 0.9305 | 648KB |
+
+#### General-Purpose / Smaller Memory Nodes (r8g.xlarge × 1 example)
+
+| Compression | ef_search | QPS | Latency (p95) | Recall@100 |
+|-------------|-----------|-----|---------------|------------|
+| 8x | 100 | 730.89 | 7.1ms | 0.9317 |
+| 8x | 200 | 564.56 | 8.3ms | 0.9634 |
+
+**Cost Optimization Recommendations**:
+- General-purpose instances are more economical for small datasets
+- 8x compression provides the best cost-effectiveness
+- 32x compression is suitable for extreme memory-constrained scenarios
+
+## GPU Acceleration Results
+
+### 100M Vectors, 768 Dimensions (3 × r8g.2xlarge)
+
+| Configuration | Index Time | Speedup |
+|---------------|------------|---------|
+| No GPU | 56271 seconds | Baseline |
+| GPU Enabled | 31037 seconds | 1.81× |
+
+**Query Performance** (6 shards, 0 replica, ondisk):
+
+| ef_search | QPS | Latency (p95) | Recall@100 |
+|-----------|-----|---------------|------------|
+| 100 | 1653.50 | 7.9ms | 0.9121 |
+| 200 | 1460.13 | 8.0ms | 0.9243 |
+| 400 | 1217.60 | 8.6ms | 0.9291 |
+
+**Key Findings**:
+- GPU accelerates index building by approximately 45-81%
+- Query performance is not affected by GPU
+- Suitable for scenarios requiring frequent index rebuilds
+
+## Instance Selection Recommendations
+
+### Selection by Data Scale (AWS Example Cost Comparison)
+
+| Data Scale | Dimensions | Recommended Instance | Shards | Replica | Expected QPS | Expected Latency | Monthly Cost (USD) |
+|------------|------------|---------------------|--------|---------|--------------|------------------|--------------------|
+| 1M | 1024 | 2 × r7g.xlarge | 2 | 1 | 1000+ | < 10ms | ~$308 |
+| 1M | 1024 (compressed) | 1 × r8g.xlarge | 1 | 0 | 700+ | < 10ms | ~$154 (50% savings) |
+| 1M | 1536 | 3 × r7g.2xlarge | 3 | 2 | 2000+ | < 12ms | ~$924 |
+| 10M | 768 | 3 × r8g.2xlarge | 3-6 | 0-1 | 1500+ | < 8ms | ~$616 |
+| 10M | 1024 | 3 × r7g.2xlarge | 3 | 0 | 2000+ | < 10ms | ~$924 |
+| 10M | 1024 (compressed) | 2 × r8g.2xlarge | 4 | 0 | 1200+ | < 12ms | ~$616 (33% savings) |
+| 100M | 768 (in-memory) | 2 × r8g.16xlarge | 17 | 1 | 2500+ | < 10ms | ~$4,934 |
+| 100M | 768 (on-disk) | 5 × r8g.xlarge | 10 | 1 | 30-70 | < 200ms | ~$970 (80% savings) |
+
+**Cost Notes**:
+- Costs are based on AWS us-east-1 region on-demand pricing
+- On-disk mode costs include EBS storage fees
+- Using Reserved Instances can save an additional 30-60%
+- Compressed mode uses 8x quantization compression
+- For self-managed OpenSearch, Kubernetes, or another cloud, use the same memory/CPU/IO profile and replace the price column with your platform's node and storage costs.
+
+### Selection by Performance Requirements (with Cost Tradeoffs)
+
+**Low-Latency Scenario** (< 10ms):
+- Use in-memory mode
+- ef_search = 40-100
+- Choose current-generation CPUs with enough memory for graph/cache headroom
+- Avoid on-disk mode
+- **Cost**: High (baseline)
+- **Use Case**: Real-time recommendations, search services
+
+**High-Throughput Scenario** (> 2000 QPS):
+- Increase the number of shards
+- Use larger nodes when CPU saturation, network limits, or shard overhead become bottlenecks
+- Consider multiple replicas to distribute load
+- **Cost**: Very high (baseline × 2-3)
+- **Use Case**: High-traffic applications
+
+**Cost-Optimized Scenario**:
+- Use on-disk mode + quantization compression
+- Accept higher latency (100-200ms)
+- Suitable for batch processing or offline scenarios
+- **Cost**: Low (50-80% savings)
+- **Use Case**: Batch processing, data analytics, MVP stage
+
+**High-Recall Scenario** (Recall > 0.95):
+- ef_search = 200-400
+- ef_construction = 400+
+- Avoid excessive quantization compression
+- **Cost**: Medium-high (baseline × 1.2-1.5)
+- **Use Case**: Precision matching, mission-critical workloads
+
+**Balanced Scenario** (Recommended):
+- Use 8x quantization compression
+- ef_search = 100-200
+- In-memory mode + reasonable sharding
+- **Cost**: Medium (30-50% savings)
+- **Use Case**: Most production environments
+
+## Parameter Tuning Recommendations
+
+### HNSW Parameters
+
+**ef_construction**:
+- Default: 128
+- High-quality index: 200-400
+- Tradeoff: Higher values increase indexing time but improve recall
+
+**m (connections)**:
+- Default: 16
+- High-dimensional data: 20-24
+- Tradeoff: Higher values increase memory but improve recall
+
+**ef_search**:
+- Low latency: 40-100
+- Balanced: 100-200
+- High recall: 200-400
+
+### Quantization Compression Parameters
+
+**oversample-factor**:
+- BQ 1-bit: 10-20
+- BQ 4-bit: 20
+- Tradeoff: Higher values improve recall but reduce performance
+
+**Compression Ratio Selection**:
+- 32x (1-bit): Extreme memory constraints, acceptable recall loss
+- 8x (4-bit): Recommended, near-lossless recall
+- No compression: Sufficient memory, pursuing maximum performance
+
+### Sharding Strategy
+
+**Number of Shards**:
+- Small dataset (< 10M): 2-4 shards
+- Medium dataset (10M-50M): 6-9 shards
+- Large dataset (> 50M): 10-17 shards
+- Rule of thumb: shards ≈ CPU cores × 1.5
+
+**Number of Replicas**:
+- Development environment: 0 replicas
+- Production environment: 1-2 replicas
+- High availability: 2 replicas (3 AZs)
+
+## Common Issues
+
+### Issue 1: Unstable QPS with Large Fluctuations
+
+**Symptoms**: QPS fluctuates from tens to thousands, latency also fluctuates significantly
+
+**Causes**:
+- EBS IOPS throttling in on-disk mode
+- Insufficient memory causing frequent page swaps
+- Excessive JVM GC pressure
+
+**Solutions**:
+1. Check EBS IOPS and throughput configuration
+2. Increase IOPS to 9000+, throughput to 500MB/s+
+3. Monitor memory usage, consider upgrading instances
+4. Adjust JVM heap size
+
+### Issue 2: Recall Lower Than Expected
+
+**Symptoms**: Recall@100 < 0.9
+
+**Causes**:
+- ef_search set too low
+- Excessive quantization compression loss
+- Insufficient index quality
+
+**Solutions**:
+1. Increase ef_search to 200+
+2. Use 4-bit instead of 1-bit quantization
+3. Increase ef_construction to 400+
+4. Increase oversample-factor
+
+### Issue 3: Excessive Memory Usage
+
+**Symptoms**: Memory usage > 85%, frequent OOM
+
+**Causes**:
+- Dataset too large
+- Compression not enabled
+- Too many replicas
+
+**Solutions**:
+1. Enable quantization compression (8x or 32x)
+2. Use on-disk mode
+3. Reduce the number of replicas
+4. Upgrade to memory-optimized instances
+
+### Issue 4: Index Build Time Too Long
+
+**Symptoms**: Load Time > 10 hours
+
+**Causes**:
+- Dataset too large
+- ef_construction set too high
+- Single-threaded writes
+
+**Solutions**:
+1. Enable GPU acceleration (45-81% improvement)
+2. Reduce ef_construction to 128-200
+3. Increase the number of write threads
+4. Use more shards for parallel building
+
+## Performance Testing Tools
+
+**Recommended Tools**:
+- opensearch-benchmark: Official performance testing tool
+- vector-search-benchmark: Vector search-specific benchmarking tool
+
+**Key Metrics to Monitor**:
+- CloudWatch: CPU, Memory, IOPS, Network
+- OpenSearch Metrics: JVM heap, GC, Query latency
+- Custom Metrics: QPS, Recall, Index size
+
+## Cost Comparison Analysis
+
+### Cost-Effectiveness Comparison of Different Configurations
+
+#### Small-Scale Scenario (1M Vectors, 768 Dimensions)
+
+| Configuration | Instance Setup | Monthly Cost | QPS | Latency | Cost/1000 QPS |
+|---------------|----------------|-------------|-----|---------|---------------|
+| Standard In-Memory | 2 × r8g.xlarge | $308 | 1,327 | 8.4ms | $232 |
+| 8x Compression | 1 × r8g.xlarge | $154 | 730 | 7.1ms | $211 |
+| 32x Compression | 1 × r8g.large | $77 | 400 | 8.5ms | $193 |
+| On-Disk Mode | 1 × r8g.large | $95 | 25 | 150ms | $3,800 |
+
+**Best Choice**: 8x compression (best cost-effectiveness)
+
+#### Medium-Scale Scenario (10M Vectors, 1024 Dimensions)
+
+| Configuration | Instance Setup | Monthly Cost | QPS | Latency | Cost/1000 QPS |
+|---------------|----------------|-------------|-----|---------|---------------|
+| Standard In-Memory | 3 × r7g.2xlarge | $924 | 2,435 | 9.0ms | $379 |
+| 8x Compression | 2 × r8g.2xlarge | $616 | 1,200 | 11ms | $513 |
+| On-Disk Mode | 1 × om2.2xlarge | $761 | 43 | 148ms | $17,698 |
+
+**Best Choice**:
+- High-performance needs: Standard in-memory
+- Cost-sensitive: 8x compression (33% savings)
+
+#### Large-Scale Scenario (100M Vectors, 768 Dimensions)
+
+| Configuration | Instance Setup | Monthly Cost | QPS | Latency | Cost/1000 QPS |
+|---------------|----------------|-------------|-----|---------|---------------|
+| In-Memory Mode | 2 × r8g.16xlarge | $4,934 | 2,982 | 9.6ms | $1,655 |
+| On-Disk Mode (Standard) | 5 × r8g.xlarge | $770 | 32 | 132ms | $24,063 |
+| On-Disk Mode (High IOPS) | 5 × r8g.xlarge | $970 | 73 | 114ms | $13,288 |
+
+**Best Choice**:
+- Real-time services: In-memory mode
+- Batch processing: On-disk mode (80% savings)
+
+### Compression Level Cost-Effectiveness Analysis
+
+#### 1M Vectors, 1024 Dimensions, Single Instance Comparison
+
+| Compression Level | Instance Type | Monthly Cost | Memory Usage | QPS | Recall | Cost-Effectiveness Score |
+|-------------------|---------------|-------------|--------------|-----|--------|--------------------------|
+| No Compression | r8g.4xlarge | $617 | 8.7 GB | 4,889 | 0.970 | 7.9 |
+| 8x (4-bit) | r8g.xlarge | $154 | 1.1 GB | 730 | 0.960 | **9.5** ⭐ |
+| 32x (1-bit) | r8g.large | $77 | 273 KB | 400 | 0.766 | 5.2 |
+
+**Cost-Effectiveness Score** = (QPS × Recall) / Cost × 100
+
+**Conclusion**: 8x compression provides the best cost-effectiveness
+
+### Replica Strategy Cost Impact
+
+| Replicas | Cost Multiplier | Availability | Read Performance | Recommended Scenario |
+|----------|-----------------|--------------|------------------|---------------------|
+| 0 | 1× | Low | Baseline | Development/Testing |
+| 1 | 2× | High | +50% | Production (recommended) |
+| 2 | 3× | Very high | +100% | Mission-critical services |
+
+**Cost Optimization Recommendations**:
+- Development environment: 0 replicas (50% savings)
+- Production environment: 1 replica (balance cost and availability)
+- Mission-critical services: 2 replicas (highest availability)
+
+### Reserved Instances Cost Savings
+
+#### 1-Year Reserved Instance Discounts
+
+| Instance Type | On-Demand Price | 1-Year Reserved | Savings | 3-Year Reserved | Savings |
+|---------------|-----------------|-----------------|---------|-----------------|---------|
+| r8g.xlarge | $154/month | $108/month | 30% | $77/month | 50% |
+| r8g.2xlarge | $308/month | $216/month | 30% | $154/month | 50% |
+| r8g.4xlarge | $617/month | $432/month | 30% | $308/month | 50% |
+| r8g.16xlarge | $2,467/month | $1,727/month | 30% | $1,234/month | 50% |
+
+**Break-Even Period**:
+- 1-year reserved: Takes effect immediately
+- 3-year reserved: Suitable for long-term stable services
+
+### Overall Cost Optimization Strategy
+
+#### Cost Optimization Priority
+
+1. **Use 8x Quantization Compression** → 50-75% savings
+   - Near-lossless recall
+   - Takes effect immediately
+   - No architecture changes required
+
+2. **Optimize Replica Configuration** → 33-50% savings
+   - Use 0 replicas for development environments
+   - Use 1 replica for production environments
+   - Avoid excessive redundancy
+
+3. **Use Reserved Instances** → 30-50% savings
+   - 1-year reserved suitable for most scenarios
+   - 3-year reserved suitable for core services
+   - Requires long-term commitment
+
+4. **Consider On-Disk Mode** → 50-80% savings
+   - Only suitable for batch processing scenarios
+   - Must accept higher latency
+   - Requires high IOPS EBS
+
+5. **Right-Size Instances** → 20-40% savings
+   - Monitor resource utilization
+   - Target 60-80% CPU/memory
+   - Evaluate and adjust periodically
+
+#### Cost Optimization Decision Tree
+
+```
+Can you accept 5% recall loss?
+├─ Yes → Use 8x compression (recommended)
+│   └─ Is this a production environment?
+│       ├─ Yes → 1 replica + 1-year RI → Total savings 65%
+│       └─ No → 0 replicas → Total savings 75%
+└─ No → Can you accept 100ms+ latency?
+    ├─ Yes → On-disk mode + 32x compression → Total savings 80%
+    └─ No → Standard configuration + 1-year RI → Total savings 30%
+```
+
+## Reference Resources
+
+- OpenSearch k-NN Official Documentation
+- HNSW Algorithm Paper
+- Binary Quantization Technical Documentation
+- AWS EC2 Instance Type Comparison
+- [AWS Pricing Calculator](https://calculator.aws/) - Cost estimation tool
+- [OpenSearch Cost Optimization Blog](https://aws.amazon.com/blogs/big-data/) - Latest optimization techniques

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/performance-benchmarks.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/performance-benchmarks.md
@@ -4,9 +4,6 @@
 
 This document provides performance benchmark data for OpenSearch vector search across different node shapes, dataset sizes, and vector dimensions. Many concrete examples use Amazon OpenSearch Service instance names because they are easy to compare, but the portable sizing signals are CPU generation, memory per node, storage IOPS/throughput, shard count, compression, and target latency.
 
-<!-- FALLBACK: opensearch, priority=1 -->
-<!-- FALLBACK: aws-pricing, priority=2, condition="cost-related" -->
-
 ## Key Performance Metrics
 
 - **QPS (Queries Per Second)**: Queries per second, higher is better

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/quantization-techniques.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/quantization-techniques.md
@@ -1,0 +1,922 @@
+# OpenSearch Vector Quantization Techniques In-Depth
+
+## Overview
+
+Vector quantization is a lossy data compression technique that reduces memory usage and computational requirements by mapping high-precision numerical values to smaller discrete values. With the rise of generative AI applications, vector data volumes are growing exponentially, making quantization techniques a key approach for balancing performance and cost.
+
+OpenSearch supports four main quantization techniques:
+- **Binary Quantization**: 1-4 bit binary quantization, up to 32× compression
+- **Byte Quantization**: 8-bit integer quantization, 4× compression
+- **FP16 Quantization**: 16-bit floating-point quantization, 2× compression
+- **Product Quantization**: Up to 64× compression
+
+<!-- FALLBACK: opensearch, priority=1 -->
+
+## Quantization Principles
+
+### Scalar Quantization vs Product Quantization
+
+**Scalar Quantization**:
+- Quantizes each dimension of the vector independently
+- Simple implementation with high computational efficiency
+- Includes Binary, Byte, and FP16 quantization
+
+**Product Quantization**:
+- Splits the vector into multiple sub-vectors, quantizing each separately
+- Higher compression ratio but increased computational complexity
+- Requires a training process to build a codebook
+
+### Memory Requirement Calculation Formula
+
+**HNSW Standard Memory Formula** (published sizing heuristic; validate with your OpenSearch version and workload):
+```
+Memory = 1.1 × (4 × d + 8 × m) × num_vectors × (number_of_replicas + 1) bytes
+
+Where:
+- d: Vector dimension (e.g., 256, 768, 1536)
+- m: HNSW connections per node (default 16)
+- num_vectors: Total number of vectors in the index
+- 4 × d: float32 storage per vector (bytes)
+- 8 × m: Connection overhead per vector in the HNSW graph structure (bytes)
+- 1.1: Additional overhead factor
+```
+
+**Quantization Scenario (FAISS engine, compressed vectors stored in memory)**:
+```
+Memory = 1.1 × (bytes_per_vector + 8 × m) × num_vectors × (number_of_replicas + 1)
+```
+
+**bytes_per_vector for different quantization methods**:
+- No compression (float32): 4 × d
+- FP16 (2x): 2 × d
+- Byte/Int8 (4x): 1 × d
+- Binary 4-bit (8x): d / 2
+- Binary 2-bit (16x): d / 4
+- Binary 1-bit (32x): d / 8
+
+## Binary Quantization
+
+### Technical Characteristics
+
+**Compression Principle**:
+Compresses 32-bit floating-point numbers into 1-4 bit binary representations, mapping continuous values to a discrete binary space through a threshold function.
+
+**Supported Encoding Bit Widths**:
+- 1-bit: 32× compression, value range {0, 1}
+- 2-bit: 16× compression, value range {0, 1, 2, 3}
+- 4-bit: 8× compression, value range {0, 1, ..., 15}
+
+### Configuration Examples
+
+**Basic Configuration**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "vector_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "cosine",
+          "parameters": {
+            "m": 16,
+            "ef_construction": 512,
+            "encoder": {
+              "name": "binary",
+              "parameters": {
+                "bits": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Advanced Configuration**:
+```json
+{
+  "settings": {
+    "index.knn": true,
+    "index.knn.algo_param.ef_search": 100
+  },
+  "mappings": {
+    "properties": {
+      "title": {"type": "text"},
+      "content": {"type": "text"},
+      "vector_field": {
+        "type": "knn_vector",
+        "dimension": 1024,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "cosine",
+          "parameters": {
+            "m": 32,                    // Increase connections to improve recall
+            "ef_construction": 1000,    // Improve build quality
+            "encoder": {
+              "name": "binary",
+              "parameters": {
+                "bits": 2               // Use 2-bit to balance compression and accuracy
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Performance Optimization
+
+**Parameter Tuning Recommendations**:
+```json
+{
+  "parameters": {
+    "m": 32,                // Recommended to increase to 32 for high-dimensional vectors
+    "ef_construction": 1000, // Improve build quality to compensate for quantization loss
+    "encoder": {
+      "name": "binary",
+      "parameters": {
+        "bits": 2           // 2-bit provides better accuracy balance
+      }
+    }
+  }
+}
+```
+
+**Query-Time Optimization**:
+```json
+{
+  "query": {
+    "knn": {
+      "vector_field": {
+        "vector": [...],
+        "k": 10,
+        "method_parameters": {
+          "ef_search": 200    // Increase search depth
+        }
+      }
+    }
+  }
+}
+```
+
+### Use Case Analysis
+
+**Best Suited Scenarios**:
+- High-dimensional vectors (≥ 768 dimensions)
+- Extremely memory-constrained environments
+- Acceptable 15-20% recall loss
+- Batch processing and offline analytics
+
+**Not Suited For**:
+- Low-dimensional vectors (< 384 dimensions)
+- Applications requiring very high recall
+- Real-time recommendation systems
+- Exact matching requirements
+
+## Byte Quantization
+
+### Technical Characteristics
+
+**Quantization Range**: -128 to +127
+**Compression Ratio**: 4×
+**Precision Loss**: Minimal (< 5%)
+
+### Implementation Methods
+
+**Method 1: Pre-processing Quantization**
+```python
+import numpy as np
+
+def quantize_to_byte(vectors):
+    """Quantize floating-point vectors to bytes"""
+    # Find global maximum absolute value
+    max_abs = np.max(np.abs(vectors))
+
+    # Scale to [-127, 127] range
+    scale_factor = 127.0 / max_abs
+    quantized = np.round(vectors * scale_factor).astype(np.int8)
+
+    return quantized, scale_factor
+
+# Usage example
+original_vectors = np.random.randn(1000, 768).astype(np.float32)
+quantized_vectors, scale = quantize_to_byte(original_vectors)
+```
+
+**Method 2: Disk Mode Auto-Quantization**
+```json
+{
+  "mappings": {
+    "properties": {
+      "vector_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "mode": "on_disk",
+        "compression_level": "4x",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+### Configuration Examples
+
+**Direct Byte Vector Index**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "byte_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "data_type": "byte",
+        "space_type": "cosine",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 512,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Data Ingestion Example**:
+```python
+import requests
+import json
+
+def index_byte_vectors(vectors, index_name):
+    """Ingest byte-quantized vectors"""
+    for i, vector in enumerate(vectors):
+        doc = {
+            "byte_vector": vector.tolist(),  # Ensure int8 type
+            "id": i
+        }
+
+        response = requests.post(
+            f"http://localhost:9200/{index_name}/_doc/{i}",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(doc)
+        )
+
+        if response.status_code != 201:
+            print(f"Error indexing document {i}: {response.text}")
+```
+
+### Quality Evaluation
+
+**Quantization Quality Check**:
+```python
+def evaluate_quantization_quality(original, quantized, scale_factor):
+    """Evaluate quantization quality"""
+    # Dequantize
+    dequantized = quantized.astype(np.float32) / scale_factor
+
+    # Calculate similarity
+    similarities = []
+    for i in range(len(original)):
+        sim = np.dot(original[i], dequantized[i]) / (
+            np.linalg.norm(original[i]) * np.linalg.norm(dequantized[i])
+        )
+        similarities.append(sim)
+
+    avg_similarity = np.mean(similarities)
+    min_similarity = np.min(similarities)
+
+    print(f"Average cosine similarity: {avg_similarity:.4f}")
+    print(f"Minimum cosine similarity: {min_similarity:.4f}")
+
+    if avg_similarity > 0.95:
+        print("✓ Excellent quantization quality")
+    elif avg_similarity > 0.90:
+        print("⚠ Good quantization quality")
+    else:
+        print("✗ Poor quantization quality, consider other methods")
+
+    return avg_similarity
+```
+
+## FP16 Quantization (Half-Precision Floating-Point Quantization)
+
+### Technical Characteristics
+
+**Numerical Range**: [-65504.0, 65504.0]
+**Compression Ratio**: 2×
+**Precision Loss**: Very small (< 2%)
+
+### Configuration Examples
+
+**Basic Configuration**:
+```json
+{
+  "mappings": {
+    "properties": {
+      "fp16_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "cosine",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "encoder": {
+              "name": "sq",
+              "parameters": {
+                "type": "fp16",
+                "clip": true
+              }
+            },
+            "ef_construction": 256,
+            "m": 8
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**clip Parameter Description**:
+- `clip: true`: Automatically clips out-of-range values to [-65504.0, 65504.0]
+- `clip: false`: Rejects vectors with out-of-range values (default)
+
+### Data Preprocessing
+
+**Range Check and Preprocessing**:
+```python
+def preprocess_for_fp16(vectors):
+    """Preprocess vectors for FP16 quantization"""
+    # Check value range
+    min_val = np.min(vectors)
+    max_val = np.max(vectors)
+
+    print(f"Original value range: [{min_val:.4f}, {max_val:.4f}]")
+
+    # Check if clipping is needed
+    if min_val < -65504.0 or max_val > 65504.0:
+        print("⚠ Clipping to FP16 range required")
+        vectors = np.clip(vectors, -65504.0, 65504.0)
+        print("✓ Clipped to FP16 range")
+    else:
+        print("✓ Value range compatible with FP16")
+
+    return vectors
+
+# Usage example
+vectors = np.random.randn(1000, 768) * 1000  # May exceed range
+processed_vectors = preprocess_for_fp16(vectors)
+```
+
+### Performance Benchmarks
+
+**FP16 vs Original Precision Comparison**:
+```python
+def benchmark_fp16_performance():
+    """FP16 performance benchmark"""
+    results = {
+        "compression_ratio": 2.0,
+        "memory_reduction": "50%",
+        "index_time_overhead": "< 5%",
+        "query_latency_overhead": "< 10%",
+        "recall_loss": "< 2%",
+        "recommended_scenarios": [
+            "Applications requiring very high precision",
+            "Conservative cost optimization strategies",
+            "Datasets with vector values within supported range"
+        ]
+    }
+    return results
+```
+
+## Product Quantization
+
+### Technical Principles
+
+**Splitting Strategy**:
+```
+Original vector (d dimensions) → m sub-vectors (d/m dimensions)
+Each sub-vector → code_size bit encoding
+Total compression → m × code_size bits
+```
+
+**Compression Ratio Calculation**:
+```
+Compression ratio = (d × 32) / (m × code_size)
+
+Example (d=1024, m=128, code_size=8):
+Compression ratio = (1024 × 32) / (128 × 8) = 32×
+```
+
+### Implementation Steps
+
+**Step 1: Create Training Index**
+```json
+PUT /pq-training-index
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "training_vector": {
+        "type": "knn_vector",
+        "dimension": 1024
+      }
+    }
+  }
+}
+```
+
+**Step 2: Ingest Training Data**
+```python
+def prepare_training_data(vectors, sample_ratio=0.1):
+    """Prepare PQ training data"""
+    # Randomly sample training data
+    n_samples = int(len(vectors) * sample_ratio)
+    indices = np.random.choice(len(vectors), n_samples, replace=False)
+    training_vectors = vectors[indices]
+
+    # Ensure at least 256 samples (2^code_size)
+    if len(training_vectors) < 256:
+        print("⚠ Insufficient training data, recommend at least 256 samples")
+
+    return training_vectors
+
+# Ingest training data
+training_data = prepare_training_data(all_vectors)
+for i, vector in enumerate(training_data):
+    doc = {"training_vector": vector.tolist()}
+    # Ingest into training index...
+```
+
+**Step 3: Train Quantizer Model**
+```json
+POST /_plugins/_knn/models/pq-model-1024/_train
+{
+  "training_index": "pq-training-index",
+  "training_field": "training_vector",
+  "dimension": 1024,
+  "description": "PQ model for 1024-dim vectors",
+  "method": {
+    "name": "hnsw",
+    "engine": "faiss",
+    "parameters": {
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "code_size": 8,
+          "m": 128
+        }
+      },
+      "ef_construction": 256,
+      "m": 8
+    }
+  }
+}
+```
+
+**Step 4: Create Production Index**
+```json
+PUT /pq-production-index
+{
+  "settings": {
+    "number_of_shards": 5,
+    "number_of_replicas": 1,
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "title": {"type": "text"},
+      "content": {"type": "text"},
+      "pq_vector": {
+        "type": "knn_vector",
+        "model_id": "pq-model-1024"
+      }
+    }
+  }
+}
+```
+
+### Parameter Optimization
+
+**Key Parameter Descriptions**:
+- `m`: Number of sub-vectors, typically dimension/8
+- `code_size`: Encoding bits per sub-vector, typically 8
+- Training data volume: At least 2^code_size samples
+
+**Parameter Selection Guide**:
+```python
+def calculate_pq_parameters(dimension):
+    """Calculate PQ parameters"""
+    # Recommended m values
+    m_options = []
+    for m in [8, 16, 32, 64, 128]:
+        if dimension % m == 0:
+            m_options.append(m)
+
+    recommended_m = dimension // 8  # Typically choose d/8
+    if recommended_m not in m_options:
+        recommended_m = min(m_options, key=lambda x: abs(x - dimension//8))
+
+    # code_size is typically fixed at 8
+    code_size = 8
+
+    # Calculate compression ratio
+    compression_ratio = (dimension * 32) // (recommended_m * code_size)
+
+    return {
+        "dimension": dimension,
+        "recommended_m": recommended_m,
+        "code_size": code_size,
+        "compression_ratio": compression_ratio,
+        "min_training_samples": 2 ** code_size
+    }
+
+# Example
+params = calculate_pq_parameters(1024)
+print(f"Recommended config: m={params['recommended_m']}, compression ratio={params['compression_ratio']}×")
+```
+
+### Quality Evaluation
+
+**PQ Model Quality Check**:
+```python
+def evaluate_pq_model(model_id, test_vectors):
+    """Evaluate PQ model quality"""
+    # Quantize using the model
+    quantized_results = []
+
+    for vector in test_vectors:
+        # Get quantized results via API
+        response = requests.post(
+            f"http://localhost:9200/_plugins/_knn/models/{model_id}/_search",
+            json={"vector": vector.tolist(), "k": 1}
+        )
+        quantized_results.append(response.json())
+
+    # Calculate reconstruction error
+    reconstruction_errors = []
+    for original, quantized in zip(test_vectors, quantized_results):
+        error = np.linalg.norm(original - quantized["reconstructed"])
+        reconstruction_errors.append(error)
+
+    avg_error = np.mean(reconstruction_errors)
+    print(f"Average reconstruction error: {avg_error:.4f}")
+
+    if avg_error < 0.1:
+        print("✓ Excellent PQ model quality")
+    elif avg_error < 0.2:
+        print("⚠ Good PQ model quality")
+    else:
+        print("✗ Poor PQ model quality, consider increasing training data or adjusting parameters")
+```
+
+## Disk Mode Quantization
+
+### Built-in Quantization Support
+
+Disk mode supports built-in scalar quantization without preprocessing:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "disk_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "mode": "on_disk",
+        "compression_level": "8x",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 512
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Compression Level Mapping
+
+| Compression Level | Quantization Method | Bits | Memory Savings |
+|----------|----------|------|----------|
+| 2x | FP16 | 16-bit | 50% |
+| 4x | Byte/Int8 | 8-bit | 75% |
+| 8x | 4-bit | 4-bit | 87.5% |
+| 16x | 2-bit | 2-bit | 93.75% |
+| 32x | Binary | 1-bit | 96.875% |
+
+### Rescoring Mechanism
+
+**Two-Stage Search Configuration**:
+```json
+{
+  "query": {
+    "knn": {
+      "disk_vector": {
+        "vector": [...],
+        "k": 10,
+        "method_parameters": {
+          "ef_search": 512
+        },
+        "rescore": {
+          "oversample_factor": 5.0
+        }
+      }
+    }
+  }
+}
+```
+
+**oversample_factor Tuning**:
+```python
+def tune_oversample_factor(compression_level, target_recall=0.90):
+    """Tune oversample_factor based on compression level"""
+    factor_map = {
+        "2x": 1.0,    # FP16 typically doesn't need rescoring
+        "4x": 1.0,    # Byte quantization has high precision
+        "8x": 2.0,    # 4-bit needs moderate rescoring
+        "16x": 3.0,   # 2-bit needs more rescoring
+        "32x": 5.0    # 1-bit needs extensive rescoring
+    }
+
+    base_factor = factor_map.get(compression_level, 3.0)
+
+    # Adjust based on target recall
+    if target_recall > 0.95:
+        return base_factor * 1.5
+    elif target_recall < 0.85:
+        return base_factor * 0.7
+    else:
+        return base_factor
+```
+
+## Quantization Method Selection Decision Tree
+
+### Decision Flow
+
+```python
+def choose_quantization_method(requirements):
+    """Quantization method selection decision tree"""
+
+    # 1. Cost priority assessment
+    if requirements["cost_priority"] == "extreme":
+        if requirements["has_training_data"]:
+            return "Product Quantization (64x)"
+        else:
+            return "Binary Quantization (32x)"
+
+    # 2. Performance requirements assessment
+    if requirements["latency_requirement"] < 20:  # ms
+        if requirements["recall_tolerance"] < 0.02:
+            return "FP16 Quantization (2x)"
+        elif requirements["recall_tolerance"] < 0.05:
+            return "Byte Quantization (4x)"
+        else:
+            return "Binary Quantization (8x-16x)"
+
+    # 3. Data characteristics assessment
+    if requirements["vector_dimension"] < 384:
+        return "FP16 Quantization (2x)"  # Low-dimensional vectors not suited for high compression
+    elif requirements["vector_dimension"] >= 768:
+        return "Binary Quantization (32x)"  # High-dimensional vectors suited for binary quantization
+
+    # 4. Default recommendation
+    return "Byte Quantization (4x)"  # Balanced choice
+
+# Usage example
+requirements = {
+    "cost_priority": "high",
+    "latency_requirement": 50,  # ms
+    "recall_tolerance": 0.05,
+    "vector_dimension": 768,
+    "has_training_data": False
+}
+
+recommended = choose_quantization_method(requirements)
+print(f"Recommended quantization method: {recommended}")
+```
+
+### Scenario-Based Recommendations
+
+**Real-Time Recommendation System**:
+```json
+{
+  "scenario": "real_time_recommendation",
+  "requirements": {
+    "latency": "< 10ms",
+    "qps": "> 1000",
+    "recall": "> 0.95"
+  },
+  "recommended": "FP16 Quantization + Memory Mode",
+  "configuration": {
+    "compression_level": "2x",
+    "mode": "in_memory",
+    "instance_type": "r8g.xlarge+"
+  }
+}
+```
+
+**Batch Processing Analytics**:
+```json
+{
+  "scenario": "batch_processing",
+  "requirements": {
+    "latency": "< 200ms",
+    "qps": "< 100",
+    "cost": "minimize"
+  },
+  "recommended": "Binary Quantization + Disk Mode",
+  "configuration": {
+    "compression_level": "32x",
+    "mode": "on_disk",
+    "instance_type": "r8g.large"
+  }
+}
+```
+
+**General Production Environment**:
+```json
+{
+  "scenario": "general_production",
+  "requirements": {
+    "latency": "< 50ms",
+    "qps": "100-1000",
+    "balance": "cost_performance"
+  },
+  "recommended": "Byte Quantization + Memory Mode",
+  "configuration": {
+    "compression_level": "4x",
+    "mode": "in_memory",
+    "instance_type": "r8g.xlarge"
+  }
+}
+```
+
+## Monitoring and Maintenance
+
+### Key Monitoring Metrics
+
+**Quantization Quality Metrics**:
+```python
+def monitor_quantization_quality():
+    """Monitor quantization quality"""
+    metrics = {
+        "recall_at_k": {
+            "target": "> 0.90",
+            "alert_threshold": "< 0.85",
+            "measurement": "Periodic recall testing"
+        },
+        "precision_at_k": {
+            "target": "> 0.85",
+            "alert_threshold": "< 0.80",
+            "measurement": "Precision evaluation"
+        },
+        "query_latency": {
+            "target": "< target latency",
+            "alert_threshold": "> target latency × 1.5",
+            "measurement": "P95 latency monitoring"
+        }
+    }
+    return metrics
+```
+
+**Resource Usage Monitoring**:
+```python
+def monitor_resource_usage():
+    """Monitor resource usage"""
+    return {
+        "memory_usage": "< 85%",
+        "cpu_usage": "< 80%",
+        "disk_iops": "< 80%",
+        "cache_hit_rate": "> 95%"
+    }
+```
+
+### Automated Testing
+
+**Recall Regression Testing**:
+```python
+import schedule
+import time
+
+def automated_recall_test():
+    """Automated recall regression test"""
+    # 1. Prepare test queries
+    test_queries = load_test_queries()
+
+    # 2. Execute searches
+    results = []
+    for query in test_queries:
+        result = search_with_quantized_index(query)
+        results.append(result)
+
+    # 3. Calculate recall
+    recall = calculate_recall(results, ground_truth)
+
+    # 4. Check threshold
+    if recall < RECALL_THRESHOLD:
+        send_alert(f"Recall degraded: {recall:.3f}")
+
+    # 5. Log history
+    log_metric("recall_at_k", recall)
+
+# Run recall test daily
+schedule.every().day.at("02:00").do(automated_recall_test)
+
+while True:
+    schedule.run_pending()
+    time.sleep(60)
+```
+
+### Failure Recovery
+
+**Quantization Failure Recovery Process**:
+```python
+def quantization_failure_recovery():
+    """Quantization failure recovery process"""
+
+    # 1. Detect failure type
+    failure_type = detect_failure_type()
+
+    if failure_type == "recall_degradation":
+        # Recall degraded - reduce compression level
+        return "reduce_compression_level"
+
+    elif failure_type == "performance_degradation":
+        # Performance degraded - optimize parameters
+        return "optimize_parameters"
+
+    elif failure_type == "index_corruption":
+        # Index corrupted - rebuild index
+        return "rebuild_index"
+
+    else:
+        # Unknown issue - rollback to original configuration
+        return "rollback_to_original"
+
+def execute_recovery_plan(plan):
+    """Execute recovery plan"""
+    if plan == "reduce_compression_level":
+        # Create new index with lower compression level
+        create_index_with_lower_compression()
+
+    elif plan == "optimize_parameters":
+        # Adjust HNSW parameters
+        update_hnsw_parameters()
+
+    elif plan == "rebuild_index":
+        # Rebuild index from backup
+        rebuild_from_backup()
+
+    elif plan == "rollback_to_original":
+        # Switch back to original index
+        switch_to_backup_index()
+```
+
+## Best Practices Summary
+
+### Implementation Recommendations
+
+1. **Phased Deployment**:
+   - Start with conservative FP16 quantization
+   - Gradually try methods with higher compression ratios
+   - Thoroughly test the results at each stage
+
+2. **Thorough Testing**:
+   - Establish a complete recall test dataset
+   - Conduct A/B testing to validate business impact
+   - Monitor key performance metrics
+
+3. **Monitoring System**:
+   - Establish automated quality monitoring
+   - Set reasonable alert thresholds
+   - Prepare rapid rollback mechanisms
+
+4. **Parameter Tuning**:
+   - Choose appropriate quantization methods based on data characteristics
+   - Optimize HNSW parameters for specific scenarios
+   - Continuously monitor and adjust configurations
+
+By systematically applying these quantization techniques, you can achieve significant cost savings while maintaining search quality, providing sustainable solutions for large-scale vector search applications.

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/quantization-techniques.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/quantization-techniques.md
@@ -10,8 +10,6 @@ OpenSearch supports four main quantization techniques:
 - **FP16 Quantization**: 16-bit floating-point quantization, 2× compression
 - **Product Quantization**: Up to 64× compression
 
-<!-- FALLBACK: opensearch, priority=1 -->
-
 ## Quantization Principles
 
 ### Scalar Quantization vs Product Quantization

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/query-optimization.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/query-optimization.md
@@ -1,0 +1,548 @@
+# Query Optimization Techniques
+
+## Core Concepts
+
+OpenSearch query performance optimization involves query structure design, cache utilization, aggregation optimization, and pagination strategies. Understanding the difference between query context and filter context is key to optimization.
+
+## Common Issues
+
+### Issue 1: Query Context vs Filter Context
+
+**Symptoms**:
+- Slow query speed
+- Cache not taking effect
+- Unnecessary relevance score calculations
+
+**Cause**:
+Query context calculates relevance scores, while filter context only performs boolean matching and can be cached.
+
+**Solution**:
+
+Use filter context for exact matching:
+```json
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "title": "machine learning"
+          }
+        }
+      ],
+      "filter": [
+        {
+          "term": {
+            "status": "published"
+          }
+        },
+        {
+          "range": {
+            "price": {
+              "gte": 10,
+              "lte": 100
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Comparison**:
+```json
+// Slow - using must (calculates scores)
+{
+  "query": {
+    "bool": {
+      "must": [
+        {"term": {"status": "published"}},
+        {"range": {"price": {"gte": 10}}}
+      ]
+    }
+  }
+}
+
+// Fast - using filter (no score calculation, cacheable)
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"status": "published"}},
+        {"range": {"price": {"gte": 10}}}
+      ]
+    }
+  }
+}
+```
+
+**Best Practices**:
+- Use `filter` for exact matching (term, range, exists)
+- Use `must` for full-text search (match, multi_match)
+- Use `must_not` for exclusion conditions
+- Filter queries are automatically cached
+- Place filters in the filter clause of a bool query
+
+### Issue 2: Deep Pagination Performance Problems
+
+**Symptoms**:
+- Queries slow down when navigating to later pages
+- High memory usage
+- Query timeouts
+
+**Cause**:
+When using from/size pagination, results must be sorted and preceding results skipped on every shard.
+
+**Solution**:
+
+1. Use search_after instead of from/size:
+```json
+// First query
+{
+  "size": 10,
+  "query": {
+    "match_all": {}
+  },
+  "sort": [
+    {"timestamp": "desc"},
+    {"_id": "asc"}
+  ]
+}
+
+// Subsequent queries
+{
+  "size": 10,
+  "query": {
+    "match_all": {}
+  },
+  "search_after": [1609459200000, "doc_123"],
+  "sort": [
+    {"timestamp": "desc"},
+    {"_id": "asc"}
+  ]
+}
+```
+
+2. Use the scroll API (suitable for exporting large volumes of data):
+```json
+// Initialize scroll
+POST /my_index/_search?scroll=1m
+{
+  "size": 1000,
+  "query": {
+    "match_all": {}
+  }
+}
+
+// Get next batch
+POST /_search/scroll
+{
+  "scroll": "1m",
+  "scroll_id": "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="
+}
+```
+
+3. Limit max_result_window:
+```json
+{
+  "settings": {
+    "max_result_window": 10000
+  }
+}
+```
+
+**Best Practices**:
+- Avoid using from > 10000
+- Use search_after for real-time pagination
+- Use the scroll API for bulk exports
+- Provide "next page" instead of "jump to page N"
+- Use a unique field (e.g., _id) as the last sort field
+
+### Issue 3: Aggregation Query Optimization
+
+**Symptoms**:
+- Slow aggregation queries
+- High memory usage
+- Inaccurate results (approximate values)
+
+**Cause**:
+Aggregations need to process large amounts of data in memory.
+
+**Solution**:
+
+1. Use filters to reduce the volume of data being aggregated:
+```json
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "2024-01-01"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "categories": {
+      "terms": {
+        "field": "category",
+        "size": 10
+      }
+    }
+  }
+}
+```
+
+2. Use composite aggregation for pagination:
+```json
+{
+  "size": 0,
+  "aggs": {
+    "my_buckets": {
+      "composite": {
+        "size": 100,
+        "sources": [
+          {"category": {"terms": {"field": "category"}}},
+          {"date": {"date_histogram": {"field": "timestamp", "calendar_interval": "day"}}}
+        ]
+      }
+    }
+  }
+}
+```
+
+3. Adjust precision parameters:
+```json
+{
+  "aggs": {
+    "categories": {
+      "terms": {
+        "field": "category",
+        "size": 10,
+        "shard_size": 50,  // Increase the number of buckets at the shard level
+        "show_term_doc_count_error": true
+      }
+    }
+  }
+}
+```
+
+**Best Practices**:
+- Set `size: 0` to return only aggregation results without documents
+- Use filters to narrow data before aggregating
+- Use composite aggregation for high-cardinality fields
+- Adjust `shard_size` to improve accuracy
+- Use `execution_hint: map` to optimize memory usage
+- Avoid deeply nested aggregations (< 3 levels)
+
+### Issue 4: Caching Strategies
+
+**Symptoms**:
+- Identical queries are repeatedly slow
+- Low cache hit rate
+- Unreasonable memory usage
+
+**Cause**:
+OpenSearch's multi-level caching mechanism is not being fully utilized.
+
+**Solution**:
+
+1. Enable request cache (for aggregation queries):
+```json
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"status": "published"}}
+      ]
+    }
+  },
+  "aggs": {
+    "categories": {
+      "terms": {"field": "category"}
+    }
+  }
+}
+```
+
+2. Use query cache (for filter queries):
+```json
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"status": "published"}}  // Automatically cached
+      ]
+    }
+  }
+}
+```
+
+3. Configure cache size:
+```json
+{
+  "settings": {
+    "index.queries.cache.enabled": true,
+    "index.requests.cache.enable": true
+  }
+}
+```
+
+4. Monitor cache effectiveness:
+```bash
+GET /_stats/request_cache,query_cache
+```
+
+**Best Practices**:
+- Filter queries automatically use the query cache
+- Aggregation queries use the request cache (size=0)
+- Queries using `now` are not cached; use `now/d` to round down
+- Regularly monitor cache hit rates and eviction rates
+- Set cache size appropriately (default is 10% of heap memory)
+
+### Issue 5: Multi-Field Search Optimization
+
+**Symptoms**:
+- Slow multi-field searches
+- Suboptimal relevance ranking
+- Complex and hard-to-maintain queries
+
+**Cause**:
+Searching across multiple fields and merging results is required.
+
+**Solution**:
+
+1. Use multi_match:
+```json
+{
+  "query": {
+    "multi_match": {
+      "query": "machine learning",
+      "fields": ["title^3", "content", "tags^2"],
+      "type": "best_fields",
+      "tie_breaker": 0.3
+    }
+  }
+}
+```
+
+2. Use bool query combinations:
+```json
+{
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "match": {
+            "title": {
+              "query": "machine learning",
+              "boost": 3
+            }
+          }
+        },
+        {
+          "match": {
+            "content": "machine learning"
+          }
+        }
+      ],
+      "minimum_should_match": 1
+    }
+  }
+}
+```
+
+3. Use copy_to fields:
+```json
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text",
+        "copy_to": "full_text"
+      },
+      "content": {
+        "type": "text",
+        "copy_to": "full_text"
+      },
+      "full_text": {
+        "type": "text"
+      }
+    }
+  }
+}
+
+// Query
+{
+  "query": {
+    "match": {
+      "full_text": "machine learning"
+    }
+  }
+}
+```
+
+**Best Practices**:
+- Use `^` to set field weights (boost)
+- `best_fields`: Best field matching (default)
+- `most_fields`: Multi-field matching
+- `cross_fields`: Cross-field matching (suitable for name searches)
+- Use `tie_breaker` to factor in scores from other fields
+- For fixed multi-field searches, use copy_to to simplify queries
+
+## Configuration Examples
+
+### High-Performance Query Template
+
+```json
+{
+  "size": 20,
+  "from": 0,
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "multi_match": {
+            "query": "{{search_term}}",
+            "fields": ["title^3", "content"],
+            "type": "best_fields"
+          }
+        }
+      ],
+      "filter": [
+        {
+          "term": {
+            "status": "published"
+          }
+        },
+        {
+          "range": {
+            "created_at": {
+              "gte": "{{start_date}}",
+              "lte": "{{end_date}}"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {"_score": "desc"},
+    {"created_at": "desc"}
+  ],
+  "_source": ["title", "summary", "created_at"],
+  "highlight": {
+    "fields": {
+      "title": {},
+      "content": {
+        "fragment_size": 150,
+        "number_of_fragments": 3
+      }
+    }
+  }
+}
+```
+
+### Aggregation Query Template
+
+```json
+{
+  "size": 0,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "now-7d/d",
+              "lte": "now/d"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "aggs": {
+    "daily_stats": {
+      "date_histogram": {
+        "field": "timestamp",
+        "calendar_interval": "day"
+      },
+      "aggs": {
+        "total_amount": {
+          "sum": {
+            "field": "amount"
+          }
+        },
+        "avg_amount": {
+          "avg": {
+            "field": "amount"
+          }
+        }
+      }
+    },
+    "top_categories": {
+      "terms": {
+        "field": "category",
+        "size": 10,
+        "order": {"_count": "desc"}
+      }
+    }
+  }
+}
+```
+
+## Performance Monitoring
+
+### Slow Query Logs
+
+Configure slow query thresholds:
+```json
+{
+  "settings": {
+    "index.search.slowlog.threshold.query.warn": "10s",
+    "index.search.slowlog.threshold.query.info": "5s",
+    "index.search.slowlog.threshold.query.debug": "2s",
+    "index.search.slowlog.threshold.fetch.warn": "1s"
+  }
+}
+```
+
+View slow query logs:
+```bash
+tail -f /var/log/opensearch/my-cluster_index_search_slowlog.log
+```
+
+### Query Performance Analysis
+
+Use the profile API:
+```json
+{
+  "profile": true,
+  "query": {
+    "match": {
+      "title": "machine learning"
+    }
+  }
+}
+```
+
+### Key Metrics
+
+- Query latency: < 100ms (simple queries), < 500ms (complex queries)
+- Cache hit rate: > 80%
+- Slow query count: < 1%
+- Aggregation queries: < 1s
+
+## Reference Resources
+
+- [OpenSearch Query DSL](https://opensearch.org/docs/latest/query-dsl/)
+- [Performance Tuning Guide](https://opensearch.org/docs/latest/tuning-your-cluster/)
+- [Cache Mechanism Details](https://opensearch.org/docs/latest/api-reference/index-apis/clear-cache/)

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/vector-search.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/vector-search.md
@@ -14,9 +14,6 @@ OpenSearch supports two vector index modes:
 - **Capacity Shape**: Choose memory-optimized nodes for low-latency in-memory k-NN, storage/IO-optimized nodes for disk mode, and enough data nodes to keep shard sizes and k-NN cache pressure manageable.
 - **Provider-Specific Mapping**: If the target is Amazon OpenSearch Service, current-generation memory-optimized families such as r7g/r8g/r8gd are common vector-search examples; optimized families such as OR2/OM2/OI2 have workload-specific tradeoffs. For self-managed OpenSearch, map the same CPU, memory, and IO requirements to your available instance or Kubernetes node classes.
 
-<!-- FALLBACK: opensearch, priority=1 -->
-<!-- FALLBACK: aws-pricing, priority=2, condition="cost-related" -->
-
 ## Common Issues
 
 ### Issue 1: First Vector Query Is Very Slow (Cold Start Problem)
@@ -121,7 +118,7 @@ Vector dimensions directly affect computational complexity and storage space.
     "properties": {
       "embedding": {
         "type": "knn_vector",
-        "dimension": 384,  // Choose based on model
+        "dimension": 384,
         "method": {
           "name": "hnsw",
           "space_type": "cosine"

--- a/skills/opensearch-skills/search/opensearch-vector-search/references/vector-search.md
+++ b/skills/opensearch-skills/search/opensearch-vector-search/references/vector-search.md
@@ -1,0 +1,497 @@
+# Vector Search and k-NN Optimization
+
+## Core Concepts
+
+OpenSearch's k-NN (k-Nearest Neighbors) plugin supports efficient vector similarity search, using the HNSW (Hierarchical Navigable Small World) algorithm to build graph indices. Vector search performance depends on index configuration, caching strategy, and query parameters.
+
+OpenSearch supports two vector index modes:
+- **Memory Mode**: Vector index is stored in memory, providing optimal performance (< 10ms latency)
+- **Disk Mode**: Vector index is stored on disk, significantly reducing memory requirements and cost, but with higher latency (100-200ms)
+
+**Portable Default Configuration**:
+- **Vector Engine**: FAISS for most production workloads; verify version support before using newer options.
+- **Similarity Algorithm**: cosine for normalized embeddings and broad semantic-search use cases; use L2 or inner product when the embedding model requires it.
+- **Capacity Shape**: Choose memory-optimized nodes for low-latency in-memory k-NN, storage/IO-optimized nodes for disk mode, and enough data nodes to keep shard sizes and k-NN cache pressure manageable.
+- **Provider-Specific Mapping**: If the target is Amazon OpenSearch Service, current-generation memory-optimized families such as r7g/r8g/r8gd are common vector-search examples; optimized families such as OR2/OM2/OI2 have workload-specific tradeoffs. For self-managed OpenSearch, map the same CPU, memory, and IO requirements to your available instance or Kubernetes node classes.
+
+<!-- FALLBACK: opensearch, priority=1 -->
+<!-- FALLBACK: aws-pricing, priority=2, condition="cost-related" -->
+
+## Common Issues
+
+### Issue 1: First Vector Query Is Very Slow (Cold Start Problem)
+
+**Symptoms**:
+- First vector query takes several seconds or longer
+- Subsequent queries perform normally
+- Problem recurs after cluster restart
+
+**Cause**:
+Vector indices are not loaded into memory by default; the first query needs to read from disk and build the cache.
+
+**Solution**:
+1. Use the warmup API to preload the index:
+```bash
+POST /my-vector-index/_warmup
+```
+
+2. Enable automatic caching in index settings:
+```json
+{
+  "settings": {
+    "index.knn.cache.enabled": true
+  }
+}
+```
+
+3. Monitor cache hit rate:
+```bash
+GET /_plugins/_knn/stats
+```
+
+**Best Practices**:
+- Execute warmup immediately after index creation or data import
+- Reserve sufficient off-heap memory for k-NN cache (circuit_breaker.parent.limit)
+- Regularly monitor cache eviction rate to avoid frequent cache invalidation
+
+### Issue 2: How to Tune HNSW Parameters
+
+**Symptoms**:
+- Slow query speed or low recall rate
+- Index build time is too long
+- Memory usage is too high
+
+**Cause**:
+HNSW parameters (ef_construction, m) directly affect index quality and performance.
+
+**Solution**:
+
+Adjust HNSW parameters:
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosine",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 512,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Parameter Details**:
+- `ef_construction`: Search depth during index construction (default 512)
+  - Higher = better recall, but slower construction
+  - Recommended range: 100-1000
+- `m`: Maximum number of connections per node (default 16)
+  - Higher = better recall, but higher memory usage
+  - Recommended range: 8-48
+
+**Best Practices**:
+- Production: ef_construction=512, m=16 (balance between performance and quality)
+- High recall scenarios: ef_construction=1000, m=32
+- Fast indexing scenarios: ef_construction=128, m=8
+- Adjust the ef parameter (ef_search) at query time to balance speed and recall
+
+### Issue 3: Vector Dimension Selection and Performance Impact
+
+**Symptoms**:
+- Query latency increases significantly with higher dimensions
+- Memory usage is too high
+
+**Cause**:
+Vector dimensions directly affect computational complexity and storage space.
+
+**Solution**:
+
+1. Choose appropriate vector dimensions:
+```json
+{
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 384,  // Choose based on model
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosine"
+        }
+      }
+    }
+  }
+}
+```
+
+2. Consider dimensionality reduction techniques:
+- PCA (Principal Component Analysis)
+- Quantization
+
+**Best Practices**:
+- Use the model's native dimensions; avoid unnecessary padding
+- Common dimensions: 384 (MiniLM), 768 (BERT), 1536 (OpenAI)
+- Lower dimensions yield better performance but may lose precision
+- Test the impact of different dimensions on recall rate
+
+### Issue 4: How to Use Disk Mode to Reduce Costs
+
+**Symptoms**:
+- Memory costs are too high
+- Large-scale vector datasets (> 50M vectors)
+- Higher latency is acceptable (100-200ms)
+
+**Cause**:
+Memory mode requires loading the entire vector index into memory, which is costly for large-scale datasets.
+
+**Solution**:
+
+Use disk mode configuration:
+```json
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "cosine",
+        "data_type": "float",
+        "mode": "on_disk",
+        "compression_level": "32x"
+      }
+    }
+  }
+}
+```
+
+**Parameter Details**:
+- `mode: "on_disk"`: Enable disk mode
+- `data_type: "float"`: Disk mode only supports float data type
+- `compression_level`: Compression level
+  - `"4x"`: Uses Lucene engine, minimal recall loss
+  - `"16x"`: Uses FAISS engine, balances performance and memory
+  - `"32x"`: Default value, maximum memory savings, 15-20% recall loss
+
+**Performance Impact**:
+- QPS: Reduced by ~98% (from 2000+ down to 30-70)
+- Latency: Increased by ~20x (from 10ms to 100-200ms)
+- Memory usage: Reduced by 32x
+- Cost: Reduced by 50-80%
+
+**Automatic Rescoring Mechanism**:
+- Disk mode enables rescoring by default to maintain recall
+- Search is performed in two phases: first search the compressed index, then rescore with full-precision vectors
+- Default `oversample_factor` is 3.0, adjustable as needed
+
+**Best Practices**:
+- Use high-performance EBS volumes (gp3, 9000+ IOPS)
+- Configure sufficient EBS throughput (500+ MB/s)
+- Monitor IOPS utilization to avoid bottlenecks
+- Suitable for batch processing or offline analytics scenarios
+- Not suitable for real-time low-latency applications
+- Only supports `float` data type
+- Consider adjusting `oversample_factor` to balance performance and recall
+
+**EBS Configuration Recommendations**:
+```json
+{
+  "ebs_options": {
+    "ebs_enabled": true,
+    "volume_type": "gp3",
+    "volume_size": 500,
+    "iops": 9000,
+    "throughput": 500
+  }
+}
+```
+
+### Issue 5: Hybrid Query (Vector + Keyword) Optimization
+
+**Symptoms**:
+- Performance degrades when using both vector search and keyword search simultaneously
+- Result ranking does not match expectations
+
+**Cause**:
+Vector similarity scores and text relevance scores need to be combined properly.
+
+**Solution**:
+
+Use script_score or hybrid query:
+```json
+{
+  "query": {
+    "script_score": {
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "match": {
+                "title": "machine learning"
+              }
+            }
+          ],
+          "filter": {
+            "term": {
+              "status": "published"
+            }
+          }
+        }
+      },
+      "script": {
+        "source": "knn_score",
+        "lang": "knn",
+        "params": {
+          "field": "embedding",
+          "query_value": [0.1, 0.2, ...],
+          "space_type": "cosine"
+        }
+      }
+    }
+  }
+}
+```
+
+**Best Practices**:
+- Use filter context for exact matching (does not affect scoring)
+- Adjust the weight between vector and text scores
+- Consider using rescore for secondary ranking
+- Test different score combination strategies
+
+## Configuration Examples
+
+### Complete Vector Index Configuration (Memory Mode)
+
+```json
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "knn.cache.enabled": true,
+      "number_of_shards": 3,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text"
+      },
+      "content": {
+        "type": "text"
+      },
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosine",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 512,
+            "m": 16
+          }
+        }
+      },
+      "timestamp": {
+        "type": "date"
+      }
+    }
+  }
+}
+```
+
+### Disk Mode Configuration (Cost Optimized)
+
+```json
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 6,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text"
+      },
+      "content": {
+        "type": "text"
+      },
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "cosine",
+        "data_type": "float",
+        "mode": "on_disk",
+        "compression_level": "16x",
+        "method": {
+          "params": {
+            "ef_construction": 512
+          }
+        }
+      },
+      "timestamp": {
+        "type": "date"
+      }
+    }
+  }
+}
+```
+
+**Disk Mode Configuration Notes**:
+- Uses `faiss` engine and `hnsw` method by default
+- `compression_level: "16x"` provides the best cost-performance ratio
+- `data_type: "float"` is a required parameter for disk mode
+- Increase shard count to improve concurrent performance
+- Requires high-performance EBS volumes
+
+### Advanced Disk Mode Configuration (Custom Parameters)
+
+```json
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "number_of_shards": 6,
+      "number_of_replicas": 1
+    }
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "space_type": "cosine",
+        "data_type": "float",
+        "mode": "on_disk",
+        "compression_level": "16x",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "params": {
+            "ef_construction": 512,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Vector Query Example
+
+```json
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.2, 0.3, ...],
+        "k": 10
+      }
+    }
+  }
+}
+```
+
+### Vector Query with Filters
+
+```json
+{
+  "size": 10,
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "knn": {
+            "embedding": {
+              "vector": [0.1, 0.2, 0.3, ...],
+              "k": 50
+            }
+          }
+        }
+      ],
+      "filter": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "2024-01-01"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Disk Mode Vector Query (with Rescoring)
+
+```json
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "embedding": {
+        "vector": [0.1, 0.2, 0.3, ...],
+        "k": 10,
+        "method_parameters": {
+          "ef_search": 512
+        },
+        "rescore": {
+          "oversample_factor": 10.0
+        }
+      }
+    }
+  }
+}
+```
+
+## Performance Monitoring
+
+### Key Metrics
+
+1. **Cache Hit Rate**:
+```bash
+GET /_plugins/_knn/stats
+```
+Check `cache_capacity_reached` and `eviction_count`
+
+2. **Query Latency**:
+```bash
+GET /_nodes/stats/indices/search
+```
+
+3. **Memory Usage**:
+```bash
+GET /_cat/nodes?v&h=name,heap.percent,ram.percent
+```
+
+### Performance Benchmarks
+
+- Single vector query: < 100ms (warm cache)
+- First query (cold start): < 2s (after warmup)
+- Cache hit rate: > 95%
+- Recall rate: > 90% (depends on HNSW parameters)
+
+## Reference Resources
+
+- [OpenSearch k-NN Official Documentation](https://opensearch.org/docs/latest/search-plugins/knn/)
+- [HNSW Algorithm Paper](https://arxiv.org/abs/1603.09320)
+- [Vector Search Best Practices](https://opensearch.org/docs/latest/search-plugins/knn/performance-tuning/)

--- a/skills/opensearch-skills/search/opensearch-vector-search/scripts/analyze_cluster.py
+++ b/skills/opensearch-skills/search/opensearch-vector-search/scripts/analyze_cluster.py
@@ -24,13 +24,13 @@ Output: JSON format for easy parsing by AI agents.
 Safety: This script is READ-ONLY. It never creates, modifies, or deletes any indices or data.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import sys
-import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 
-warnings.filterwarnings("ignore")
 
 try:
     from opensearchpy import OpenSearch, RequestsHttpConnection
@@ -40,7 +40,7 @@ except ImportError:
 
 
 def create_client(url: str, username: str = None, password: str = None,
-                  no_auth: bool = False, verify_ssl: bool = False) -> OpenSearch:
+                  no_auth: bool = False, verify_ssl: bool = True) -> OpenSearch:
     """Create an OpenSearch client connection."""
     if OpenSearch is None or RequestsHttpConnection is None:
         print(json.dumps({
@@ -56,7 +56,7 @@ def create_client(url: str, username: str = None, password: str = None,
         "hosts": [parsed],
         "use_ssl": use_ssl,
         "verify_certs": verify_ssl,
-        "ssl_show_warn": False,
+        "ssl_show_warn": not verify_ssl,
         "connection_class": RequestsHttpConnection,
         "timeout": 30,
     }
@@ -65,6 +65,14 @@ def create_client(url: str, username: str = None, password: str = None,
         kwargs["http_auth"] = (username, password)
 
     return OpenSearch(**kwargs)
+
+
+def _as_int(value, default: int = 0) -> int:
+    """Return an integer value without raising on incomplete API responses."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def safe_request(func, *args, **kwargs):
@@ -332,11 +340,7 @@ def get_index_detail(client: OpenSearch, index_name: str) -> dict:
 
     # Memory estimate for vector fields
     if isinstance(result.get("vector_fields"), list) and result["vector_fields"]:
-        doc_count = 0
-        try:
-            doc_count = result.get("stats", {}).get("docs_count", 0) or 0
-        except Exception:
-            pass
+        doc_count = _as_int(result.get("stats", {}).get("docs_count"))
 
         if doc_count > 0:
             result["memory_estimates"] = []
@@ -372,9 +376,9 @@ def get_index_detail(client: OpenSearch, index_name: str) -> dict:
                     compression_label = f"binary {bits}-bit ({int(32/bits)}x)"
                 elif encoder_name == "pq":
                     # PQ: code_size bits per sub-vector, m sub-vectors
-                    pq_m = encoder_params.get("m", dim // 8)
-                    code_size = encoder_params.get("code_size", 8)
-                    total_bytes = (code_size / 8) * pq_m
+                    pq_m = _as_int(encoder_params.get("m"), dim // 8 if dim else 0)
+                    code_size = _as_int(encoder_params.get("code_size"), 8)
+                    total_bytes = (code_size / 8) * pq_m if pq_m else 0
                     bytes_per_dim = total_bytes / dim if dim > 0 else 0
                     compression_label = f"product quantization (PQ m={pq_m}, code_size={code_size})"
 
@@ -566,7 +570,7 @@ def _analyze_index_config(detail: dict, recommendations: list):
         return
 
     # Check knn setting
-    if settings.get("knn") != "true" and vector_fields:
+    if str(settings.get("knn")).lower() != "true" and vector_fields:
         recommendations.append({
             "severity": "CRITICAL",
             "category": "knn_setting",
@@ -642,7 +646,7 @@ def _analyze_index_config(detail: dict, recommendations: list):
                 })
 
         # Quantization recommendations for large indices
-        doc_count = stats.get("docs_count", 0) or 0
+        doc_count = _as_int(stats.get("docs_count"))
         if doc_count > 10_000_000 and not encoder_name and data_type == "float" and not mode:
             recommendations.append({
                 "severity": "INFO",
@@ -682,7 +686,7 @@ def _analyze_index_config(detail: dict, recommendations: list):
     num_shards = settings.get("number_of_shards")
     if num_shards:
         num_shards = int(num_shards)
-        doc_count = stats.get("docs_count", 0) or 0
+        doc_count = _as_int(stats.get("docs_count"))
         if num_shards == 1 and doc_count > 5_000_000:
             recommendations.append({
                 "severity": "WARNING",
@@ -703,7 +707,7 @@ def _analyze_index_config(detail: dict, recommendations: list):
     # Refresh interval
     refresh = settings.get("refresh_interval")
     if refresh and refresh == "1s":
-        doc_count = stats.get("docs_count", 0) or 0
+        doc_count = _as_int(stats.get("docs_count"))
         if doc_count > 1_000_000:
             recommendations.append({
                 "severity": "INFO",
@@ -721,7 +725,11 @@ def main():
     parser.add_argument("--username", "-u", help="Username for basic auth")
     parser.add_argument("--password", "-p", help="Password for basic auth")
     parser.add_argument("--no-auth", action="store_true", help="Connect without authentication")
-    parser.add_argument("--verify-ssl", action="store_true", help="Verify SSL certificates (default: false)")
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification (only for trusted development clusters).",
+    )
     parser.add_argument("--index", "-i", help="Specific index to analyze")
     parser.add_argument("--action", "-a", default="cluster-overview",
                         choices=["cluster-overview", "index-detail", "shard-analysis", "all"],
@@ -746,7 +754,7 @@ def main():
             username=args.username,
             password=args.password,
             no_auth=args.no_auth,
-            verify_ssl=args.verify_ssl,
+            verify_ssl=not args.insecure,
         )
         # Test connection
         client.info()
@@ -759,7 +767,7 @@ def main():
 
     output = {
         "success": True,
-        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "cluster_url": args.url,
     }
 

--- a/skills/opensearch-skills/search/opensearch-vector-search/scripts/analyze_cluster.py
+++ b/skills/opensearch-skills/search/opensearch-vector-search/scripts/analyze_cluster.py
@@ -1,0 +1,814 @@
+#!/usr/bin/env python3
+"""
+OpenSearch Vector Search Cluster Analyzer
+
+Connects to an OpenSearch cluster and analyzes vector (k-NN) index configurations.
+Provides optimization recommendations based on best practices.
+
+Usage:
+  python3 analyze_cluster.py --url <opensearch_url> --username <user> --password <pass>
+  python3 analyze_cluster.py --url <opensearch_url> --no-auth
+  python3 analyze_cluster.py --url <opensearch_url> --username <user> --password <pass> --index <index_name>
+  python3 analyze_cluster.py --url <opensearch_url> --username <user> --password <pass> --action cluster-overview
+  python3 analyze_cluster.py --url <opensearch_url> --username <user> --password <pass> --action index-detail --index <index_name>
+  python3 analyze_cluster.py --url <opensearch_url> --username <user> --password <pass> --action shard-analysis --index <index_name>
+
+Actions:
+  cluster-overview  - Cluster health, nodes, and all k-NN index summary (default)
+  index-detail      - Deep dive into a specific index's vector configuration
+  shard-analysis    - Shard distribution and sizing for a specific index
+  all               - Run all analyses
+
+Output: JSON format for easy parsing by AI agents.
+
+Safety: This script is READ-ONLY. It never creates, modifies, or deletes any indices or data.
+"""
+
+import argparse
+import json
+import sys
+import warnings
+from datetime import datetime
+
+warnings.filterwarnings("ignore")
+
+try:
+    from opensearchpy import OpenSearch, RequestsHttpConnection
+except ImportError:
+    OpenSearch = None
+    RequestsHttpConnection = None
+
+
+def create_client(url: str, username: str = None, password: str = None,
+                  no_auth: bool = False, verify_ssl: bool = False) -> OpenSearch:
+    """Create an OpenSearch client connection."""
+    if OpenSearch is None or RequestsHttpConnection is None:
+        print(json.dumps({
+            "error": "opensearch-py not installed. Run: uv add opensearch-py or use a Python environment with opensearch-py.",
+            "success": False
+        }))
+        sys.exit(1)
+
+    parsed = url.rstrip("/")
+    use_ssl = parsed.startswith("https")
+
+    kwargs = {
+        "hosts": [parsed],
+        "use_ssl": use_ssl,
+        "verify_certs": verify_ssl,
+        "ssl_show_warn": False,
+        "connection_class": RequestsHttpConnection,
+        "timeout": 30,
+    }
+
+    if not no_auth and username and password:
+        kwargs["http_auth"] = (username, password)
+
+    return OpenSearch(**kwargs)
+
+
+def safe_request(func, *args, **kwargs):
+    """Execute a request safely, returning None on error."""
+    try:
+        return func(*args, **kwargs)
+    except Exception as e:
+        return {"_error": str(e)}
+
+
+def get_cluster_overview(client: OpenSearch) -> dict:
+    """Get cluster health, version, and node information."""
+    result = {}
+
+    # Cluster health
+    health = safe_request(client.cluster.health)
+    if health and "_error" not in health:
+        result["cluster_health"] = {
+            "cluster_name": health.get("cluster_name"),
+            "status": health.get("status"),
+            "number_of_nodes": health.get("number_of_nodes"),
+            "number_of_data_nodes": health.get("number_of_data_nodes"),
+            "active_primary_shards": health.get("active_primary_shards"),
+            "active_shards": health.get("active_shards"),
+            "unassigned_shards": health.get("unassigned_shards"),
+        }
+    else:
+        result["cluster_health"] = health
+
+    # Cluster info (version)
+    info = safe_request(client.info)
+    if info and "_error" not in info:
+        version_info = info.get("version", {})
+        result["version"] = {
+            "distribution": version_info.get("distribution", "elasticsearch"),
+            "number": version_info.get("number"),
+            "lucene_version": version_info.get("lucene_version"),
+        }
+    else:
+        result["version"] = info
+
+    # Node stats
+    try:
+        nodes_stats = client.nodes.stats(metric="os,jvm,indices")
+        nodes_summary = []
+        if "nodes" in nodes_stats:
+            for node_id, node_data in nodes_stats["nodes"].items():
+                node_info = {
+                    "name": node_data.get("name"),
+                    "roles": node_data.get("roles", []),
+                    "os": {},
+                    "jvm": {},
+                    "indices": {},
+                }
+                # OS info
+                os_data = node_data.get("os", {})
+                mem = os_data.get("mem", {})
+                node_info["os"] = {
+                    "total_memory_gb": round(mem.get("total_in_bytes", 0) / (1024**3), 1),
+                    "used_memory_gb": round(mem.get("used_in_bytes", 0) / (1024**3), 1),
+                    "free_memory_gb": round(mem.get("free_in_bytes", 0) / (1024**3), 1),
+                    "memory_used_percent": mem.get("used_percent"),
+                    "cpu_percent": os_data.get("cpu", {}).get("percent"),
+                }
+                # JVM info
+                jvm_data = node_data.get("jvm", {})
+                jvm_mem = jvm_data.get("mem", {})
+                node_info["jvm"] = {
+                    "heap_max_gb": round(jvm_mem.get("heap_max_in_bytes", 0) / (1024**3), 2),
+                    "heap_used_gb": round(jvm_mem.get("heap_used_in_bytes", 0) / (1024**3), 2),
+                    "heap_used_percent": jvm_mem.get("heap_used_percent"),
+                }
+                # Index stats
+                indices_data = node_data.get("indices", {})
+                store = indices_data.get("store", {})
+                docs = indices_data.get("docs", {})
+                node_info["indices"] = {
+                    "doc_count": docs.get("count"),
+                    "store_size_gb": round(store.get("size_in_bytes", 0) / (1024**3), 2),
+                }
+                nodes_summary.append(node_info)
+        result["nodes"] = nodes_summary
+    except Exception as e:
+        result["nodes"] = {"_error": str(e)}
+
+    # k-NN stats
+    try:
+        knn_stats = client.transport.perform_request("GET", "/_plugins/_knn/stats")
+        if isinstance(knn_stats, dict):
+            # Extract cluster-level knn stats
+            cluster_knn = {}
+            for key in ["circuit_breaker_triggered", "total_graph_memory",
+                        "cache_capacity_reached", "eviction_count",
+                        "hit_count", "miss_count", "graph_memory_usage",
+                        "graph_memory_usage_percentage", "graph_index_requests",
+                        "graph_index_errors", "graph_query_requests",
+                        "graph_query_errors", "knn_query_requests"]:
+                if key in knn_stats:
+                    result.setdefault("knn_stats", {})[key] = knn_stats[key]
+            # Node-level knn stats
+            nodes_knn = knn_stats.get("nodes", {})
+            if nodes_knn:
+                node_knn_list = []
+                for nid, ndata in nodes_knn.items():
+                    node_knn_list.append({
+                        "graph_memory_usage": ndata.get("graph_memory_usage"),
+                        "graph_memory_usage_percentage": ndata.get("graph_memory_usage_percentage"),
+                        "cache_capacity_reached": ndata.get("cache_capacity_reached"),
+                        "graph_query_requests": ndata.get("graph_query_requests"),
+                        "graph_index_requests": ndata.get("graph_index_requests"),
+                    })
+                result["knn_node_stats"] = node_knn_list
+    except Exception:
+        result["knn_stats"] = {"_note": "k-NN plugin may not be installed or accessible"}
+
+    return result
+
+
+def find_knn_indices(client: OpenSearch) -> list:
+    """Find all indices with k-NN vector fields."""
+    knn_indices = []
+
+    try:
+        # Get all indices
+        indices = client.cat.indices(format="json", h="index,docs.count,store.size,pri,rep,health,status")
+        if not indices:
+            return []
+
+        for idx_info in indices:
+            index_name = idx_info.get("index", "")
+            # Skip system indices
+            if index_name.startswith("."):
+                continue
+
+            # Check if index has knn setting or knn_vector fields
+            try:
+                settings = client.indices.get_settings(index=index_name)
+                mappings = client.indices.get_mapping(index=index_name)
+
+                idx_settings = settings.get(index_name, {}).get("settings", {}).get("index", {})
+                knn_enabled = idx_settings.get("knn", "false")
+
+                # Check for knn_vector fields in mapping
+                idx_mapping = mappings.get(index_name, {}).get("mappings", {})
+                vector_fields = _extract_vector_fields(idx_mapping.get("properties", {}))
+
+                if str(knn_enabled).lower() == "true" or vector_fields:
+                    knn_indices.append({
+                        "index": index_name,
+                        "docs_count": idx_info.get("docs.count", "0"),
+                        "store_size": idx_info.get("store.size", "0"),
+                        "primary_shards": idx_info.get("pri"),
+                        "replicas": idx_info.get("rep"),
+                        "health": idx_info.get("health"),
+                        "status": idx_info.get("status"),
+                        "knn_enabled": str(knn_enabled).lower() == "true",
+                        "vector_fields_count": len(vector_fields),
+                        "vector_fields_summary": [
+                            {
+                                "name": f["name"],
+                                "dimension": f.get("dimension"),
+                                "engine": f.get("engine"),
+                                "space_type": f.get("space_type"),
+                            }
+                            for f in vector_fields
+                        ],
+                    })
+            except Exception:
+                continue
+
+    except Exception as e:
+        return [{"_error": str(e)}]
+
+    return knn_indices
+
+
+def _extract_vector_fields(properties: dict, prefix: str = "") -> list:
+    """Recursively extract knn_vector fields from index mappings."""
+    fields = []
+    for field_name, field_def in properties.items():
+        full_name = f"{prefix}.{field_name}" if prefix else field_name
+        if field_def.get("type") == "knn_vector":
+            method = field_def.get("method", {})
+            params = method.get("parameters", {})
+            encoder = params.get("encoder", {})
+            fields.append({
+                "name": full_name,
+                "dimension": field_def.get("dimension"),
+                "data_type": field_def.get("data_type", "float"),
+                "mode": field_def.get("mode"),
+                "compression_level": field_def.get("compression_level"),
+                "space_type": field_def.get("space_type") or method.get("space_type"),
+                "engine": method.get("engine"),
+                "method_name": method.get("name"),
+                "hnsw_m": params.get("m"),
+                "hnsw_ef_construction": params.get("ef_construction"),
+                "encoder_name": encoder.get("name") if encoder else None,
+                "encoder_params": encoder.get("parameters") if encoder else None,
+            })
+        # Recurse into nested/object fields
+        if "properties" in field_def:
+            fields.extend(_extract_vector_fields(field_def["properties"], full_name))
+
+    return fields
+
+
+def get_index_detail(client: OpenSearch, index_name: str) -> dict:
+    """Get detailed vector configuration for a specific index."""
+    result = {"index": index_name}
+
+    # Settings
+    try:
+        settings = client.indices.get_settings(index=index_name)
+        idx_settings = settings.get(index_name, {}).get("settings", {}).get("index", {})
+        result["settings"] = {
+            "knn": idx_settings.get("knn"),
+            "knn_algo_param_ef_search": idx_settings.get("knn.algo_param.ef_search"),
+            "number_of_shards": idx_settings.get("number_of_shards"),
+            "number_of_replicas": idx_settings.get("number_of_replicas"),
+            "refresh_interval": idx_settings.get("refresh_interval"),
+            "codec": idx_settings.get("codec"),
+        }
+    except Exception as e:
+        result["settings"] = {"_error": str(e)}
+
+    # Mappings - vector fields
+    try:
+        mappings = client.indices.get_mapping(index=index_name)
+        idx_mapping = mappings.get(index_name, {}).get("mappings", {})
+        vector_fields = _extract_vector_fields(idx_mapping.get("properties", {}))
+        result["vector_fields"] = vector_fields
+
+        # Non-vector fields summary
+        all_fields = _count_fields(idx_mapping.get("properties", {}))
+        result["total_fields"] = all_fields
+        result["non_vector_fields"] = all_fields - len(vector_fields)
+    except Exception as e:
+        result["vector_fields"] = {"_error": str(e)}
+
+    # Index stats
+    try:
+        stats = client.indices.stats(index=index_name)
+        idx_stats = stats.get("indices", {}).get(index_name, {})
+        primaries = idx_stats.get("primaries", {})
+        total = idx_stats.get("total", {})
+
+        result["stats"] = {
+            "docs_count": primaries.get("docs", {}).get("count"),
+            "docs_deleted": primaries.get("docs", {}).get("deleted"),
+            "store_size_bytes": primaries.get("store", {}).get("size_in_bytes"),
+            "store_size_gb": round(primaries.get("store", {}).get("size_in_bytes", 0) / (1024**3), 3),
+            "total_store_size_gb": round(total.get("store", {}).get("size_in_bytes", 0) / (1024**3), 3),
+            "indexing_total": primaries.get("indexing", {}).get("index_total"),
+            "search_query_total": total.get("search", {}).get("query_total"),
+            "search_query_time_ms": total.get("search", {}).get("query_time_in_millis"),
+        }
+
+        # Compute avg search latency
+        query_total = total.get("search", {}).get("query_total", 0)
+        query_time = total.get("search", {}).get("query_time_in_millis", 0)
+        if query_total > 0:
+            result["stats"]["avg_search_latency_ms"] = round(query_time / query_total, 2)
+    except Exception as e:
+        result["stats"] = {"_error": str(e)}
+
+    # Memory estimate for vector fields
+    if isinstance(result.get("vector_fields"), list) and result["vector_fields"]:
+        doc_count = 0
+        try:
+            doc_count = result.get("stats", {}).get("docs_count", 0) or 0
+        except Exception:
+            pass
+
+        if doc_count > 0:
+            result["memory_estimates"] = []
+            for vf in result["vector_fields"]:
+                dim = vf.get("dimension", 0)
+                m = vf.get("hnsw_m") or 16
+                replicas = int(result.get("settings", {}).get("number_of_replicas", 1) or 1)
+
+                # Determine compression ratio
+                encoder_name = vf.get("encoder_name")
+                encoder_params = vf.get("encoder_params") or {}
+                mode = vf.get("mode")
+                compression = vf.get("compression_level")
+                data_type = vf.get("data_type", "float")
+
+                bytes_per_dim = 4  # float32 default
+                compression_label = "none (float32)"
+
+                if data_type == "byte":
+                    bytes_per_dim = 1
+                    compression_label = "byte (4x)"
+                elif encoder_name == "sq":
+                    sq_type = encoder_params.get("type", "")
+                    if sq_type == "fp16":
+                        bytes_per_dim = 2
+                        compression_label = "FP16 (2x)"
+                    elif sq_type in ("int8", "byte"):
+                        bytes_per_dim = 1
+                        compression_label = "byte/int8 (4x)"
+                elif encoder_name == "binary":
+                    bits = encoder_params.get("bits", 1)
+                    bytes_per_dim = bits / 8
+                    compression_label = f"binary {bits}-bit ({int(32/bits)}x)"
+                elif encoder_name == "pq":
+                    # PQ: code_size bits per sub-vector, m sub-vectors
+                    pq_m = encoder_params.get("m", dim // 8)
+                    code_size = encoder_params.get("code_size", 8)
+                    total_bytes = (code_size / 8) * pq_m
+                    bytes_per_dim = total_bytes / dim if dim > 0 else 0
+                    compression_label = f"product quantization (PQ m={pq_m}, code_size={code_size})"
+
+                if mode == "on_disk":
+                    compression_label += " + disk mode"
+                    if compression:
+                        compression_label += f" (compression_level={compression})"
+
+                # HNSW memory formula: 1.1 * (bytes_per_dim * d + 8 * m) * num_vectors * (replicas+1)
+                mem_bytes = 1.1 * (bytes_per_dim * dim + 8 * m) * doc_count * (replicas + 1)
+                mem_gb = mem_bytes / (1024**3)
+
+                result["memory_estimates"].append({
+                    "field": vf["name"],
+                    "dimension": dim,
+                    "doc_count": doc_count,
+                    "hnsw_m": m,
+                    "replicas": replicas,
+                    "compression": compression_label,
+                    "bytes_per_dim": bytes_per_dim,
+                    "estimated_memory_gb": round(mem_gb, 2),
+                    "mode": mode or "in_memory",
+                })
+
+    return result
+
+
+def get_shard_analysis(client: OpenSearch, index_name: str) -> dict:
+    """Analyze shard distribution for a specific index."""
+    result = {"index": index_name}
+
+    try:
+        shards = client.cat.shards(index=index_name, format="json",
+                                    h="index,shard,prirep,state,docs,store,node")
+        result["shards"] = shards
+
+        # Summary
+        primary_shards = [s for s in shards if s.get("prirep") == "p"]
+        replica_shards = [s for s in shards if s.get("prirep") == "r"]
+
+        primary_sizes = []
+        for s in primary_shards:
+            store = s.get("store", "0b")
+            primary_sizes.append(store)
+
+        result["summary"] = {
+            "total_shards": len(shards),
+            "primary_shards": len(primary_shards),
+            "replica_shards": len(replica_shards),
+            "shard_states": {},
+        }
+
+        for s in shards:
+            state = s.get("state", "UNKNOWN")
+            result["summary"]["shard_states"][state] = result["summary"]["shard_states"].get(state, 0) + 1
+
+        # Node distribution
+        node_dist = {}
+        for s in shards:
+            node = s.get("node", "UNASSIGNED")
+            node_dist[node] = node_dist.get(node, 0) + 1
+        result["summary"]["node_distribution"] = node_dist
+
+    except Exception as e:
+        result["shards"] = {"_error": str(e)}
+
+    return result
+
+
+def _count_fields(properties: dict) -> int:
+    """Count total number of fields in mappings."""
+    count = 0
+    for field_name, field_def in properties.items():
+        count += 1
+        if "properties" in field_def:
+            count += _count_fields(field_def["properties"])
+    return count
+
+
+def generate_recommendations(cluster_overview: dict, knn_indices: list,
+                              index_details: list = None) -> list:
+    """Generate optimization recommendations based on analysis results."""
+    recommendations = []
+
+    # Check cluster health
+    health = cluster_overview.get("cluster_health", {})
+    if health.get("status") == "red":
+        recommendations.append({
+            "severity": "CRITICAL",
+            "category": "cluster_health",
+            "message": "Cluster status is RED. Some primary shards are unassigned.",
+            "action": "Check unassigned shards and resolve allocation issues before optimizing vector search."
+        })
+    elif health.get("status") == "yellow":
+        recommendations.append({
+            "severity": "WARNING",
+            "category": "cluster_health",
+            "message": "Cluster status is YELLOW. Some replica shards are unassigned.",
+            "action": "Ensure enough data nodes for replica allocation, or reduce replica count."
+        })
+
+    if health.get("unassigned_shards", 0) > 0:
+        recommendations.append({
+            "severity": "WARNING",
+            "category": "cluster_health",
+            "message": f"{health['unassigned_shards']} unassigned shards detected.",
+            "action": "Run GET /_cluster/allocation/explain to diagnose allocation failures."
+        })
+
+    # Check node memory
+    nodes = cluster_overview.get("nodes", [])
+    for node in nodes:
+        if isinstance(node, dict) and "os" in node:
+            mem_pct = node["os"].get("memory_used_percent", 0)
+            if mem_pct and mem_pct > 90:
+                recommendations.append({
+                    "severity": "WARNING",
+                    "category": "memory",
+                    "message": f"Node '{node.get('name')}' memory usage is {mem_pct}% (>90%).",
+                    "action": "Consider scaling up instance type or adding more data nodes."
+                })
+            jvm_pct = node.get("jvm", {}).get("heap_used_percent", 0)
+            if jvm_pct and jvm_pct > 85:
+                recommendations.append({
+                    "severity": "WARNING",
+                    "category": "jvm",
+                    "message": f"Node '{node.get('name')}' JVM heap usage is {jvm_pct}% (>85%).",
+                    "action": "Check for memory pressure. Consider reducing shard count or upgrading instances."
+                })
+
+    # Check k-NN stats
+    knn_stats = cluster_overview.get("knn_stats", {})
+    if knn_stats.get("circuit_breaker_triggered"):
+        recommendations.append({
+            "severity": "CRITICAL",
+            "category": "knn_memory",
+            "message": "k-NN circuit breaker has been triggered. Vector graphs may be evicted from memory.",
+            "action": "Increase node memory, reduce vector index size, or enable quantization/disk mode."
+        })
+    if knn_stats.get("cache_capacity_reached"):
+        recommendations.append({
+            "severity": "WARNING",
+            "category": "knn_cache",
+            "message": "k-NN cache capacity has been reached. Frequent evictions may degrade performance.",
+            "action": "Increase knn.memory.circuit_breaker.limit or add more memory."
+        })
+
+    # Analyze each k-NN index
+    if index_details:
+        for detail in index_details:
+            _analyze_index_config(detail, recommendations)
+    elif knn_indices:
+        for idx in knn_indices:
+            if idx.get("vector_fields_summary"):
+                for vf in idx["vector_fields_summary"]:
+                    # Check engine
+                    if vf.get("engine") and vf["engine"] not in ("faiss", None):
+                        recommendations.append({
+                            "severity": "INFO",
+                            "category": "engine",
+                            "index": idx["index"],
+                            "field": vf["name"],
+                            "message": f"Using '{vf['engine']}' engine. FAISS is recommended for better performance.",
+                            "action": "Consider migrating to FAISS engine. Requires reindex."
+                        })
+                    # Check space_type
+                    if vf.get("space_type") and vf["space_type"] == "l2":
+                        recommendations.append({
+                            "severity": "INFO",
+                            "category": "space_type",
+                            "index": idx["index"],
+                            "field": vf["name"],
+                            "message": f"Using 'l2' space type. 'cosine' is recommended for broader applicability.",
+                            "action": "Consider using cosine similarity unless L2 distance is specifically required."
+                        })
+
+    return recommendations
+
+
+def _analyze_index_config(detail: dict, recommendations: list):
+    """Analyze a single index configuration and add recommendations."""
+    index_name = detail.get("index", "unknown")
+    settings = detail.get("settings", {})
+    vector_fields = detail.get("vector_fields", [])
+    stats = detail.get("stats", {})
+    memory_estimates = detail.get("memory_estimates", [])
+
+    if not isinstance(vector_fields, list):
+        return
+
+    # Check knn setting
+    if settings.get("knn") != "true" and vector_fields:
+        recommendations.append({
+            "severity": "CRITICAL",
+            "category": "knn_setting",
+            "index": index_name,
+            "message": "index.knn is not enabled but knn_vector fields exist.",
+            "action": "Set index.knn=true in index settings. Requires reindex."
+        })
+
+    for vf in vector_fields:
+        field_name = vf.get("name", "unknown")
+        dim = vf.get("dimension", 0)
+        engine = vf.get("engine")
+        method = vf.get("method_name")
+        space_type = vf.get("space_type")
+        m = vf.get("hnsw_m")
+        ef_construction = vf.get("hnsw_ef_construction")
+        encoder_name = vf.get("encoder_name")
+        data_type = vf.get("data_type", "float")
+        mode = vf.get("mode")
+
+        # Engine recommendation
+        if engine and engine != "faiss":
+            recommendations.append({
+                "severity": "INFO",
+                "category": "engine",
+                "index": index_name,
+                "field": field_name,
+                "message": f"Using '{engine}' engine. FAISS is recommended for production workloads.",
+                "action": "Migrate to FAISS engine for better performance and quantization support. Requires reindex."
+            })
+
+        # Space type recommendation
+        if space_type == "l2":
+            recommendations.append({
+                "severity": "INFO",
+                "category": "space_type",
+                "index": index_name,
+                "field": field_name,
+                "message": "Using 'l2' (Euclidean distance). 'cosine' is generally recommended.",
+                "action": "Use cosine similarity unless L2 is specifically required by your embedding model."
+            })
+
+        # HNSW parameter checks
+        if m is not None:
+            if m < 8:
+                recommendations.append({
+                    "severity": "WARNING",
+                    "category": "hnsw_params",
+                    "index": index_name,
+                    "field": field_name,
+                    "message": f"HNSW m={m} is too low. May result in poor recall.",
+                    "action": "Increase m to 16 (recommended default). Requires reindex."
+                })
+            elif m > 48:
+                recommendations.append({
+                    "severity": "INFO",
+                    "category": "hnsw_params",
+                    "index": index_name,
+                    "field": field_name,
+                    "message": f"HNSW m={m} is very high. Increases memory usage significantly.",
+                    "action": "Consider m=16 or m=32 unless extremely high recall is required."
+                })
+
+        if ef_construction is not None:
+            if ef_construction < 100:
+                recommendations.append({
+                    "severity": "WARNING",
+                    "category": "hnsw_params",
+                    "index": index_name,
+                    "field": field_name,
+                    "message": f"ef_construction={ef_construction} is low. May result in poor index quality.",
+                    "action": "Increase ef_construction to 256-512 for better recall. Requires reindex."
+                })
+
+        # Quantization recommendations for large indices
+        doc_count = stats.get("docs_count", 0) or 0
+        if doc_count > 10_000_000 and not encoder_name and data_type == "float" and not mode:
+            recommendations.append({
+                "severity": "INFO",
+                "category": "quantization",
+                "index": index_name,
+                "field": field_name,
+                "message": f"Index has {doc_count:,} docs with no compression. Consider quantization to reduce memory.",
+                "action": "Use Byte quantization (4x, <5% recall loss) or FP16 (2x, <2% recall loss). Requires reindex."
+            })
+
+        # Disk mode recommendation for very large indices
+        if doc_count > 50_000_000 and not mode:
+            recommendations.append({
+                "severity": "INFO",
+                "category": "disk_mode",
+                "index": index_name,
+                "field": field_name,
+                "message": f"Index has {doc_count:,} docs. Disk mode can reduce memory by 32x.",
+                "action": "If latency tolerance is 100-200ms, consider mode: on_disk with compression. Requires reindex."
+            })
+
+    # Memory estimate warnings
+    for mem in memory_estimates:
+        mem_gb = mem.get("estimated_memory_gb", 0)
+        if mem_gb > 100:
+            recommendations.append({
+                "severity": "WARNING",
+                "category": "memory_sizing",
+                "index": index_name,
+                "field": mem.get("field"),
+                "message": f"Estimated vector memory: {mem_gb:.1f} GB for field '{mem.get('field')}'.",
+                "action": f"Ensure cluster has sufficient KNN-available memory. "
+                          f"Recommended total node memory > {mem_gb * 1.5:.0f} GB."
+            })
+
+    # Shard count check
+    num_shards = settings.get("number_of_shards")
+    if num_shards:
+        num_shards = int(num_shards)
+        doc_count = stats.get("docs_count", 0) or 0
+        if num_shards == 1 and doc_count > 5_000_000:
+            recommendations.append({
+                "severity": "WARNING",
+                "category": "sharding",
+                "index": index_name,
+                "message": f"Only 1 primary shard for {doc_count:,} docs. May limit query parallelism.",
+                "action": "Consider increasing primary shards to data_node_count × 1.5-2."
+            })
+        if num_shards > 50:
+            recommendations.append({
+                "severity": "WARNING",
+                "category": "sharding",
+                "index": index_name,
+                "message": f"{num_shards} primary shards is excessive. Each shard has memory overhead.",
+                "action": "Reduce shard count. Recommended: data_node_count × 1.5-2."
+            })
+
+    # Refresh interval
+    refresh = settings.get("refresh_interval")
+    if refresh and refresh == "1s":
+        doc_count = stats.get("docs_count", 0) or 0
+        if doc_count > 1_000_000:
+            recommendations.append({
+                "severity": "INFO",
+                "category": "refresh_interval",
+                "index": index_name,
+                "message": "refresh_interval is 1s (default). For large vector indices, 30s is recommended.",
+                "action": "Set refresh_interval to 30s to reduce indexing overhead."
+            })
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="OpenSearch Vector Search Cluster Analyzer (READ-ONLY)")
+    parser.add_argument("--url", required=True, help="OpenSearch cluster URL (e.g., https://host:9200)")
+    parser.add_argument("--username", "-u", help="Username for basic auth")
+    parser.add_argument("--password", "-p", help="Password for basic auth")
+    parser.add_argument("--no-auth", action="store_true", help="Connect without authentication")
+    parser.add_argument("--verify-ssl", action="store_true", help="Verify SSL certificates (default: false)")
+    parser.add_argument("--index", "-i", help="Specific index to analyze")
+    parser.add_argument("--action", "-a", default="cluster-overview",
+                        choices=["cluster-overview", "index-detail", "shard-analysis", "all"],
+                        help="Analysis action to perform")
+    parser.add_argument("--format", "-f", default="json", choices=["json", "pretty"],
+                        help="Output format")
+
+    args = parser.parse_args()
+
+    # Validate auth
+    if not args.no_auth and (not args.username or not args.password):
+        print(json.dumps({
+            "error": "Either provide --username and --password, or use --no-auth",
+            "success": False
+        }))
+        sys.exit(1)
+
+    # Connect
+    try:
+        client = create_client(
+            url=args.url,
+            username=args.username,
+            password=args.password,
+            no_auth=args.no_auth,
+            verify_ssl=args.verify_ssl,
+        )
+        # Test connection
+        client.info()
+    except Exception as e:
+        print(json.dumps({
+            "error": f"Failed to connect to {args.url}: {str(e)}",
+            "success": False
+        }))
+        sys.exit(1)
+
+    output = {
+        "success": True,
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "cluster_url": args.url,
+    }
+
+    actions = [args.action] if args.action != "all" else ["cluster-overview", "index-detail", "shard-analysis"]
+
+    if "cluster-overview" in actions:
+        output["cluster_overview"] = get_cluster_overview(client)
+        output["knn_indices"] = find_knn_indices(client)
+
+    if "index-detail" in actions:
+        if args.index:
+            output["index_detail"] = get_index_detail(client, args.index)
+        elif "knn_indices" in output:
+            # Analyze all k-NN indices
+            details = []
+            for idx in output.get("knn_indices", []):
+                if isinstance(idx, dict) and "index" in idx:
+                    details.append(get_index_detail(client, idx["index"]))
+            output["index_details"] = details
+        else:
+            output["index_detail"] = {"_note": "Specify --index or run with --action all"}
+
+    if "shard-analysis" in actions:
+        if args.index:
+            output["shard_analysis"] = get_shard_analysis(client, args.index)
+        elif "knn_indices" in output:
+            shard_analyses = []
+            for idx in output.get("knn_indices", []):
+                if isinstance(idx, dict) and "index" in idx:
+                    shard_analyses.append(get_shard_analysis(client, idx["index"]))
+            output["shard_analyses"] = shard_analyses
+
+    # Generate recommendations
+    index_details = None
+    if "index_detail" in output and isinstance(output["index_detail"], dict):
+        index_details = [output["index_detail"]]
+    elif "index_details" in output:
+        index_details = output["index_details"]
+
+    output["recommendations"] = generate_recommendations(
+        output.get("cluster_overview", {}),
+        output.get("knn_indices", []),
+        index_details,
+    )
+
+    # Output
+    indent = 2 if args.format == "pretty" else None
+    print(json.dumps(output, indent=indent, default=str, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/opensearch-skills/search/opensearch-vector-search/scripts/get_opensearch_pricing.py
+++ b/skills/opensearch-skills/search/opensearch-vector-search/scripts/get_opensearch_pricing.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Fetch Amazon OpenSearch Service on-demand pricing from AWS Pricing API.
+
+SECURITY NOTE:
+  - This script makes READ-ONLY HTTPS requests to the AWS Pricing API (pricing.us-east-1.amazonaws.com)
+  - It does NOT modify any AWS resources
+  - It only fetches publicly available pricing data
+  - Requires: boto3, valid AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or IAM role)
+  - No local filesystem writes, no localhost connections
+
+Usage:
+  python3 get_opensearch_pricing.py --region us-east-1 [--instance-type r7g.xlarge] [--format table|json]
+"""
+
+import argparse
+import json
+import sys
+
+
+def get_opensearch_pricing(region: str, instance_type: str = None) -> list[dict]:
+    """Fetch OpenSearch on-demand instance pricing."""
+    try:
+        import boto3
+    except ImportError:
+        print(
+            "Error: boto3 not installed. Run: uv add boto3 or use a Python environment with boto3.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Pricing API is only available in us-east-1 and ap-south-1
+    client = boto3.client("pricing", region_name="us-east-1")
+
+    filters = [
+        {"Type": "TERM_MATCH", "Field": "ServiceCode", "Value": "AmazonES"},
+        {"Type": "TERM_MATCH", "Field": "location", "Value": region_to_location(region)},
+        {"Type": "TERM_MATCH", "Field": "termType", "Value": "OnDemand"},
+    ]
+    if instance_type:
+        # OpenSearch instance types have .search suffix in pricing API
+        it = instance_type if ".search" in instance_type else instance_type + ".search"
+        filters.append(
+            {"Type": "TERM_MATCH", "Field": "instanceType", "Value": it}
+        )
+
+    results = []
+    next_token = None
+    while True:
+        kwargs = {"ServiceCode": "AmazonES", "Filters": filters, "MaxResults": 100}
+        if next_token:
+            kwargs["NextToken"] = next_token
+        resp = client.get_products(**kwargs)
+
+        for price_item_str in resp["PriceList"]:
+            item = json.loads(price_item_str) if isinstance(price_item_str, str) else price_item_str
+            attrs = item.get("product", {}).get("attributes", {})
+            inst_type = attrs.get("instanceType", "")
+            if not inst_type:
+                continue
+
+            # Extract on-demand price
+            price_per_hour = None
+            terms = item.get("terms", {}).get("OnDemand", {})
+            for term in terms.values():
+                for dim in term.get("priceDimensions", {}).values():
+                    ppu = dim.get("pricePerUnit", {}).get("USD")
+                    if ppu and float(ppu) > 0:
+                        price_per_hour = float(ppu)
+                        break
+
+            if price_per_hour is None:
+                continue
+
+            results.append({
+                "instance_type": inst_type,
+                "vcpu": attrs.get("vcpu", ""),
+                "memory_gib": attrs.get("memoryGib", attrs.get("memory", "")),
+                "price_per_hour_usd": price_per_hour,
+                "price_per_month_usd": round(price_per_hour * 730, 2),
+                "storage": attrs.get("storage", ""),
+                "network": attrs.get("networkPerformance", ""),
+            })
+
+        next_token = resp.get("NextToken")
+        if not next_token:
+            break
+
+    # Deduplicate by instance_type, keep lowest price
+    seen = {}
+    for r in results:
+        key = r["instance_type"]
+        if key not in seen or r["price_per_hour_usd"] < seen[key]["price_per_hour_usd"]:
+            seen[key] = r
+    results = sorted(seen.values(), key=lambda x: x["price_per_month_usd"])
+    return results
+
+
+def region_to_location(region: str) -> str:
+    """Map AWS region code to pricing API location name."""
+    mapping = {
+        "us-east-1": "US East (N. Virginia)",
+        "us-east-2": "US East (Ohio)",
+        "us-west-1": "US West (N. California)",
+        "us-west-2": "US West (Oregon)",
+        "eu-west-1": "EU (Ireland)",
+        "eu-west-2": "EU (London)",
+        "eu-west-3": "EU (Paris)",
+        "eu-central-1": "EU (Frankfurt)",
+        "eu-north-1": "EU (Stockholm)",
+        "ap-northeast-1": "Asia Pacific (Tokyo)",
+        "ap-northeast-2": "Asia Pacific (Seoul)",
+        "ap-southeast-1": "Asia Pacific (Singapore)",
+        "ap-southeast-2": "Asia Pacific (Sydney)",
+        "ap-south-1": "Asia Pacific (Mumbai)",
+        "sa-east-1": "South America (Sao Paulo)",
+        "ca-central-1": "Canada (Central)",
+        "me-south-1": "Middle East (Bahrain)",
+        "af-south-1": "Africa (Cape Town)",
+        "ap-east-1": "Asia Pacific (Hong Kong)",
+        "ap-southeast-3": "Asia Pacific (Jakarta)",
+        "eu-south-1": "EU (Milan)",
+        "me-central-1": "Middle East (UAE)",
+        "il-central-1": "Israel (Tel Aviv)",
+    }
+    return mapping.get(region, region)
+
+
+def print_table(results: list[dict]):
+    """Print results as a formatted table."""
+    if not results:
+        print("No pricing data found.")
+        return
+    header = f"{'Instance Type':<22} {'vCPU':<6} {'Memory':<10} {'$/hour':<10} {'$/month':<12} {'Network':<20}"
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        mem = r["memory_gib"]
+        if isinstance(mem, str) and "GiB" in mem:
+            mem = mem.replace(" GiB", "")
+        print(
+            f"{r['instance_type']:<22} {r['vcpu']:<6} {mem:<10} "
+            f"${r['price_per_hour_usd']:<9.4f} ${r['price_per_month_usd']:<11.2f} {r['network']:<20}"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch Amazon OpenSearch Service pricing")
+    parser.add_argument("--region", default="us-east-1", help="AWS region (default: us-east-1)")
+    parser.add_argument("--instance-type", default=None, help="Filter by instance type (e.g. r7g.xlarge)")
+    parser.add_argument("--format", choices=["table", "json"], default="table", help="Output format")
+    args = parser.parse_args()
+
+    results = get_opensearch_pricing(args.region, args.instance_type)
+
+    if args.format == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        print(f"\nAmazon OpenSearch Service On-Demand Pricing ({args.region})\n")
+        print_table(results)
+        print(f"\nTotal: {len(results)} instance types")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/opensearch-skills/search/opensearch-vector-search/scripts/get_opensearch_pricing.py
+++ b/skills/opensearch-skills/search/opensearch-vector-search/scripts/get_opensearch_pricing.py
@@ -13,9 +13,23 @@ Usage:
   python3 get_opensearch_pricing.py --region us-east-1 [--instance-type r7g.xlarge] [--format table|json]
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import sys
+
+
+def normalize_instance_type(instance_type: str) -> str:
+    """Normalize an Amazon OpenSearch Service instance type for the Pricing API."""
+    normalized = instance_type.strip().lower()
+    if normalized.endswith(".search"):
+        normalized = normalized.removesuffix(".search")
+    if "." not in normalized:
+        raise ValueError(
+            "Instance type must include both family and size, for example r7g.xlarge."
+        )
+    return f"{normalized}.search"
 
 
 def get_opensearch_pricing(region: str, instance_type: str = None) -> list[dict]:
@@ -39,7 +53,7 @@ def get_opensearch_pricing(region: str, instance_type: str = None) -> list[dict]
     ]
     if instance_type:
         # OpenSearch instance types have .search suffix in pricing API
-        it = instance_type if ".search" in instance_type else instance_type + ".search"
+        it = normalize_instance_type(instance_type)
         filters.append(
             {"Type": "TERM_MATCH", "Field": "instanceType", "Value": it}
         )
@@ -151,7 +165,10 @@ def main():
     parser.add_argument("--format", choices=["table", "json"], default="table", help="Output format")
     args = parser.parse_args()
 
-    results = get_opensearch_pricing(args.region, args.instance_type)
+    try:
+        results = get_opensearch_pricing(args.region, args.instance_type)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     if args.format == "json":
         print(json.dumps(results, indent=2))

--- a/tests/evals/fixtures/routing.json
+++ b/tests/evals/fixtures/routing.json
@@ -18,6 +18,24 @@
     "rationale": "Document ingestion + search setup"
   },
   {
+    "id": "routing-vector-01",
+    "prompt": "My OpenSearch k-NN queries over 100M 768-dimensional vectors are slow. How should I tune HNSW and ef_search?",
+    "expected_skill": "opensearch-vector-search",
+    "rationale": "Existing vector workload tuning and HNSW parameters"
+  },
+  {
+    "id": "routing-vector-02",
+    "prompt": "I need capacity planning for 1 billion embeddings with byte quantization and disk mode",
+    "expected_skill": "opensearch-vector-search",
+    "rationale": "Vector memory sizing, quantization, and disk mode"
+  },
+  {
+    "id": "routing-vector-03",
+    "prompt": "Analyze my existing OpenSearch cluster's knn_vector mappings and shard distribution without changing anything",
+    "expected_skill": "opensearch-vector-search",
+    "rationale": "Read-only analysis of an existing vector search cluster"
+  },
+  {
     "id": "routing-logs-01",
     "prompt": "Show me the top 10 errors in my application logs from the last hour",
     "expected_skill": "log-analytics",

--- a/tests/evals/test_skill_routing.py
+++ b/tests/evals/test_skill_routing.py
@@ -46,7 +46,7 @@ def test_skill_routing(case, eval_bag, bedrock_client):  # noqa: F811
     wrapped_prompt = (
         f"{case['prompt']}\n\n"
         "Which skill should handle this request? "
-        "Reply with the skill name (e.g. opensearch-launchpad, log-analytics, "
+        "Reply with the skill name (e.g. opensearch-launchpad, opensearch-vector-search, log-analytics, "
         "trace-analytics, aws-setup, managed-ingestion-service, document-processing) and a brief explanation."
     )
     response = call_skill(router_skill, wrapped_prompt, bedrock_client)

--- a/tests/test_agent_skills_vector_search.py
+++ b/tests/test_agent_skills_vector_search.py
@@ -1,0 +1,52 @@
+"""Tests for the opensearch-vector-search skill assets."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SKILL_DIR = _REPO_ROOT / "skills" / "opensearch-skills" / "search" / "opensearch-vector-search"
+
+
+def test_vector_search_reference_files_are_bundled():
+    expected = {
+        "vector-search.md",
+        "quantization-techniques.md",
+        "cost-optimization.md",
+        "cluster-tuning.md",
+        "performance-benchmarks.md",
+        "indexing-strategies.md",
+        "query-optimization.md",
+        "optimized-instances.md",
+    }
+
+    actual = {path.name for path in (_SKILL_DIR / "references").glob("*.md")}
+
+    assert expected <= actual
+
+
+def test_analyzer_help_does_not_require_cluster_or_opensearchpy():
+    result = subprocess.run(
+        [sys.executable, str(_SKILL_DIR / "scripts" / "analyze_cluster.py"), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "READ-ONLY" in result.stdout
+    assert "--action" in result.stdout
+
+
+def test_pricing_help_does_not_require_boto3_or_aws_credentials():
+    result = subprocess.run(
+        [sys.executable, str(_SKILL_DIR / "scripts" / "get_opensearch_pricing.py"), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "--region" in result.stdout
+    assert "--instance-type" in result.stdout

--- a/tests/test_agent_skills_vector_search.py
+++ b/tests/test_agent_skills_vector_search.py
@@ -1,12 +1,24 @@
 """Tests for the opensearch-vector-search skill assets."""
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SKILL_DIR = _REPO_ROOT / "skills" / "opensearch-skills" / "search" / "opensearch-vector-search"
+
+
+def _load_script(name: str):
+    path = _SKILL_DIR / "scripts" / name
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_vector_search_reference_files_are_bundled():
@@ -39,6 +51,45 @@ def test_analyzer_help_does_not_require_cluster_or_opensearchpy():
     assert "--action" in result.stdout
 
 
+def test_analyzer_normalizes_knn_and_doc_count_values():
+    analyzer = _load_script("analyze_cluster.py")
+    recommendations = []
+
+    analyzer._analyze_index_config(
+        {
+            "index": "vectors",
+            "settings": {"knn": True},
+            "vector_fields": [
+                {
+                    "name": "embedding",
+                    "data_type": "float",
+                }
+            ],
+            "stats": {"docs_count": "10000001"},
+        },
+        recommendations,
+    )
+
+    assert not any(item["category"] == "knn_setting" for item in recommendations)
+    assert any(item["category"] == "quantization" for item in recommendations)
+
+
+def test_analyzer_uses_tls_verification_by_default():
+    analyzer = _load_script("analyze_cluster.py")
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    analyzer.OpenSearch = FakeClient
+    analyzer.RequestsHttpConnection = object
+    analyzer.create_client("https://cluster.example")
+
+    assert captured["verify_certs"] is True
+    assert captured["ssl_show_warn"] is False
+
+
 def test_pricing_help_does_not_require_boto3_or_aws_credentials():
     result = subprocess.run(
         [sys.executable, str(_SKILL_DIR / "scripts" / "get_opensearch_pricing.py"), "--help"],
@@ -50,3 +101,23 @@ def test_pricing_help_does_not_require_boto3_or_aws_credentials():
     assert result.returncode == 0
     assert "--region" in result.stdout
     assert "--instance-type" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("r7g.xlarge", "r7g.xlarge.search"),
+        ("r7g.xlarge.search", "r7g.xlarge.search"),
+    ],
+)
+def test_pricing_normalizes_instance_type(value, expected):
+    pricing = _load_script("get_opensearch_pricing.py")
+
+    assert pricing.normalize_instance_type(value) == expected
+
+
+def test_pricing_rejects_instance_type_without_size():
+    pricing = _load_script("get_opensearch_pricing.py")
+
+    with pytest.raises(ValueError, match="family and size"):
+        pricing.normalize_instance_type("r7g")


### PR DESCRIPTION
## Summary
- add `opensearch-vector-search` as a Search leaf skill for k-NN/HNSW tuning, quantization, disk mode, capacity planning, and read-only cluster analysis
- route vector tuning and existing-workload diagnosis separately from `opensearch-launchpad`
- bundle focused references, a read-only analyzer, and optional AWS pricing lookup
- add routing fixtures and asset/help tests

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ -q` (`675 passed, 2 skipped`)

## Notes
The skill keeps its primary workflow portable across self-managed OpenSearch, Docker, Kubernetes, Amazon OpenSearch Service, and OpenSearch Serverless. AWS pricing remains an optional provider-specific helper.