### PR TITLE
Fix CI: restore the missing test-macos job key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: Run tests
         run: uv run pytest tests/ --ignore=tests/evals -v
+
+  test-macos:
     name: Test on macOS
     runs-on: macOS-latest
     steps:


### PR DESCRIPTION
## What

`ci.yml` on `main` is missing the `test-macos:` job key — the mapping under `test-linux` currently carries `name`, `runs-on` and `steps` twice. GitHub Actions rejects duplicate mapping keys at parse time, so every recent run (pushes to `main` and every open PR) fails with **Invalid workflow file** and zero jobs executed. The red X on currently open PRs comes from this, not from the changes under review.

## Fix

Restore the job key (one line, plus a blank separator to match `test-windows`). The workflow parses back to the three intended jobs: linux / macos / windows.

Verified locally: `yaml.safe_load` returns `jobs == ['test-linux', 'test-macos', 'test-windows']`, each with `runs-on` and `steps`. Since `pull_request` runs read the workflow from the merge ref, this PR's own checks should demonstrate the fix by actually running all three jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)