### PR TITLE
Hackathon issue template update - US resident

### DIFF
--- a/.github/ISSUE_TEMPLATE/hackathon_submission.yaml
+++ b/.github/ISSUE_TEMPLATE/hackathon_submission.yaml
@@ -13,6 +13,8 @@ body:
           required: true
         - label: I have reviewed and accept the [Code of Conduct](https://opensearch.org/code-of-conduct/).
           required: true
+        - label: I am a legal United States resident 18 years or older.
+          required: true
 
   - type: input
     id: name


### PR DESCRIPTION
### Description
Small update to the Agent Skills hackathon issue template - make the US legal resident requirement even more obvious.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
